### PR TITLE
remove button type=menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,26 +389,7 @@
               </p>
             </td>
           </tr>
-          <tr id="typemenu" tabindex="-1">
-            <td>
-              <code><a>button</a> <a data-cite=
-              "html/form-elements.html#attr-button-type">type="menu"</a></code>
-            </td>
-            <td>
-              <code>role=<a href="#index-aria-button">button</a></code>
-            </td>
-            <td>
-              <p>
-                Roles: <code><a href=
-                "#index-aria-menuitem">menuitem</a></code>.<br>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any) <span class=
-                "changed-feature">(changed)</span>
-              </p>
-            </td>
-          </tr>
-          <tr id="caption2" tabindex="-1">
+          <tr id="canvas" tabindex="-1">
             <td>
               <a><code>canvas</code></a>
             </td>
@@ -962,7 +943,7 @@
           <tr id="input-button" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
-              "html/input.html#button-state-(type=button)">`button`</a></code> 
+              "html/input.html#button-state-(type=button)">`button`</a></code>
             </td>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
@@ -3546,7 +3527,7 @@
               with no <a data-cite="html/dom.html#heading-content">Heading
               content</a>, <a data-cite=
               "html/dom.html#sectioning-content-2">Sectioning
-              content</a>, 
+              content</a>,
               <a data-cite="html/sections.html#sectioning-root">Sectioning
               roots</a>
             </td>
@@ -4045,7 +4026,7 @@
               none
             </td>
             <td>&nbsp;
-              
+
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
         The <span class="new-feature">(new)</span> and <span class=
         "changed-feature">(changed)</span> markers in the following table
         indicate new (in ARIA 1.1) or changed (between ARIA 1.0/1.1) ARIA
-        roles, states and properties
+        roles, states and properties.
       </p>
       <table class="simple">
         <caption>
@@ -185,7 +185,7 @@
           </td>
           <td>
             <p>
-              <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn"><strong>Any</strong> <code>role<!---0.768817%--></code></a>
+              <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn"><strong>Any</strong> <code>role</code></a>
             </p>
             <p>
               <a href="#index-aria-global">global <code>aria-*</code> attributes</a> and
@@ -660,12 +660,12 @@
             </td>
             <td>
               If not a descendant of an <code>article</code>,
-              <code>aside</code>, <code>main</code>, <code>nav</code> 
+              <code>aside</code>, <code>main</code>, <code>nav</code>
               <span class="changed-feature">(changed)</span> or
-              <code>section</code> element 
-              or an element with <code>role=article</code>, <code>complimentary</code>, 
-              <code>main</code>, <code>navigation</code> 
-              <span class="changed-feature">(changed)</span> or <code>region</code> 
+              <code>section</code> element
+              or an element with <code>role=article</code>, <code>complementary</code>,
+              <code>main</code>, <code>navigation</code>
+              <span class="changed-feature">(changed)</span> or <code>region</code>
               then <code>role=<a href=
               "#index-aria-contentinfo">contentinfo</a></code>, otherwise <a>No
               corresponding role</a>
@@ -784,11 +784,11 @@
             </td>
             <td>
               If not a descendant of an <code>article</code>,
-              <code>aside</code>, <code>main</code>, <code>nav</code> 
+              <code>aside</code>, <code>main</code>, <code>nav</code>
               <span class="changed-feature">(changed)</span> or
-              <code>section</code> element 
-              or an element with <code>role=article</code>, <code>complimentary</code>, 
-              <code>main</code>, <code>navigation</code> 
+              <code>section</code> element
+              or an element with <code>role=article</code>, <code>complementary</code>,
+              <code>main</code>, <code>navigation</code>
               <span class="changed-feature">(changed)</span> or <code>region</code>
               then <code>role=<a href=
               "#index-aria-banner">banner</a></code>, otherwise <a>No
@@ -833,8 +833,7 @@
                 "#index-aria-presentation"><code>presentation</code></a>
               </p>
               <p>
-                DPub Role: <a data-cite=
-                "dpub-aria-1.0#doc-pagebreak"><code>doc-pagebreak</code></a> -
+                DPub Role: <a data-cite="dpub-aria-1.0#doc-pagebreak"><code>doc-pagebreak</code></a> -
                 <span class="new-feature">(new)</span>
               </p>
               <p>
@@ -852,8 +851,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="iframe" tabindex="-1">
@@ -902,8 +900,7 @@
           <tr id="img" tabindex="-1">
             <td>
               <code><a>img</a> with <a data-cite=
-              "html/embedded-content.html#attr-img-alt">alt</a>="some
-              text"</code>
+              "html/embedded-content.html#attr-img-alt">alt</a>="some text"</code>
             </td>
             <td>
               <code>role=<a href="#index-aria-img">img</a></code>
@@ -911,8 +908,7 @@
             <td>
               <p>
                 <strong>Any</strong> `role` except <code>presentation</code> or
-                <code>none</code> <span class=
-                "changed-feature">(changed)</span>
+                <code>none</code> <span class="changed-feature">(changed)</span>
               </p>
               <p>
                 <a href="#index-aria-global">global `aria-*` attributes</a> and


### PR DESCRIPTION
this button type is obsolete in HTML so we should not list it.

related to issue #140


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/170.html" title="Last updated on Sep 29, 2019, 1:16 PM UTC (cf688d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/170/d50ff5c...cf688d2.html" title="Last updated on Sep 29, 2019, 1:16 PM UTC (cf688d2)">Diff</a>