### PR TITLE
revise issue 125

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
         indicate new (in ARIA 1.1) or changed (between ARIA 1.0/1.1) ARIA
         roles, states and properties
       </p>
-      <table class="simple"> 
+      <table class="simple">
         <caption>
           Rules of ARIA attributes usage by HTML language feature
         </caption>
@@ -249,7 +249,7 @@
           <td><p> <strong class="nosupport">No `role`</strong> </p>
             <p> <a href="#index-aria-global">global `aria-*` attributes</a> and
               any `aria-*` attributes applicable to the allowed roles and
-              implied role (if any)            </p></td>
+              implied role (if any)</p></td>
         </tr>
         <tr id="article" tabindex="-1">
           <td>
@@ -1739,9 +1739,11 @@
             </td>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
-              <p><b>Note</b> that some UAs may suppress a list's semantics if its list 
-                markers have been removed. Authors MAY add `role="list"` to reinstate 
-                the `list` role, in such situations.</p>
+              <p>
+                <b>Note</b> that some user agents suppress a list's
+                <a>implicit ARIA semantics</a> if list markers are removed.
+                Authors can use `role="list"` to reinstate the role, if necessary.
+              </p>
             </td>
             <td>
               <p>
@@ -2270,11 +2272,13 @@
             </td>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
-              <p><b>Note</b> that some UAs may suppress a list's semantics if its list 
-                markers have been removed. Authors MAY add `role="list"` to reinstate 
-                the `list` role, in such situations.</p>
             </td>
             <td>
+              <p>
+                <b>Note</b> that some user agents suppress a list's
+                <a>implicit ARIA semantics</a> if list markers are removed.
+                Authors can use `role="list"` to reinstate the role, if necessary.
+              </p>
               <p>
                 Role: <code><a href="#index-aria-directory">directory</a>,
                 <a href="#index-aria-group">group</a>, <a href=


### PR DESCRIPTION
closes #125, though I would like to add a more global note about this in the future.

This commit specifically changes “MAY” to “can” in the notes, along with some other wording updates.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/167.html" title="Last updated on Sep 29, 2019, 4:00 AM UTC (43e8699)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/167/6624325...43e8699.html" title="Last updated on Sep 29, 2019, 4:00 AM UTC (43e8699)">Diff</a>