### PR TITLE
Update allowed roles for <hr>

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       </pre>
 
      <details><summary>Example document for conformance checking</summary>
-     <p>If you <a href="http://validator.w3.org/nu/?doc=https%3A%2F%2Fw3c.github.io%2Fhtml-aria%2Fexamples%2Fnonconforming1.html" target="_blank">check this file</a> using a HTML5 <a href="http://validator.w3.org/nu/">conformance checker</a> an error will be displayed.</p>
+     <p>If you <a href="https://validator.w3.org/nu/?doc=https%3A%2F%2Fw3c.github.io%2Fhtml-aria%2Fexamples%2Fnonconforming1.html" target="_blank">check this file</a> using a HTML5 <a href="http://validator.w3.org/nu/">conformance checker</a> an error will be displayed.</p>
      <p><a href="examples/nonconforming1.html">non conforming ARIA use example</a>:</p>
      <iframe style="width:100%;height:300px" src="examples/nonconforming1.html"></iframe>
      </details>
@@ -287,7 +287,8 @@
     <TR id="hr" tabindex="-1">
       <TD><code><a href="https://www.w3.org/TR/html/grouping-content.html#the-hr-element">hr</a> </code>
       <TD><code>role=<a href="#index-aria-separator">separator</a></code></TD>
-      <TD><p>Role: <code>presentation</code></p>
+      <TD>
+        <p>Roles: <code><a href="#index-aria-none">none</a></code> or <a href="#index-aria-presentation"><code>presentation</code></a></p>
         <p>DPub Role: <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagebreak"><code>doc-pagebreak</code></a> - <span class="new-feature">(new)</span></p>
         <p><a href="#index-aria-global">global <code>aria-*</code> attributes</a> and any <code>aria-*</code> attributes applicable to the <code>separator</code> role.</p></TD>
     </TR>


### PR DESCRIPTION
Addresses [issue 86](https://github.com/w3c/html-aria/issues/86)

As `hr` can accept a `presentation` role, it can also accept a `role=“none”`.

This commit also updates the validator.w3.org url from http to https.