### PR TITLE
add remaining elements from HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,6 +331,24 @@
             </p>
           </td>
         </tr>
+        <tr id="autonomous-custom-elemenet" tabindex="-1">
+          <td>
+            <a>autonomous custom element</a>
+          </td>
+          <td>
+            <a>No corresponding role</a>
+          </td>
+          <td>
+            <p>
+              <a><strong>Any</strong> `role`</a>
+            </p>
+            <p>
+              <a href="#index-aria-global">global `aria-*` attributes</a> and
+              any `aria-*` attributes applicable to the allowed roles and
+              implied role (if any)
+            </p>
+          </td>
+        </tr>
         <tbody>
           <tr id="base" tabindex="-1">
             <td>
@@ -340,8 +358,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="body" tabindex="-1">
@@ -433,8 +450,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="datalist" tabindex="-1">
@@ -774,8 +790,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="header" tabindex="-1">
@@ -1095,8 +1110,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="input-image" tabindex="-1">
@@ -1415,7 +1429,7 @@
           <tr id="ins-del" tabindex="-1">
             <td>
               <p>
-                <a><code>ins</code></a> and <a><code>del</code></a>
+                [^ins^] and [^del^]
               </p>
             </td>
             <td>
@@ -1434,7 +1448,7 @@
           </tr>
           <tr id="label" tabindex="-1">
             <td>
-              <a><code>label</code></a>
+              [^label^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1450,7 +1464,7 @@
           </tr>
           <tr id="legend" tabindex="-1">
             <td>
-              <a><code>legend</code></a>
+              [^legend^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1466,8 +1480,7 @@
           </tr>
           <tr id="li" tabindex="-1">
             <td>
-              <a><code>li</code></a> element whose parent is an
-              <a><code>ol</code></a> or <a><code>ul</code></a>
+              [^li^] element whose parent is an [^ol^], [^ul^] or [^menu^]
             </td>
             <td>
               <code>role=<a href="#index-aria-listitem">listitem</a></code>
@@ -1501,20 +1514,19 @@
           </tr>
           <tr id="link-href" tabindex="-1">
             <td>
-              <a><code>link</code></a> element with a <a data-cite=
+              [^link^] element with a <a data-cite=
               "html/semantics.html#attr-link-href"><code>href</code></a>
             </td>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="main" tabindex="-1">
             <td>
-              <a><code>main</code></a>
+              [^main^]
             </td>
             <td>
               <code>role=<a href="#index-aria-main">main</a></code>
@@ -1532,14 +1544,13 @@
           </tr>
           <tr id="map" tabindex="-1">
             <td>
-              <a><code>map</code></a>
+              [^map^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="math" tabindex="-1">
@@ -1561,98 +1572,49 @@
               </p>
             </td>
           </tr>
-         <!-- <tr id="menu-context" tabindex="-1">
+          <tr id="menu" tabindex="-1">
             <td>
-              <code><a>menu</a> <a data-cite=
-              "html/obsolete.html#attr-menu-type">type</a> = <a data-cite=
-              "html/interactive-elements.html#attr-valuedef-menu-type-context">context</a></code>
+              [^menu^]
             </td>
             <td>
-              <code>role=<a href="#index-aria-menu">menu</a></code>
+              <code>role=<a href="#index-aria-list">list</a></code>
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <b>Note</b> that some user agents suppress a list's
+                <a>implicit ARIA semantics</a> if list markers are removed.
+                Authors can use `role="list"` to reinstate the role, if necessary.
+              </p>
+              <p>
+                Role: <code><a href="#index-aria-directory">directory</a>,
+                <a href="#index-aria-group">group</a>, <a href=
+                "#index-aria-listbox">listbox</a>, <a href=
+                "#index-aria-menu">menu</a>, <a href=
+                "#index-aria-menubar">menubar</a>, <a href=
+                "#index-aria-radiogroup">radiogroup</a></code> - <span class=
+                "changed-feature">(changed)</span>, <code><a href=
+                "#index-aria-tablist">tablist</a>, <a href=
+                "#index-aria-toolbar">toolbar</a>, <a href=
+                "#index-aria-tree">tree</a>, <a href=
+                "#index-aria-presentation">presentation</a></code> or
+                <code><a href="#index-aria-none">none</a></code>
               </p>
               <p>
                 <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code>menu</code>
-                role.
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
               </p>
             </td>
           </tr>
-          <tr id="menuitem-command" tabindex="-1">
-            <td>
-              <a data-cite=
-              "html/interactive-elements.html#the-menuitem-element"><code>menuitem</code></a>
-              <code>type=command</code>
-            </td>
-            <td>
-              <code>role=<a href="#index-aria-menuitem">menuitem</a></code>
-            </td>
-            <td>
-              <p>
-                <strong class="nosupport">No `role`</strong>
-              </p>
-              <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code>menuitem</code>
-                role.
-              </p>
-            </td>
-          </tr>
-          <tr id="menuitem-checkbox" tabindex="-1">
-            <td>
-              <a data-cite=
-              "html/interactive-elements.html#the-menuitem-element"><code>menuitem</code></a>
-              <code>type=checkbox</code>
-            </td>
-            <td>
-              <code>role=<a href=
-              "#index-aria-menuitemcheckbox">menuitemcheckbox</a></code>
-            </td>
-            <td>
-              <p>
-                <strong class="nosupport">No `role`</strong>
-              </p>
-              <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the
-                <code>menuitemcheckbox</code> role.
-              </p>
-            </td>
-          </tr>
-          <tr id="menuitem-radio" tabindex="-1">
-            <td>
-              <a data-cite=
-              "html/interactive-elements.html#the-menuitem-element"><code>menuitem</code></a>
-              <code>type=radio</code>
-            </td>
-            <td>
-              <code>role=<a href=
-              "#index-aria-menuitemradio">menuitemradio</a></code>
-            </td>
-            <td>
-              <p>
-                <strong class="nosupport">No `role`</strong>
-              </p>
-              <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the
-                <code>menuitemradio</code> role.
-              </p>
-            </td>
-          </tr>-->
           <tr id="meta" tabindex="-1">
             <td>
-              <code><a>meta</a></code>
+              [^meta^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="meter" tabindex="-1">
@@ -1701,8 +1663,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="object" tabindex="-1">
@@ -1727,7 +1688,7 @@
           </tr>
           <tr id="ol" tabindex="-1">
             <td>
-              <code><a>ol</a></code>
+              [^ol^]
             </td>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
@@ -1798,7 +1759,7 @@
           </tr>
           <tr id="output" tabindex="-1">
             <td>
-              <code><a>output</a></code>
+              [^output^]
             </td>
             <td>
               <code>role=<a href="#index-aria-status">status</a></code>
@@ -1816,7 +1777,7 @@
           </tr>
           <tr>
             <td>
-              <code><a>param</a></code>
+              [^param^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1833,8 +1794,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="progress" tabindex="-1">
@@ -1851,7 +1811,7 @@
               <p>
                 <a href="#index-aria-global">global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the
-                <code>progressbar</code> role.
+                `progressbar` role.
               </p>
             </td>
           </tr>
@@ -1863,13 +1823,12 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="section" tabindex="-1">
             <td>
-              <a><code>section</code></a>
+              [^section^]
             </td>
             <td>
               <code>role=<a href="#index-aria-region">region</a></code> if the
@@ -1945,7 +1904,7 @@
           </tr>
           <tr id="select" tabindex="-1">
             <td>
-              <code><a data-xref-for="HTMLElement">select</a></code> (with NO
+              [^select^] (with NO
               <code>multiple</code> attribute and NO <code>size</code>
               attribute having value greater than <code>1</code>) <span class=
               "changed-feature">(changed)</span>
@@ -1989,8 +1948,7 @@
           <tr id="source2" tabindex="-1">
             <td><code><a>slot</a></code></td>
             <td><a>No corresponding role</a></td>
-            <td><strong class="nosupport">No `role` or `aria-*`
-              attributes</strong></td>
+            <td><strong class="nosupport">No `role` or `aria-*` attributes</strong></td>
           </tr>
           <tr id="source" tabindex="-1">
             <td>
@@ -2000,8 +1958,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="span" tabindex="-1">
@@ -2030,8 +1987,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="svg" tabindex="-1">
@@ -2103,8 +2059,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*`
-              attributes</strong>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
           <tr id="textarea" tabindex="-1">
@@ -2261,7 +2216,7 @@
           </tr>
           <tr id="ul" tabindex="-1">
             <td>
-              <a><code>ul</code></a>
+              [^ul^]
             </td>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>


### PR DESCRIPTION
closes #140

this commit:
* re-adds `menu` per its definition in the living standard and how it is mapped in HTML AAM
* adds `menu` as an allowed parent of `li`
* adds autonomous custom element (though i think it’d be beneficial to provide more guidance on this in the future)

Additionally this commit does a bunch of source cleanup and starts converting more of the links to the HTML spec to the respec syntax.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/171.html" title="Last updated on Sep 29, 2019, 6:02 PM UTC (a5ca202)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/171/229a0b3...a5ca202.html" title="Last updated on Sep 29, 2019, 6:02 PM UTC (a5ca202)">Diff</a>