### PR TITLE
remove duplicate role=presentation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1468,7 +1468,7 @@
                 <a href="#index-aria-menuitemradio">menuitemradio</a>, <a href=
                 "#index-aria-option">option</a>, <a href=
                 "#index-aria-none">none</a></code>, <a href=
-                "#index-aria-presentation"><code>presentation</code></a><code><a href="#index-aria-presentation">presentation</a>,
+                "#index-aria-presentation"><code>presentation</code></a>,
                 <a href="#index-aria-radio">radio</a></code> - <span class=
                 "changed-feature">(changed)</span>, <code><a href=
                 "#index-aria-separator">separator</a>, <a href=


### PR DESCRIPTION
there were two role=presentation links next to each other in the table cell.  this commit removes one of them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/162.html" title="Last updated on Sep 28, 2019, 3:03 PM UTC (18e2c37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/162/58e96dc...18e2c37.html" title="Last updated on Sep 28, 2019, 3:03 PM UTC (18e2c37)">Diff</a>