### PR TITLE
w3cid needed for automagic publishing

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@
                 {   name:       "Steve Faulkner",
                     url:        "http://www.paciellogroup.com",
                     company:    "The Paciello Group",
-                    companyURL: "http://www.paciellogroup.com" }
+                    companyURL: "http://www.paciellogroup.com",
+                    w3cid:      "35007" }
           ],
 		  "wg":          ["Web Platform Working Group"],
       "wgURI":        ["http://www.w3.org/WebPlatform/WG/"],


### PR DESCRIPTION
This should fix the issue with the specification not updating itself.
Regression introduced in 58330b6ba29533289cb893c18077f120d7740f87
