### PR TITLE
allow role=note on section element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1893,24 +1893,27 @@
             </td>
             <td>
               <p>
-                Roles: <code><a href="#index-aria-alert">alert</a>, <a href=
-                "#index-aria-alertdialog">alertdialog</a>, <a href=
-                "#index-aria-application">application</a>, <a href=
-                "#index-aria-banner">banner</a>, <a href=
-                "#index-aria-complementary">complementary</a>, <a href=
-                "#index-aria-contentinfo">contentinfo</a>, <a href=
-                "#index-aria-dialog">dialog</a>, <a href=
-                "#index-aria-document">document</a>,<a href=
-                "#index-aria-feed">feed</a></code> - <span class=
-                "new-feature">(new)</span>, <code><a href=
-                "#index-aria-log">log</a>, <a href="#index-aria-main">main</a>,
-                <a href="#index-aria-marquee">marquee</a>, <a href=
-                "#index-aria-navigation">navigation</a>, <a href=
-                "#index-aria-none">none</a></code>, <a href=
-                "#index-aria-presentation"><code>presentation</code></a><code><a href="#index-aria-presentation">presentation</a>,
-                <a href="#index-aria-search">search</a>, <a href=
-                "#index-aria-status">status</a></code> or <code><a href=
-                "#index-aria-tabpanel">tabpanel</a></code> - <span class=
+                Roles:
+                <a href="#index-aria-alert">`alert`</a>,
+                <a href="#index-aria-alertdialog">`alertdialog`</a>,
+                <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-banner">`banner`</a>,
+                <a href="#index-aria-complementary">`complementary`</a>,
+                <a href="#index-aria-contentinfo">`contentinfo`</a>,
+                <a href="#index-aria-dialog">`dialog`</a>,
+                <a href="#index-aria-document">`document`</a>,
+                <a href="#index-aria-feed">`feed`</a> - <span class=
+                "new-feature">(new)</span>,
+                <a href="#index-aria-log">`log`</a>,
+                <a href="#index-aria-main">`main`</a>,
+                <a href="#index-aria-marquee">`marquee`</a>,
+                <a href="#index-aria-navigation">`navigation`</a>,
+                <a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-note">`note`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>,
+                <a href="#index-aria-search">`search`</a>,
+                <a href="#index-aria-status">`status`</a> or
+                <a href="#index-aria-tabpanel">`tabpanel`</a> - <span class=
                 "changed-feature">(changed)</span>
               </p>
               <p>
@@ -5227,17 +5230,6 @@
     </section>
     <script src="details-summary/jquery.details.min.js"></script>
     <script>
-
-
-
-
-
-
-
-
-
-
-
       $('details').details();
     </script>
   </body>


### PR DESCRIPTION
closes #103

seems to me there's no reason to allow `role=note` on `aside` and not on `section`, so unless told otherwise I'm going to assume this was in error, and potentially even related to the the duplicate “role=presentation” that was in the allowed roles cell for the section element.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/169.html" title="Last updated on Sep 29, 2019, 8:54 AM UTC (9589748)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/169/d89b738...9589748.html" title="Last updated on Sep 29, 2019, 8:54 AM UTC (9589748)">Diff</a>