### PR TITLE
Set up automatic publication with Travis & Echidna

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+branches:
+  only:
+    - gh-pages
+env:
+  global:
+    - URL="https://w3c.github.io/html-aria/echidna-manifest.txt"
+    - DECISION="[TO-DO]"
+    - secure: "[TO-DO]"
+script:
+  - echo "Done!"
+after_success:
+  - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ branches:
 env:
   global:
     - URL="https://w3c.github.io/html-aria/echidna-manifest.txt"
-    - DECISION="[TO-DO]"
-    - secure: "[TO-DO]"
+    - DECISION="https://lists.w3.org/Archives/Public/public-html-admin/2015May/0021.html"
+    - secure: GCoNiJ83LqT6HxuSFPXg0yHBbNxvTVJqzMjubbeU0W+zFUe+C45DoY5EH8tfuNivJbw+SzjoKHYHNSMLsqMaZ9wl1SYkcfbM/HIdkUF6HpXZtxblFCqj7srThSuhbSkzPNodSmwCmjNraKBmqtk95+wl4Ck9wF/d4aFJhyPT4nxtkErIH5fhcJPAeJ9Ui8VuQSrEy9k4VNZU8ylRSoLOSqClHtlpVfhHBITNeoIVzByT6Yp5lwWV4DL8bcCzYnyBLYh2e09POF+tnL/dGkbm5E4GvSFaglZM9mbmb5SLH0y7i21WI7LKtir4G831p1tBQGRejZ/P2e8vgveizsWxWxGL/VrJR9lgJqCjppLmm6rfcKF3lR34PzYRPE+IzJ63HOOysuESKAXq4orCzdP64pooN75JnOQV+baYVJV78abmeA1epGqLOaRcMRreWf/2U+jvzYMqfH7lNP74c82cur9rswfHm14oKhJzbFrJ+CIGO2KqdAlISSm6Hoa7lTARhn5XefmQtSR0hq2q9POmPP5Qo/hH1HeTvriZd1RpeGfEzUAkutUWY19bvAnkxWUlF5PGu0t8zesrn8l54TX4wwHuWeQNoLhU1D0ftnfF6oXH1MmO++EN/qYJAX/QOUY0XO+BV5OU9I0kSJPDuNS6eQBxGrIluNRYXLyhnPdYe0U=
 script:
   - echo "Done!"
 after_success:

--- a/echidna-manifest.txt
+++ b/echidna-manifest.txt
@@ -1,0 +1,6 @@
+index.html?specStatus=WD;shortName=html-aria respec
+https://specs.webplatform.org/html-aria/webspecs/master/details-summary/jquery.details.min.js
+https://www.w3.org/StyleSheets/TR/W3C-WD
+https://specs.webplatform.org/assets/img/rightArrow.png
+https://www.w3.org/Icons/w3c_home
+https://www.w3.org/StyleSheets/TR/logo-WD

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
           specStatus: "ED",
           shortName:  "html-aria",
 		  repository: "https://github.com/w3c/html-aria",
+          subtitle:  "Living Document",
           editors: [
                 {   name:       "Steve Faulkner",
                     url:        "http://www.paciellogroup.com",

--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
                 {   name:       "Steve Faulkner",
                     url:        "http://www.paciellogroup.com",
                     company:    "The Paciello Group",
-                    companyURL: "http://www.paciellogroup.com" }
+                    companyURL: "http://www.paciellogroup.com",
+                    w3cid:      "35007" }
           ],
 		  wg:           "HTML Working Group",
       wgURI:        "http://www.w3.org/html/wg/",


### PR DESCRIPTION
This branch is a suggestion to the group to switch to [automatic publication of WDs with Echidna](https://github.com/w3c/echidna/wiki/FAQ) (and using [Travis](https://travis-ci.org/) to submit those publications automatically as part of a CI process).

**What is already done here:**
- Added the [W3C ID of the editor](https://github.com/w3c/echidna/wiki/Preparing-your-document#data-editor-id) to the Respec config.
- Added a [manifest](https://github.com/w3c/echidna/wiki/Preparing-your-document#manifest-file) for Echidna (which I generated using [echidna-manifester](https://github.com/w3c/echidna-manifester)).
- Added a Travis config file with the minimum necessary to submit a request to publish to Echidna for every cycle of continuous integration.

**What the group still would have to do:**
- Fill in the URL of some document or e-mail stating the group's decision to publish (first `[TO-DO]`).
- The team contact should get a (secret) _token_ for this repo, [as instructed here](https://github.com/w3c/echidna/wiki/Token-creation). (To be able to publish, the field &ldquo;source&rdquo; will have to match the beginning of the document or manifest that is submitted for publication. So, in this case, &ldquo;source&rdquo; should be something like `https://w3c.github.io/html-aria/`).
- &hellip;encrypt that token using the Travis command-line client, [as instructed here](https://github.com/w3c/echidna/wiki/Setting-up-Echidna-as-a-GitHub-hook)
- &hellip;and assign the resulting string to the `secure` variable (second `[TO-DO]`).
- Switch on Travis [CI for this repository](https://travis-ci.org/w3c/html-aria).
- Sit back, enjoy, and spread the word of Echidna!

h/t @sideshowbarker
## 

[@tripu, 2/Sep: added note about &ldquo;source&rdquo; field associated to the token]
