### PR TITLE
Resolves #181

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
           </th>
         </tr>
         <tbody>
-          <tr id="ahref" tabindex="-1">
+          <tr id="a-href" tabindex="-1">
             <td>
             <a><code>a</code></a> element with a <a data-cite="html/links.html#attr-hyperlink-href"><code>href</code></a></td>
             <td>
@@ -177,7 +177,7 @@
               </p>
             </td>
           </tr>
-          <tr id="anohref" tabindex="-1">
+          <tr id="a-no-href" tabindex="-1">
             <td>
               <a><code>a</code></a> element without a <a data-cite="html/links.html#attr-hyperlink-href"><code>href</code></a>
             </td>
@@ -231,7 +231,7 @@
               </p>
             </td>
           </tr>
-          <tr id="areahref" tabindex="-1">
+          <tr id="area-href" tabindex="-1">
             <td>
               <a><code>area</code></a> with a <a data-cite=
               "html/links.html#attr-hyperlink-href"><code>href</code></a>
@@ -250,7 +250,7 @@
               </p>
             </td>
           </tr>
-          <tr id="areahref2" tabindex="-1">
+          <tr id="area-no-href" tabindex="-1">
             <td><a><code>area</code></a> without a <a data-cite=
               "html/links.html#attr-hyperlink-href"><code>href</code></a></td>
             <td><a>No corresponding role</a></td>
@@ -334,7 +334,7 @@
               </p>
             </td>
           </tr>
-          <tr id="autonomous-custom-elemenet" tabindex="-1">
+          <tr id="autonomous-custom-element" tabindex="-1">
             <td>
               <a>autonomous custom element</a>
             </td>
@@ -473,7 +473,7 @@
               </p>
             </td>
           </tr>
-          <tr id="dd-dt" tabindex="-1">
+          <tr id="dd" tabindex="-1">
             <td>
               [^dd^]
             </td>
@@ -566,7 +566,7 @@
               </p>
             </td>
           </tr>
-          <tr id="dd-dt2" tabindex="-1">
+          <tr id="dt" tabindex="-1">
             <td>
               <code><a>dt</a></code>
             </td>
@@ -607,7 +607,7 @@
               </p>
             </td>
           </tr>
-          <tr tabindex="-1">
+          <tr id="figcaption" tabindex="-1">
             <td>
               <a><code>figcaption</code></a> - <span class=
               "new-feature">(new)</span>
@@ -1016,7 +1016,7 @@
               </p>
             </td>
           </tr>
-          <tr>
+          <tr id="input-color" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#color-state-(type=color)">color</a></code>
@@ -1031,7 +1031,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-color" tabindex="-1">
+          <tr id="input-date" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#date-state-(type=date)">date</a></code>
@@ -1048,7 +1048,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-datetime" tabindex="-1">
+          <tr id="input-datetime-local" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#local-date-and-time-state-(type=datetime-local)">datetime-local</a></code>
@@ -1065,7 +1065,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-email" tabindex="-1">
+          <tr id="input-email-no-list" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#e-mail-state-(type=email)">email</a></code> with
@@ -1298,7 +1298,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-tel" tabindex="-1">
+          <tr id="input-tel-no-list" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#telephone-state-(type=tel)">tel</a></code>, with
@@ -1318,7 +1318,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-text" tabindex="-1">
+          <tr id="input-text-no-list" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#text-(type=text)-state-and-search-state-(type=search)">text</a></code>,
@@ -1386,7 +1386,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-url" tabindex="-1">
+          <tr id="input-url-no-list" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#url-state-(type=url)">url</a></code> with no
@@ -1767,7 +1767,7 @@
               </p>
             </td>
           </tr>
-          <tr>
+          <tr id="param" tabindex="-1">
             <td>
               [^param^]
             </td>
@@ -1935,7 +1935,7 @@
               </p>
             </td>
           </tr>
-          <tr id="source2" tabindex="-1">
+          <tr id="slot" tabindex="-1">
             <td><code><a>slot</a></code></td>
             <td><a>No corresponding role</a></td>
             <td><strong class="nosupport">No `role` or `aria-*` attributes</strong></td>
@@ -2069,7 +2069,7 @@
               </p>
             </td>
           </tr>
-          <tr id="tbody-tfoot-thead" tabindex="-1">
+          <tr id="tbody-thead-tfoot" tabindex="-1">
             <td>
               <p>
                 [^tbody^], [^thead^], [^tfoot^]
@@ -2089,7 +2089,7 @@
               </p>
             </td>
           </tr>
-          <tr id="el-title" tabindex="-1">
+          <tr id="title" tabindex="-1">
             <td>
               [^title^]
             </td>
@@ -2100,7 +2100,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="TD" tabindex="-1">
+          <tr id="td" tabindex="-1">
             <td>
               [^td^]
             </td>
@@ -2391,7 +2391,7 @@
               </p>
             </td>
           </tr>
-          <tr tabindex="-1">
+          <tr id="attr-contenteditable" tabindex="-1">
             <td>
               Element with <code><a data-cite=
               "html/interaction.html#attr-contenteditable">contenteditable</a></code>

--- a/index.html
+++ b/index.html
@@ -2089,7 +2089,7 @@
               </p>
             </td>
           </tr>
-          <tr id="title" tabindex="-1">
+          <tr id="el-title" tabindex="-1">
             <td>
               [^title^]
             </td>


### PR DESCRIPTION
- Tidy up id and tabindex in docconformance table rows


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aria/pull/182.html" title="Last updated on Oct 7, 2019, 1:22 PM UTC (78c2594)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/182/39b5a5d...carmacleod:78c2594.html" title="Last updated on Oct 7, 2019, 1:22 PM UTC (78c2594)">Diff</a>