### PR TITLE
(doc): clarify rules for aria-invalid

### DIFF
--- a/index.html
+++ b/index.html
@@ -879,7 +879,7 @@ p.note, div.note {
         constraint validation</a> but that does not <a
 			  href="https://www.w3.org/TR/html/sec-forms.html#satisfy-its-constraints">satisfy its constraints</a></TD>
       <TD><code>aria-invalid=&quot;true&quot;</code></TD>
-      <TD><p>The <code>aria-invalid</code> attribute for may be used on any HTML5 elements that allow <a href="#index-aria-global">global <code>aria-*</code> attributes</a> except<em> </em><a href="https://www.w3.org/TR/html/sec-forms.html#submittable-element">submittable elements</a> that does not satisy its <em> </em><a href="https://www.w3.org/TR/html/sec-forms.html#constraints">constraints</a>. - <span class="changed-feature">(changed)</span></p></TD>
+      <TD><p>The <code>aria-invalid</code> attribute may be used on any HTML5 element that allows <a href="#index-aria-global">global <code>aria-*</code> attributes</a> except for a <a href="https://www.w3.org/TR/html/sec-forms.html#submittable-element">submittable element</a> that does not satisy its <a href="https://www.w3.org/TR/html/sec-forms.html#constraints">validation constraints</a>. - <span class="changed-feature">(changed)</span></p></TD>
     </TR>
     <TR tabindex="-1">
       <TD>Element with <code><a href="https://www.w3.org/TR/html/editing.html#element-attrdef-global-contenteditable">contenteditable</a></code> attribute</TD>

--- a/index.html
+++ b/index.html
@@ -879,7 +879,7 @@ p.note, div.note {
         constraint validation</a> but that does not <a
 			  href="https://www.w3.org/TR/html/sec-forms.html#satisfy-its-constraints">satisfy its constraints</a></TD>
       <TD><code>aria-invalid=&quot;true&quot;</code></TD>
-      <TD><p>The <code>aria-invalid</code> attribute for may be used on any HTML5 elements that allow <a href="#index-aria-global">global <code>aria-*</code> attributes</a> except<em> </em><a href="https://www.w3.org/TR/html/sec-forms.html#submittable-element">submittable elements</a>   that<em> </em>have the <a href="https://www.w3.org/TR/html/sec-forms.html#element-attrdef-input-required"><code>required</code></a> attribute set. - <span class="changed-feature">(changed)</span></p></TD>
+      <TD><p>The <code>aria-invalid</code> attribute for may be used on any HTML5 elements that allow <a href="#index-aria-global">global <code>aria-*</code> attributes</a> except<em> </em><a href="https://www.w3.org/TR/html/sec-forms.html#submittable-element">submittable elements</a> that does not satisy its <em> </em><a href="https://www.w3.org/TR/html/sec-forms.html#constraints">constraints</a>. - <span class="changed-feature">(changed)</span></p></TD>
     </TR>
     <TR tabindex="-1">
       <TD>Element with <code><a href="https://www.w3.org/TR/html/editing.html#element-attrdef-global-contenteditable">contenteditable</a></code> attribute</TD>


### PR DESCRIPTION
I am attempting to clarify language around the use of `aria-invalid`. Its (dynamic) use is only valid when a submittable element does not satisfy its constraints. Based on the existing text, it seems that only the `required` attribute causes problems `aria-invalid` use and only when the value is empty. This broader language includes scenarios on page load as well as any interaction up to and including the submit action.