### PR TITLE
add doc-dedication to aside dpub allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
         </tr>
         <tr id="aside" tabindex="-1">
           <td>
-            <code><a>aside</a></code>
+            [^aside^]
           </td>
           <td>
             <code>role=<a href=
@@ -291,20 +291,22 @@
           </td>
           <td>
             <p>
-              Roles: <code><a href="#index-aria-feed">feed</a></code> -
-              <span class="new-feature">(new)</span>, <code><a href=
-              "#index-aria-note">note</a>, <a href=
-              "#index-aria-presentation">presentation</a>, <a href=
-              "#index-aria-none">none</a>, <a href=
-              "#index-aria-region">region</a></code> or <a href=
-              "#index-aria-search"><code>search</code></a>.
+              Roles: <a href="#index-aria-feed">`feed`</a> -
+              <span class="new-feature">(new)</span>,
+              <a href="#index-aria-note">`note`</a>,
+              <a href="#index-aria-presentation">`presentation`</a>,
+              <a href="#index-aria-none">`none`</a>,
+              <a href="#index-aria-region">`region`</a>
+              or <a href="#index-aria-search">`search`</a>.
             </p>
             <p>
               DPub Roles: <a data-cite=
-              "dpub-aria-1.0#doc-example"><code>doc-example</code></a><code>,
-              <a data-cite="dpub-aria-1.0#doc-footnote">doc-footnote</a>,
-              <a data-cite="dpub-aria-1.0#doc-pullquote">doc-pullquote</a>,
-              <a data-cite="dpub-aria-1.0#doc-tip">doc-tip</a></code> -
+              "dpub-aria-1.0#doc-dedication">`doc-dedication`</a>,
+              <a data-cite=
+              "dpub-aria-1.0#doc-example">`doc-example`</a>,
+              <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>,
+              <a data-cite="dpub-aria-1.0#doc-pullquote">`doc-pullquote`</a>,
+              <a data-cite="dpub-aria-1.0#doc-tip">`doc-tip`</a> -
               <span class="new-feature">(new)</span>
             </p>
             <p>
@@ -316,7 +318,7 @@
         </tr>
         <tr id="audio" tabindex="-1">
           <td>
-            <code><a>audio</a></code>
+            [^audio^]
           </td>
           <td>
             <a>No corresponding role</a>
@@ -352,7 +354,7 @@
         <tbody>
           <tr id="base" tabindex="-1">
             <td>
-              <code><a>base</a></code>
+              [^base^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -363,7 +365,7 @@
           </tr>
           <tr id="body" tabindex="-1">
             <td>
-              <a><code>body</code></a>
+              [^body^]
             </td>
             <td>
               <code>role=<a href="#index-aria-document">document</a></code>
@@ -381,7 +383,7 @@
           </tr>
           <tr id="button" tabindex="-1">
             <td>
-              <code><a>button</a></code>
+              [^button^]
             </td>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
@@ -408,7 +410,7 @@
           </tr>
           <tr id="canvas" tabindex="-1">
             <td>
-              <a><code>canvas</code></a>
+              [^canvas^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -426,7 +428,7 @@
           </tr>
           <tr id="caption" tabindex="-1">
             <td>
-              <a><code>caption</code></a>
+              [^caption^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -443,7 +445,7 @@
           <tr id="col-colgroup" tabindex="-1">
             <td>
               <p>
-                <a><code>col</code></a><code>, <a>colgroup</a></code>
+                [^col^], [^colgroup^]
               </p>
             </td>
             <td>
@@ -455,7 +457,7 @@
           </tr>
           <tr id="datalist" tabindex="-1">
             <td>
-              <code><a>datalist</a></code>
+              [^datalist^]
             </td>
             <td>
               <code>role=<a href="#index-aria-listbox">listbox</a></code>
@@ -473,7 +475,7 @@
           </tr>
           <tr id="dd-dt" tabindex="-1">
             <td>
-              <a><code>dd</code></a>
+              [^dd^]
             </td>
             <td>
               <code>role=<a href="#index-aria-definition">definition</a></code>
@@ -491,7 +493,7 @@
           </tr>
           <tr id="details" tabindex="-1">
             <td>
-              <code><a>details</a></code>
+              [^details^]
             </td>
             <td>
               <code>role=<a href="#index-aria-group">group</a></code>
@@ -509,7 +511,7 @@
           </tr>
           <tr id="dialog" tabindex="-1">
             <td>
-              <a><code>dialog</code></a>
+              [^dialog^]
             </td>
             <td>
               <code>role=<a href="#index-aria-dialog">dialog</a></code>


### PR DESCRIPTION
closes #173

adds `doc-dedication` as an allowed dpub role for the `aside` element.

Additional source code cleanup and changing various element links to respec syntax.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/174.html" title="Last updated on Sep 30, 2019, 1:09 PM UTC (c306325)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/174/dd88e83...c306325.html" title="Last updated on Sep 30, 2019, 1:09 PM UTC (c306325)">Diff</a>