### PR TITLE
Resolves #181 as per discussion

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
           </th>
         </tr>
         <tbody>
-          <tr id="a-href" tabindex="-1">
+          <tr id="el-a" tabindex="-1">
             <td>
             <a><code>a</code></a> element with a <a data-cite="html/links.html#attr-hyperlink-href"><code>href</code></a></td>
             <td>
@@ -177,7 +177,7 @@
               </p>
             </td>
           </tr>
-          <tr id="a-no-href" tabindex="-1">
+          <tr id="el-a-no-href" tabindex="-1">
             <td>
               <a><code>a</code></a> element without a <a data-cite="html/links.html#attr-hyperlink-href"><code>href</code></a>
             </td>
@@ -195,7 +195,7 @@
               </p>
             </td>
           </tr>
-          <tr id="abbr" tabindex="-1">
+          <tr id="el-abbr" tabindex="-1">
             <td>
               <a><code>abbr</code></a>
             </td>
@@ -213,7 +213,7 @@
               </p>
             </td>
           </tr>
-          <tr id="address" tabindex="-1">
+          <tr id="el-address" tabindex="-1">
             <td>
               <a><code>address</code></a>
             </td>
@@ -231,7 +231,7 @@
               </p>
             </td>
           </tr>
-          <tr id="area-href" tabindex="-1">
+          <tr id="el-area" tabindex="-1">
             <td>
               <a><code>area</code></a> with a <a data-cite=
               "html/links.html#attr-hyperlink-href"><code>href</code></a>
@@ -250,7 +250,7 @@
               </p>
             </td>
           </tr>
-          <tr id="area-no-href" tabindex="-1">
+          <tr id="el-area-no-href" tabindex="-1">
             <td><a><code>area</code></a> without a <a data-cite=
               "html/links.html#attr-hyperlink-href"><code>href</code></a></td>
             <td><a>No corresponding role</a></td>
@@ -259,7 +259,7 @@
                 any `aria-*` attributes applicable to the allowed roles and
                 implied role (if any)</p></td>
           </tr>
-          <tr id="article" tabindex="-1">
+          <tr id="el-article" tabindex="-1">
             <td>
               <code><a>article</a></code>
             </td>
@@ -282,7 +282,7 @@
               </p>
             </td>
           </tr>
-          <tr id="aside" tabindex="-1">
+          <tr id="el-aside" tabindex="-1">
             <td>
               [^aside^]
             </td>
@@ -317,7 +317,7 @@
               </p>
             </td>
           </tr>
-          <tr id="audio" tabindex="-1">
+          <tr id="el-audio" tabindex="-1">
             <td>
               [^audio^]
             </td>
@@ -352,7 +352,7 @@
               </p>
             </td>
           </tr>
-          <tr id="base" tabindex="-1">
+          <tr id="el-base" tabindex="-1">
             <td>
               [^base^]
             </td>
@@ -363,7 +363,25 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="body" tabindex="-1">
+          <tr id="el-blockquote" tabindex="-1">
+            <td>
+              <a><code>blockquote</code></a>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport">Any `role`</strong>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-body" tabindex="-1">
             <td>
               [^body^]
             </td>
@@ -381,7 +399,7 @@
               </p>
             </td>
           </tr>
-          <tr id="button" tabindex="-1">
+          <tr id="el-button" tabindex="-1">
             <td>
               [^button^]
             </td>
@@ -408,7 +426,7 @@
               </p>
             </td>
           </tr>
-          <tr id="canvas" tabindex="-1">
+          <tr id="el-canvas" tabindex="-1">
             <td>
               [^canvas^]
             </td>
@@ -426,7 +444,7 @@
               </p>
             </td>
           </tr>
-          <tr id="caption" tabindex="-1">
+          <tr id="el-caption" tabindex="-1">
             <td>
               [^caption^]
             </td>
@@ -442,10 +460,10 @@
               </p>
             </td>
           </tr>
-          <tr id="col-colgroup" tabindex="-1">
+          <tr id="el-col" tabindex="-1">
             <td>
               <p>
-                [^col^], [^colgroup^]
+                [^col^]
               </p>
             </td>
             <td>
@@ -455,7 +473,20 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="datalist" tabindex="-1">
+          <tr id="el-colgroup" tabindex="-1">
+            <td>
+              <p>
+                [^colgroup^]
+              </p>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+            </td>
+          </tr>
+          <tr id="el-datalist" tabindex="-1">
             <td>
               [^datalist^]
             </td>
@@ -473,7 +504,7 @@
               </p>
             </td>
           </tr>
-          <tr id="dd" tabindex="-1">
+          <tr id="el-dd" tabindex="-1">
             <td>
               [^dd^]
             </td>
@@ -491,7 +522,25 @@
               </p>
             </td>
           </tr>
-          <tr id="details" tabindex="-1">
+          <tr id="el-del" tabindex="-1">
+            <td>
+              [^del^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport">Any `role`</strong>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-details" tabindex="-1">
             <td>
               [^details^]
             </td>
@@ -509,7 +558,7 @@
               </p>
             </td>
           </tr>
-          <tr id="dialog" tabindex="-1">
+          <tr id="el-dialog" tabindex="-1">
             <td>
               [^dialog^]
             </td>
@@ -528,7 +577,7 @@
               </p>
             </td>
           </tr>
-          <tr id="div" tabindex="-1">
+          <tr id="el-div" tabindex="-1">
             <td>
               <a><code>div</code></a>
             </td>
@@ -546,7 +595,7 @@
               </p>
             </td>
           </tr>
-          <tr id="dl" tabindex="-1">
+          <tr id="el-dl" tabindex="-1">
             <td>
               <a><code>dl</code></a>
             </td>
@@ -566,7 +615,7 @@
               </p>
             </td>
           </tr>
-          <tr id="dt" tabindex="-1">
+          <tr id="el-dt" tabindex="-1">
             <td>
               <code><a>dt</a></code>
             </td>
@@ -585,7 +634,25 @@
               </p>
             </td>
           </tr>
-          <tr id="embed" tabindex="-1">
+          <tr id="el-em" tabindex="-1">
+            <td>
+              <a><code>em</code></a>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-embed" tabindex="-1">
             <td>
               <code><a>embed</a></code>
             </td>
@@ -607,7 +674,7 @@
               </p>
             </td>
           </tr>
-          <tr id="figcaption" tabindex="-1">
+          <tr id="el-figcaption" tabindex="-1">
             <td>
               <a><code>figcaption</code></a> - <span class=
               "new-feature">(new)</span>
@@ -629,7 +696,7 @@
               </p>
             </td>
           </tr>
-          <tr id="fieldset" tabindex="-1">
+          <tr id="el-fieldset" tabindex="-1">
             <td>
               <a><code>fieldset</code></a>
             </td>
@@ -650,7 +717,7 @@
               </p>
             </td>
           </tr>
-          <tr id="figure" tabindex="-1">
+          <tr id="el-figure" tabindex="-1">
             <td>
               <a><code>figure</code></a>
             </td>
@@ -672,7 +739,7 @@
               </p>
             </td>
           </tr>
-          <tr id="footer" tabindex="-1">
+          <tr id="el-footer" tabindex="-1">
             <td>
               <code><a>footer</a></code>
             </td>
@@ -706,7 +773,7 @@
               </p>
             </td>
           </tr>
-          <tr id="form" tabindex="-1">
+          <tr id="el-form" tabindex="-1">
             <td>
               <code><a>form</a></code>
             </td>
@@ -730,31 +797,7 @@
               </p>
             </td>
           </tr>
-          <tr id="p-pre-blockquote" tabindex="-1">
-            <td>
-              <p>
-                grouping content elements not listed elsewhere:
-              </p>
-              <p>
-                <a><code>p</code></a><code>, <a>pre</a>,
-                <a>blockquote</a></code>
-              </p>
-            </td>
-            <td>
-              <a>No corresponding role</a>
-            </td>
-            <td>
-              <p>
-                <strong class="nosupport">Any `role`</strong>
-              </p>
-              <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
-              </p>
-            </td>
-          </tr>
-          <tr id="h1-h6" tabindex="-1">
+          <tr id="el-h1-h6" tabindex="-1">
             <td>
               <a data-cite=
               "html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>
@@ -784,7 +827,7 @@
               </p>
             </td>
           </tr>
-          <tr id="head" tabindex="-1">
+          <tr id="el-head" tabindex="-1">
             <td>
               <code><a>head</a></code>
             </td>
@@ -795,7 +838,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="header" tabindex="-1">
+          <tr id="el-header" tabindex="-1">
             <td>
               <a><code>header</code></a>
             </td>
@@ -828,7 +871,7 @@
               </p>
             </td>
           </tr>
-          <tr id="hgroup" tabindex="-1">
+          <tr id="el-hgroup" tabindex="-1">
             <td><a><code>hgroup</code></a></td>
             <td><a>No corresponding role</a></td>
             <td><p> <a><strong>Any</strong> `role`</a> </p>
@@ -836,7 +879,7 @@
                 any `aria-*` attributes applicable to the allowed roles and
                 implied role (if any) </p></td>
           </tr>
-          <tr id="hr" tabindex="-1">
+          <tr id="el-hr" tabindex="-1">
             <td>
               <code><a>hr</a></code>
             </td>
@@ -860,7 +903,7 @@
               </p>
             </td>
           </tr>
-          <tr id="html" tabindex="-1">
+          <tr id="el-html" tabindex="-1">
             <td>
               <code><a>html</a></code>
             </td>
@@ -871,7 +914,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="iframe" tabindex="-1">
+          <tr id="el-iframe" tabindex="-1">
             <td>
               <a><code>iframe</code></a>
             </td>
@@ -893,7 +936,27 @@
               </p>
             </td>
           </tr>
-          <tr id="img-alt" tabindex="-1">
+          <tr id="el-img" tabindex="-1">
+            <td>
+              <code><a>img</a> with <a data-cite=
+              "html/embedded-content.html#attr-img-alt">alt</a>="some text"</code>
+            </td>
+            <td>
+              <code>role=<a href="#index-aria-img">img</a></code>
+            </td>
+            <td>
+              <p>
+                <strong>Any</strong> `role` except <code>presentation</code> or
+                <code>none</code> <span class="changed-feature">(changed)</span>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-img-empty-alt" tabindex="-1">
             <td>
               <code><a>img</a> with <a data-cite=
               "html/embedded-content.html#attr-img-alt">alt</a>=""</code>
@@ -914,27 +977,7 @@
               </p>
             </td>
           </tr>
-          <tr id="img" tabindex="-1">
-            <td>
-              <code><a>img</a> with <a data-cite=
-              "html/embedded-content.html#attr-img-alt">alt</a>="some text"</code>
-            </td>
-            <td>
-              <code>role=<a href="#index-aria-img">img</a></code>
-            </td>
-            <td>
-              <p>
-                <strong>Any</strong> `role` except <code>presentation</code> or
-                <code>none</code> <span class="changed-feature">(changed)</span>
-              </p>
-              <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
-              </p>
-            </td>
-          </tr>
-          <tr id="img-no-alt" tabindex="-1">
+          <tr id="el-img-no-alt" tabindex="-1">
             <td>
               <code><a>img</a> with no <a data-cite="html/images.html#unknown-images">alt</a>=""</code>
             </td>
@@ -953,7 +996,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-button" tabindex="-1">
+          <tr id="el-input-button" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#button-state-(type=button)">`button`</a></code>
@@ -980,7 +1023,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-checkbox" tabindex="-1">
+          <tr id="el-input-checkbox" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#checkbox-state-(type=checkbox)">checkbox</a></code>
@@ -1016,7 +1059,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-color" tabindex="-1">
+          <tr id="el-input-color" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#color-state-(type=color)">color</a></code>
@@ -1031,7 +1074,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-date" tabindex="-1">
+          <tr id="el-input-date" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#date-state-(type=date)">date</a></code>
@@ -1048,7 +1091,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-datetime-local" tabindex="-1">
+          <tr id="el-input-datetime-local" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#local-date-and-time-state-(type=datetime-local)">datetime-local</a></code>
@@ -1065,7 +1108,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-email-no-list" tabindex="-1">
+          <tr id="el-input-email" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#e-mail-state-(type=email)">email</a></code> with
@@ -1086,7 +1129,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-file" tabindex="-1">
+          <tr id="el-input-file" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#file-upload-state-(type=file)">file</a></code>
@@ -1103,7 +1146,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-hidden" tabindex="-1">
+          <tr id="el-input-hidden" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#hidden-state-(type=hidden)">hidden</a></code>
@@ -1115,7 +1158,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="input-image" tabindex="-1">
+          <tr id="el-input-image" tabindex="-1">
             <td>
               <code>input type=</code><a data-cite=
               "html/input.html#image-button-state-(type=image)"><code>image</code></a>
@@ -1139,7 +1182,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-month" tabindex="-1">
+          <tr id="el-input-month" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#month-state-(type=month)">month</a></code>
@@ -1156,7 +1199,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-number" tabindex="-1">
+          <tr id="el-input-number" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#number-state-(type=number)">number</a></code>
@@ -1175,7 +1218,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-password" tabindex="-1">
+          <tr id="el-input-password" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#password-state-(type=password)">password</a></code>
@@ -1195,7 +1238,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-radio" tabindex="-1">
+          <tr id="el-input-radio" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#radio-button-state-(type=radio)">radio</a></code>
@@ -1222,7 +1265,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-range" tabindex="-1">
+          <tr id="el-input-range" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#range-state-(type=range)">range</a></code>
@@ -1240,7 +1283,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-reset" tabindex="-1">
+          <tr id="el-input-reset" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#reset-button-state-(type=reset)">reset</a></code>
@@ -1258,7 +1301,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-search-no-list" tabindex="-1">
+          <tr id="el-input-search" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#text-(type=text)-state-and-search-state-(type=search)">search</a></code>,
@@ -1279,7 +1322,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-submit" tabindex="-1">
+          <tr id="el-input-submit" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#submit-button-state-(type=submit)" title=
@@ -1298,7 +1341,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-tel-no-list" tabindex="-1">
+          <tr id="el-input-tel" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#telephone-state-(type=tel)">tel</a></code>, with
@@ -1318,7 +1361,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-text-no-list" tabindex="-1">
+          <tr id="el-input-text" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#text-(type=text)-state-and-search-state-(type=search)">text</a></code>,
@@ -1340,7 +1383,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-text-list" tabindex="-1">
+          <tr id="el-input-text-list" tabindex="-1">
             <td>
               <code>input type=</code> <a data-cite=
               "html/input.html#text-(type=text)-state-and-search-state-(type=search)">
@@ -1369,7 +1412,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-time" tabindex="-1">
+          <tr id="el-input-time" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#time-state-(type=time)">time</a></code>
@@ -1386,7 +1429,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-url-no-list" tabindex="-1">
+          <tr id="el-input-url" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#url-state-(type=url)">url</a></code> with no
@@ -1406,7 +1449,7 @@
               </p>
             </td>
           </tr>
-          <tr id="input-week" tabindex="-1">
+          <tr id="el-input-week" tabindex="-1">
             <td>
               <code>input type=<a data-cite=
               "html/input.html#week-state-(type=week)">week</a></code>
@@ -1423,11 +1466,9 @@
               </p>
             </td>
           </tr>
-          <tr id="ins-del" tabindex="-1">
+          <tr id="el-ins" tabindex="-1">
             <td>
-              <p>
-                [^ins^] and [^del^]
-              </p>
+              [^ins^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1443,7 +1484,7 @@
               </p>
             </td>
           </tr>
-          <tr id="label" tabindex="-1">
+          <tr id="el-label" tabindex="-1">
             <td>
               [^label^]
             </td>
@@ -1459,7 +1500,7 @@
               </p>
             </td>
           </tr>
-          <tr id="legend" tabindex="-1">
+          <tr id="el-legend" tabindex="-1">
             <td>
               [^legend^]
             </td>
@@ -1475,7 +1516,7 @@
               </p>
             </td>
           </tr>
-          <tr id="li" tabindex="-1">
+          <tr id="el-li" tabindex="-1">
             <td>
               [^li^] element whose parent is an [^ol^], [^ul^] or [^menu^]
             </td>
@@ -1509,7 +1550,7 @@
               </p>
             </td>
           </tr>
-          <tr id="link-href" tabindex="-1">
+          <tr id="el-link" tabindex="-1">
             <td>
               [^link^] element with a <a data-cite=
               "html/semantics.html#attr-link-href"><code>href</code></a>
@@ -1521,7 +1562,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="main" tabindex="-1">
+          <tr id="el-main" tabindex="-1">
             <td>
               [^main^]
             </td>
@@ -1538,7 +1579,7 @@
               </p>
             </td>
           </tr>
-          <tr id="map" tabindex="-1">
+          <tr id="el-map" tabindex="-1">
             <td>
               [^map^]
             </td>
@@ -1549,7 +1590,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="math" tabindex="-1">
+          <tr id="el-math" tabindex="-1">
             <td>
               <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
             </td>
@@ -1566,7 +1607,7 @@
               </p>
             </td>
           </tr>
-          <tr id="menu" tabindex="-1">
+          <tr id="el-menu" tabindex="-1">
             <td>
               [^menu^]
             </td>
@@ -1600,7 +1641,7 @@
               </p>
             </td>
           </tr>
-          <tr id="meta" tabindex="-1">
+          <tr id="el-meta" tabindex="-1">
             <td>
               [^meta^]
             </td>
@@ -1611,7 +1652,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="meter" tabindex="-1">
+          <tr id="el-meter" tabindex="-1">
             <td>
               [^meter^]
             </td>
@@ -1627,7 +1668,7 @@
               </p>
             </td>
           </tr>
-          <tr id="nav" tabindex="-1">
+          <tr id="el-nav" tabindex="-1">
             <td>
               [^nav^]
             </td>
@@ -1649,7 +1690,7 @@
               </p>
             </td>
           </tr>
-          <tr id="noscript" tabindex="-1">
+          <tr id="el-noscript" tabindex="-1">
             <td>
               [^noscript^]
             </td>
@@ -1660,7 +1701,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="object" tabindex="-1">
+          <tr id="el-object" tabindex="-1">
             <td>
               [^object^]
             </td>
@@ -1680,7 +1721,7 @@
               </p>
             </td>
           </tr>
-          <tr id="ol" tabindex="-1">
+          <tr id="el-ol" tabindex="-1">
             <td>
               [^ol^]
             </td>
@@ -1713,7 +1754,7 @@
               </p>
             </td>
           </tr>
-          <tr id="optgroup" tabindex="-1">
+          <tr id="el-optgroup" tabindex="-1">
             <td>
               [^optgroup^]
             </td>
@@ -1730,7 +1771,7 @@
               </p>
             </td>
           </tr>
-          <tr id="option" tabindex="-1">
+          <tr id="el-option" tabindex="-1">
             <td>
               [^option^] element that is in a <a data-cite=
               "html/input.html#attr-input-list">list of options</a> or that
@@ -1749,7 +1790,7 @@
               </p>
             </td>
           </tr>
-          <tr id="output" tabindex="-1">
+          <tr id="el-output" tabindex="-1">
             <td>
               [^output^]
             </td>
@@ -1767,7 +1808,25 @@
               </p>
             </td>
           </tr>
-          <tr id="param" tabindex="-1">
+          <tr id="el-p" tabindex="-1">
+            <td>
+              <a><code>p</code></a>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport">Any `role`</strong>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-param" tabindex="-1">
             <td>
               [^param^]
             </td>
@@ -1778,7 +1837,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="picture" tabindex="-1">
+          <tr id="el-picture" tabindex="-1">
             <td>
               [^picture^]
             </td>
@@ -1789,7 +1848,25 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="progress" tabindex="-1">
+          <tr id="el-pre" tabindex="-1">
+            <td>
+              <a><code>pre</code></a>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport">Any `role`</strong>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-progress" tabindex="-1">
             <td>
               [^progress^]
             </td>
@@ -1806,7 +1883,7 @@
               </p>
             </td>
           </tr>
-          <tr id="script" tabindex="-1">
+          <tr id="el-script" tabindex="-1">
             <td>
               [^script^]
             </td>
@@ -1817,7 +1894,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="section" tabindex="-1">
+          <tr id="el-section" tabindex="-1">
             <td>
               [^section^]
             </td>
@@ -1893,7 +1970,7 @@
               </p>
             </td>
           </tr>
-          <tr id="select" tabindex="-1">
+          <tr id="el-select" tabindex="-1">
             <td>
               [^select^] (with NO `multiple` attribute and NO `size`
               attribute having value greater than `1`) <span class=
@@ -1914,7 +1991,7 @@
               </p>
             </td>
           </tr>
-          <tr id="select2" tabindex="-1">
+          <tr id="el-select-multiple-or-size-greater-1" tabindex="-1">
             <td>
               <code><a data-xref-for="HTMLElement">select</a></code> (with a
               <code>multiple</code> attribute or a <code>size</code> attribute
@@ -1935,12 +2012,12 @@
               </p>
             </td>
           </tr>
-          <tr id="slot" tabindex="-1">
+          <tr id="el-slot" tabindex="-1">
             <td><code><a>slot</a></code></td>
             <td><a>No corresponding role</a></td>
             <td><strong class="nosupport">No `role` or `aria-*` attributes</strong></td>
           </tr>
-          <tr id="source" tabindex="-1">
+          <tr id="el-source" tabindex="-1">
             <td>
               <code><a>source</a></code>
             </td>
@@ -1951,7 +2028,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="span" tabindex="-1">
+          <tr id="el-span" tabindex="-1">
             <td>
               <a><code>span</code></a>
             </td>
@@ -1969,7 +2046,25 @@
               </p>
             </td>
           </tr>
-          <tr id="style" tabindex="-1">
+          <tr id="el-strong" tabindex="-1">
+            <td>
+              <a><code>strong</code></a>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-style" tabindex="-1">
             <td>
               [^style^]
             </td>
@@ -1980,7 +2075,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="svg" tabindex="-1">
+          <tr id="el-svg" tabindex="-1">
             <td>
               <code><a data-cite=
               "html/embedded-content-other.html#svg-0">SVG</a></code>
@@ -2001,7 +2096,25 @@
               </p>
             </td>
           </tr>
-          <tr id="summary" tabindex="-1">
+          <tr id="el-sub" tabindex="-1">
+            <td>
+              <code><a data-cite="html/text-level-semantics.html#the-sub-and-sup-elements">sub</a></code>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-summary" tabindex="-1">
             <td>
               [^summary^]
             </td>
@@ -2022,7 +2135,25 @@
               </p>
             </td>
           </tr>
-          <tr id="table" tabindex="-1">
+          <tr id="el-sup" tabindex="-1">
+            <td>
+              <code><a data-cite="html/text-level-semantics.html#the-sub-and-sup-elements">sup</a></code>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
+          <tr id="el-table" tabindex="-1">
             <td>
               [^table^]
             </td>
@@ -2041,7 +2172,25 @@
               </p>
             </td>
           </tr>
-          <tr id="template" tabindex="-1">
+          <tr id="el-tbody" tabindex="-1">
+            <td>
+              [^tbody^]
+            </td>
+            <td>
+              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*`attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-template" tabindex="-1">
             <td>
               [^template^]
             </td>
@@ -2052,7 +2201,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="textarea" tabindex="-1">
+          <tr id="el-textarea" tabindex="-1">
             <td>
               [^textarea^]
             </td>
@@ -2069,11 +2218,9 @@
               </p>
             </td>
           </tr>
-          <tr id="tbody-thead-tfoot" tabindex="-1">
+          <tr id="el-tfoot" tabindex="-1">
             <td>
-              <p>
-                [^tbody^], [^thead^], [^tfoot^]
-              </p>
+              [^tfoot^]
             </td>
             <td>
               <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
@@ -2089,6 +2236,42 @@
               </p>
             </td>
           </tr>
+          <tr id="el-thead" tabindex="-1">
+            <td>
+              [^thead^]
+            </td>
+            <td>
+              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*`attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-time" tabindex="-1">
+            <td>
+              <a><code>time</code></a>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any)
+              </p>
+            </td>
+          </tr>
           <tr id="el-title" tabindex="-1">
             <td>
               [^title^]
@@ -2100,7 +2283,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="td" tabindex="-1">
+          <tr id="el-td" tabindex="-1">
             <td>
               [^td^]
             </td>
@@ -2128,12 +2311,10 @@
                 Text level semantic elements not listed elsewhere:
               </p>
               <p>
-                <a><code>em</code></a><code>, <a>i</a>, <a>strong</a>, <a>small</a>,
+                <code><a>i</a>, <a>small</a>,
                 <a>s</a>, <a>cite</a>, <a>q</a>, <a>dfn</a>, <a>abbr</a>,
-                <a>time</a>, <a>code</a>, <a>var</a>, <a>samp</a>, <a>kbd</a>,
-                <a data-cite=
-                "html/text-level-semantics.html#the-sub-and-sup-elements">sub
-                and sup</a>, <a>b</a>, <a>u</a>, <a>mark</a>, <a>ruby</a>,
+                <a>code</a>, <a>var</a>, <a>samp</a>, <a>kbd</a>,
+                <a>b</a>, <a>u</a>, <a>mark</a>, <a>ruby</a>,
                 <a>rp</a>, <a>rt</a>, <a>bdi</a>, <a>bdo</a>, <a>br</a>, <a>wbr</a></code>
               </p>
             </td>
@@ -2149,7 +2330,7 @@
               </p>
             </td>
           </tr>
-          <tr id="th" tabindex="-1">
+          <tr id="el-th" tabindex="-1">
             <td>
               [^th^]
             </td>
@@ -2169,7 +2350,7 @@
               </p>
             </td>
           </tr>
-          <tr id="tr" tabindex="-1">
+          <tr id="el-tr" tabindex="-1">
             <td>
               [^tr^]
             </td>
@@ -2189,7 +2370,7 @@
               </p>
             </td>
           </tr>
-          <tr id="track" tabindex="-1">
+          <tr id="el-track" tabindex="-1">
             <td>
               [^track^]
             </td>
@@ -2200,7 +2381,7 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
-          <tr id="ul" tabindex="-1">
+          <tr id="el-ul" tabindex="-1">
             <td>
               [^ul^]
             </td>
@@ -2234,7 +2415,7 @@
               </p>
             </td>
           </tr>
-          <tr id="video" tabindex="-1">
+          <tr id="el-video" tabindex="-1">
             <td>
               <a><code>video</code></a>
             </td>
@@ -2253,7 +2434,7 @@
               </p>
             </td>
           </tr>
-          <tr id="attr-disabled" tabindex="-1">
+          <tr id="att-disabled" tabindex="-1">
             <td>
               Element with a <a data-cite=
               "html/form-control-infrastructure.html#attr-fe-disabled">
@@ -2276,7 +2457,7 @@
               </p>
             </td>
           </tr>
-          <tr id="attr-placeholder" tabindex="-1">
+          <tr id="att-placeholder" tabindex="-1">
             <td>
               Element with a <a data-cite=
               "html/input.html#the-placeholder-attribute"><code>placeholder</code></a>
@@ -2299,7 +2480,7 @@
               </p>
             </td>
           </tr>
-          <tr id="attr-required" tabindex="-1">
+          <tr id="att-required" tabindex="-1">
             <td>
               Element with a <a data-cite=
               "html/input.html#attr-input-required"><code>required</code></a>
@@ -2325,7 +2506,7 @@
               </p>
             </td>
           </tr>
-          <tr id="attr-readonly" tabindex="-1">
+          <tr id="att-readonly" tabindex="-1">
             <td>
               Element with a <a data-cite=
               "html/input.html#attr-input-readonly"><code>readonly</code></a>
@@ -2347,7 +2528,7 @@
               </p>
             </td>
           </tr>
-          <tr id="attr-hidden" tabindex="-1">
+          <tr id="att-hidden" tabindex="-1">
             <td>
               Element with a <a data-cite=
               "html/interaction.html#the-hidden-attribute"><code>hidden</code></a>
@@ -2391,7 +2572,7 @@
               </p>
             </td>
           </tr>
-          <tr id="attr-contenteditable" tabindex="-1">
+          <tr id="att-contenteditable" tabindex="-1">
             <td>
               Element with <code><a data-cite=
               "html/interaction.html#attr-contenteditable">contenteditable</a></code>

--- a/index.html
+++ b/index.html
@@ -2,11 +2,8 @@
 <html lang="en-US">
   <head>
     <meta charset="utf-8">
-    <title>
-      ARIA in HTML
-    </title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class=
-    "remove"></script>
+    <title>ARIA in HTML</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
     <script class="remove">
     var respecConfig = {
       editors: [
@@ -115,12 +112,7 @@
         <span>implicit ARIA semantics</span> is unnecessary and is NOT
         RECOMMENDED as these properties are already set by the browser.
       </p>
-      <p class="note">
-        The <span class="new-feature">(new)</span> and <span class=
-        "changed-feature">(changed)</span> markers in the following table
-        indicate new (in ARIA 1.1) or changed (between ARIA 1.0/1.1) ARIA
-        roles, states and properties.
-      </p>
+
       <table class="simple">
         <caption>
           Rules of ARIA attributes usage by HTML language feature
@@ -144,60 +136,60 @@
         <tbody>
           <tr id="el-a" tabindex="-1">
             <td>
-            <a><code>a</code></a> element with a <a data-cite="html/links.html#attr-hyperlink-href"><code>href</code></a></td>
+              [^a^] element with a <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
+            </td>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
             </td>
             <td>
               <p>
-                Roles: <code><a>button</a>, <a href=
-                "#index-aria-checkbox">checkbox</a>, <a href=
-                "#index-aria-menuitem">menuitem</a>, <a href=
-                "#index-aria-menuitemcheckbox">menuitemcheckbox</a>, <a href=
-                "#index-aria-menuitemradio">menuitemradio</a>, <a href=
-                "#index-aria-option">option</a></code> - <span class=
-                "changed-feature">(changed)</span>, <code><a href=
-                "#index-aria-radio">radio</a>, <a href=
-                "#index-aria-switch">switch</a></code> - <span class=
-                "new-feature">(new)</span>, <a href="#index-aria-tab">tab</a> or
-                <code><a href="#index-aria-treeitem">treeitem</a></code>
+                Roles:
+                <a href="#index-aria-button">`button`</a>,
+                <a href="#index-aria-checkbox">`checkbox`</a>,
+                <a href="#index-aria-menuitem">`menuitem`</a>,
+                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                <a href="#index-aria-option">`option`</a>,
+                <a href="#index-aria-radio">`radio`</a>,
+                <a href="#index-aria-switch">`switch`</a>,
+                <a href="#index-aria-tab">`tab`</a>
+                or <a href="#index-aria-treeitem">`treeitem`</a>
               </p>
               <p>
-                DPub Roles: <a data-cite=
-                "dpub-aria-1.0#doc-backlink"><code>doc-backlink</code></a><code>,
-                <a data-cite="dpub-aria-1.0#doc-biblioref">doc-biblioref</a>,
-                <a data-cite="dpub-aria-1.0#doc-glossref">doc-glossref</a>,
-                <a data-cite="dpub-aria-1.0#doc-noteref">doc-noteref</a></code> -
-                <span class="new-feature">(new)</span>
+                DPub Roles:
+                <a data-cite="dpub-aria-1.0#doc-backlink">`doc-backlink`</a>,
+                <a data-cite="dpub-aria-1.0#doc-biblioref">`doc-biblioref`</a>,
+                <a data-cite="dpub-aria-1.0#doc-glossref">`doc-glossref`</a>,
+                <a data-cite="dpub-aria-1.0#doc-noteref">`doc-noteref`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-a-no-href" tabindex="-1">
             <td>
-              <a><code>a</code></a> element without a <a data-cite="html/links.html#attr-hyperlink-href"><code>href</code></a>
+              [^a^] element without a <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
             </td>
             <td>
               <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn">No corresponding role</a>
             </td>
             <td>
               <p>
-                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn"><strong>Any</strong> <code>role</code></a>
+                <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global <code>aria-*</code> attributes</a> and
-                any <code>aria-*</code> attributes applicable to the allowed roles and
-                implied role (if any)
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-abbr" tabindex="-1">
             <td>
-              <a><code>abbr</code></a>
+              [^abbr^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -207,15 +199,15 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-address" tabindex="-1">
             <td>
-              <a><code>address</code></a>
+              [^address^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -225,7 +217,7 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
                 implied role (if any).
               </p>
@@ -233,8 +225,7 @@
           </tr>
           <tr id="el-area" tabindex="-1">
             <td>
-              <a><code>area</code></a> with a <a data-cite=
-              "html/links.html#attr-hyperlink-href"><code>href</code></a>
+              [^area^] with a <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
@@ -244,41 +235,46 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code><a href=
-                "#index-aria-link">link</a></code> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the <a href=
+                "#index-aria-link">`link`</a> role.
               </p>
             </td>
           </tr>
           <tr id="el-area-no-href" tabindex="-1">
-            <td><a><code>area</code></a> without a <a data-cite=
-              "html/links.html#attr-hyperlink-href"><code>href</code></a></td>
+            <td>
+              [^area^] without a <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
+            </td>
             <td><a>No corresponding role</a></td>
-            <td><p> <strong class="nosupport">No `role`</strong> </p>
-              <p> <a href="#index-aria-global">global `aria-*` attributes</a> and
+            <td>
+              <p><strong class="nosupport">No `role`</strong></p>
+              <p><a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)</p></td>
+                implied role (if any).</p>
+            </td>
           </tr>
           <tr id="el-article" tabindex="-1">
             <td>
-              <code><a>article</a></code>
+              [^article^]
             </td>
             <td>
               <code>role=<a href="#index-aria-article">article</a></code>
             </td>
             <td>
               <p>
-                Roles: <code><a href="#index-aria-feed">feed</a></code> -
-                <span class="new-feature">(new)</span>, <code><a href=
-                "#index-aria-presentation">presentation</a>, <a href=
-                "#index-aria-none">none</a>, <a href=
-                "#index-aria-document">document</a>, <a href=
-                "#index-aria-application">application</a>, <a href=
-                "#index-aria-main">main</a> or <a href=
-                "#index-aria-region">region</a></code>.<br>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                Roles:
+                <a href="#index-aria-feed">`feed`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>,
+                <a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-document">`document`</a>,
+                <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-main">`main`</a>
+                or <a href="#index-aria-region">`region`</a>.
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -287,13 +283,12 @@
               [^aside^]
             </td>
             <td>
-              <code>role=<a href=
-              "#index-aria-complementary">complementary</a></code>
+              <code>role=<a href="#index-aria-complementary">complementary</a></code>
             </td>
             <td>
               <p>
-                Roles: <a href="#index-aria-feed">`feed`</a> -
-                <span class="new-feature">(new)</span>,
+                Roles:
+                <a href="#index-aria-feed">`feed`</a>,
                 <a href="#index-aria-note">`note`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>,
                 <a href="#index-aria-none">`none`</a>,
@@ -301,19 +296,17 @@
                 or <a href="#index-aria-search">`search`</a>.
               </p>
               <p>
-                DPub Roles: <a data-cite=
-                "dpub-aria-1.0#doc-dedication">`doc-dedication`</a>,
-                <a data-cite=
-                "dpub-aria-1.0#doc-example">`doc-example`</a>,
+                DPub Roles:
+                <a data-cite="dpub-aria-1.0#doc-dedication">`doc-dedication`</a>,
+                <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>,
                 <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>,
                 <a data-cite="dpub-aria-1.0#doc-pullquote">`doc-pullquote`</a>,
-                <a data-cite="dpub-aria-1.0#doc-tip">`doc-tip`</a> -
-                <span class="new-feature">(new)</span>
+                <a data-cite="dpub-aria-1.0#doc-tip">`doc-tip`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -326,11 +319,13 @@
             </td>
             <td>
               <p>
-                Role: <a href=
-                "#index-aria-application"><code>application</code></a><br>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                Role:
+                <a href="#index-aria-application">`application`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the <a href=
-                "#index-aria-application"><code>application</code></a> role.
+                "#index-aria-application">`application`</a> role.
               </p>
             </td>
           </tr>
@@ -346,9 +341,9 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -365,19 +360,19 @@
           </tr>
           <tr id="el-blockquote" tabindex="-1">
             <td>
-              <a><code>blockquote</code></a>
+              [^blockquote^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                <strong class="nosupport">Any `role`</strong>
+                <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -393,9 +388,9 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code><a href=
-                "#index-aria-document">document</a></code> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a>
+                and any `aria-*` attributes applicable to the
+                <a href="#index-aria-document">`document`</a> role.
               </p>
             </td>
           </tr>
@@ -408,21 +403,21 @@
             </td>
             <td>
               <p>
-                Roles: <code><a href=
-                "#index-aria-checkbox">checkbox</a></code>, <code><a href=
-                "#index-aria-link">link</a>, <a href=
-                "#index-aria-menuitem">menuitem</a>, <a href=
-                "#index-aria-menuitemcheckbox">menuitemcheckbox</a>, <a href=
-                "#index-aria-menuitemradio">menuitemradio</a>,<a href=
-                "#index-aria-option">option</a></code> - <span class=
-                "changed-feature">(changed)</span><code>, <a href=
-                "#index-aria-radio">radio</a></code>, <a href=
-                "#index-aria-switch"><code>switch</code></a> - <span class=
-                "new-feature">(new)</span> or <a href=
-                "#index-aria-tab"><code>tab</code></a><br>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                Roles:
+                <a href="#index-aria-checkbox">`checkbox`</a>,
+                <a href="#index-aria-link">`link`</a>,
+                <a href="#index-aria-menuitem">`menuitem`</a>,
+                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                <a href="#index-aria-option">`option`</a>,
+                <a href="#index-aria-radio">`radio`</a>,
+                <a href="#index-aria-switch">`switch`</a>
+                or <a href="#index-aria-tab">`tab`</a>.
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -438,9 +433,9 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -456,7 +451,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a>
+                <a href="#index-aria-global">Global `aria-*` attributes</a>
               </p>
             </td>
           </tr>
@@ -498,9 +493,9 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <a href=
-                "#index-aria-listbox">listbox</a> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a>
+                and any `aria-*` attributes applicable to the
+                <a href="#index-aria-listbox">`listbox`</a> role.
               </p>
             </td>
           </tr>
@@ -516,9 +511,8 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the
-                <code>definition</code> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `definition` role.
               </p>
             </td>
           </tr>
@@ -531,12 +525,12 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">Any `role`</strong>
+                <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -552,9 +546,8 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code>group</code>
-                role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `group` role.
               </p>
             </td>
           </tr>
@@ -567,19 +560,18 @@
             </td>
             <td>
               <p>
-                Role: <a href=
-                "#index-aria-alertdialog"><code>alertdialog</code></a>
+                Role:
+                <a href="#index-aria-alertdialog">`alertdialog`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code>dialog</code>
-                role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `dialog` role.
               </p>
             </td>
           </tr>
           <tr id="el-div" tabindex="-1">
             <td>
-              <a><code>div</code></a>
+              [^div^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -589,54 +581,56 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-dl" tabindex="-1">
             <td>
-              <a><code>dl</code></a>
+              [^dl^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-group">group</a>, <a href=
-                "#index-aria-list">list</a>, <a href=
-                "#index-aria-presentation">presentation</a></code> or
-              <code><a href="#index-aria-none">none</a></code></p>
+                Roles:
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-list">`list`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>.
+              </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-dt" tabindex="-1">
             <td>
-              <code><a>dt</a></code>
+              [^dt^]
             </td>
             <td>
               <code>role=<a href="#index-aria-term">term</a></code>
             </td>
             <td>
               <p>
-                Role: <code>role=<a href=
-                "#index-aria-listitem">listitem</a></code>
+                Role:
+                <a href="#index-aria-listitem">`listitem`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-em" tabindex="-1">
             <td>
-              <a><code>em</code></a>
+              [^em^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -646,190 +640,179 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-embed" tabindex="-1">
             <td>
-              <code><a>embed</a></code>
+              [^embed^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-application">application</a>,
-                <a href="#index-aria-document">document</a>, <a href=
-                "#index-aria-presentation">presentation</a>, <a href=
-                "#index-aria-none">none</a></code> or <code><a href=
-                "#index-aria-img">img</a></code>
+                Roles:
+                <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-document">`document`</a>,
+                <a href="#index-aria-img">`img`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-figcaption" tabindex="-1">
             <td>
-              <a><code>figcaption</code></a> - <span class=
-              "new-feature">(new)</span>
+              [^figcaption^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                Roles: <code><a href="#index-aria-group">group</a></code>,
-                <code><a href=
-                "#index-aria-presentation">presentation</a></code> <code>or
-                <a href="#index-aria-none">none</a></code>
+                Roles:
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-fieldset" tabindex="-1">
             <td>
-              <a><code>fieldset</code></a>
+              [^fieldset^]
             </td>
             <td>
               <code>role=<a href="#index-aria-group">group</a></code>
-              <span class="changed-feature">(changed)</span>
             </td>
             <td>
               <p>
-                Roles: <code><a href="#index-aria-radiogroup">radiogroup</a></code>, <code><a href="#index-aria-none">none</a></code>, or
-                <code><a href=
-                "#index-aria-presentation">presentation</a></code>
+                Roles:
+                <a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-radiogroup">`radiogroup`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-figure" tabindex="-1">
             <td>
-              <a><code>figure</code></a>
+              [^figure^]
             </td>
             <td>
-              <code>role=<a href="#index-aria-figure">figure</a></code> -
-              <span class="new-feature">(new)</span>
+              <code>role=<a href="#index-aria-figure">figure</a></code>
             </td>
             <td>
               <p>
-                Roles: <code><a href=
-                "#index-aria-group">group</a></code><code>, <a href=
-                "#index-aria-none">none</a></code> or <code><a href=
-                "#index-aria-presentation">presentation</a></code>
+                Roles:
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-none">`none`</a>
+                or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-footer" tabindex="-1">
             <td>
-              <code><a>footer</a></code>
+              [^footer^]
             </td>
             <td>
-              If not a descendant of an <code>article</code>,
-              <code>aside</code>, <code>main</code>, <code>nav</code>
-              <span class="changed-feature">(changed)</span> or
-              <code>section</code> element
-              or an element with <code>role=article</code>, <code>complementary</code>,
-              <code>main</code>, <code>navigation</code>
-              <span class="changed-feature">(changed)</span> or <code>region</code>
-              then <code>role=<a href=
-              "#index-aria-contentinfo">contentinfo</a></code>, otherwise <a>No
-              corresponding role</a>
+              If not a descendant of an `article`, `aside`, `main`, `nav`
+              or `section` element, or an element with `role=article`, `complementary`,
+              `main`, `navigation` or `region`
+              then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>,
+              otherwise <a>No corresponding role</a>.
             </td>
             <td>
               <p>
-                Roles: <code><a href="#index-aria-group">group</a></code>,
-                <code><a href="#index-aria-none">none</a></code> or
-                <code><a href=
-                "#index-aria-presentation">presentation</a></code>
+                Roles:
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-none">`none`</a>
+                or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                DPub Roles: <a data-cite=
-                "dpub-aria-1.0#doc-footnote"><code>doc-footnote</code></a> -
-                <span class="new-feature">(new)</span>
+                DPub Roles:
+                <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed.
               </p>
             </td>
           </tr>
           <tr id="el-form" tabindex="-1">
             <td>
-              <code><a>form</a></code>
+              [^form^]
             </td>
             <td>
               <code>role=<a href="#index-aria-form">form</a></code> if the
-              <code><a>form</a></code> element has an <a data-cite=
-              "html-aam-1.0#dfn-accessible-name" data-link-type=
-              "dfn">accessible name</a>. Otherwise, <a>no corresponding
-              role</a>.
+              [^form^] element has an
+              <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>.
+              Otherwise, <a>no corresponding role</a>.
             </td>
             <td>
               <p>
-                Role: <a href="#index-aria-search"><code>search</code></a>,
-                <code><a href="#index-aria-none">none</a></code> or <a href=
-                "#index-aria-presentation"><code>presentation</code></a>
+                Roles:
+                <a href="#index-aria-search">`search`</a>,
+                <a href="#index-aria-none">`none`</a>
+                or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-h1-h6" tabindex="-1">
             <td>
-              <a data-cite=
-              "html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>
-              h1</code></a> to <a data-cite=
-              "html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>
-              h6</code></a> element
+              <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1 to h6`</a>
             </td>
             <td>
-              <code>role=<a href="#index-aria-heading">heading</a></code>, with
-              the <code>aria-level</code> = positive integer
+              <code>role=<a href="#index-aria-heading">heading</a></code>,
+              with the `aria-level` = positive integer.
             </td>
             <td>
               <p>
-                Role: <a href="#index-aria-tab"><code>tab</code></a><code>,
-                <a href="#index-aria-none">none</a></code> or <a href=
-                "#index-aria-presentation"><code>presentation</code></a>
+                Roles:
+                <a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-tab">`tab`</a>.
               </p>
               <p>
-                DPub Role: <a data-cite=
-                "dpub-aria-1.0#doc-subtitle"><code>doc-subtitle</code></a> -
-                <span class="new-feature">(new)</span>
+                DPub Role:
+                <a data-cite="dpub-aria-1.0#doc-subtitle">`doc-subtitle`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-head" tabindex="-1">
             <td>
-              <code><a>head</a></code>
+              [^head^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -840,72 +823,72 @@
           </tr>
           <tr id="el-header" tabindex="-1">
             <td>
-              <a><code>header</code></a>
+              [^header^]
             </td>
             <td>
-              If not a descendant of an <code>article</code>,
-              <code>aside</code>, <code>main</code>, <code>nav</code>
-              <span class="changed-feature">(changed)</span> or
-              <code>section</code> element
-              or an element with <code>role=article</code>, <code>complementary</code>,
-              <code>main</code>, <code>navigation</code>
-              <span class="changed-feature">(changed)</span> or <code>region</code>
-              then <code>role=<a href=
-              "#index-aria-banner">banner</a></code>, otherwise <a>No
-              corresponding role</a>
+              If not a descendant of an `article`, `aside`, `main`,
+              `nav` or `section` element, or an element with `role=article`,
+              `complementary`, `main`, `navigation`
+              or `region` then <code>role=<a href="#index-aria-banner">banner</a></code>,
+              otherwise <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                Roles: <a href="#index-aria-group"><code>group</code></a>,
-                <code><a href="#index-aria-none">none</a></code> or <a href=
-                "#index-aria-presentation"><code>presentation</code></a>
+                Roles:
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-none">`none`</a>
+                or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                DPub Role: <a data-cite=
-                "dpub-aria-1.0#doc-footnote"><code>doc-footnote</code></a> -
-                <span class="new-feature">(new)</span>
+                DPub Role:
+                <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-hgroup" tabindex="-1">
-            <td><a><code>hgroup</code></a></td>
+            <td>
+              [^hgroup^]
+            </td>
             <td><a>No corresponding role</a></td>
-            <td><p> <a><strong>Any</strong> `role`</a> </p>
-              <p> <a href="#index-aria-global">global `aria-*` attributes</a> and
+            <td>
+              <p><a><strong>Any</strong> `role`</a>.</p>
+              <p><a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any) </p></td>
+                implied role (if any).
+              </p>
+            </td>
           </tr>
           <tr id="el-hr" tabindex="-1">
             <td>
-              <code><a>hr</a></code>
+              [^hr^]
             </td>
             <td>
               <code>role=<a href="#index-aria-separator">separator</a></code>
             </td>
             <td>
               <p>
-                Roles: <code><a href="#index-aria-none">none</a></code> or
-                <a href=
-                "#index-aria-presentation"><code>presentation</code></a>
+                Roles:
+                <a href="#index-aria-none">`none`</a>
+                or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                DPub Role: <a data-cite="dpub-aria-1.0#doc-pagebreak"><code>doc-pagebreak</code></a> -
-                <span class="new-feature">(new)</span>
+                DPub Role:
+                <a data-cite="dpub-aria-1.0#doc-pagebreak">`doc-pagebreak`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the
-                <code>separator</code> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `separator` role.
               </p>
             </td>
           </tr>
           <tr id="el-html" tabindex="-1">
             <td>
-              <code><a>html</a></code>
+              [^html^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -916,23 +899,24 @@
           </tr>
           <tr id="el-iframe" tabindex="-1">
             <td>
-              <a><code>iframe</code></a>
+              [^iframe^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-application">application</a>,
-                <a href="#index-aria-document">document</a>, <a href=
-                "#index-aria-none">none</a></code>, <a href=
-                "#index-aria-presentation"><code>presentation</code></a> or
-                <a href="#index-aria-img"><code>img</code></a>
+                Roles:
+                <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-document">`document`</a>,
+                <a href="#index-aria-img">`img`</a>,
+                <a href="#index-aria-none">`none`</a>,
+                or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -946,13 +930,14 @@
             </td>
             <td>
               <p>
-                <strong>Any</strong> `role` except <code>presentation</code> or
-                <code>none</code> <span class="changed-feature">(changed)</span>
+                <a><strong>Any</strong> `role`</a> except
+                <a href="#index-aria-none">`none`</a>,
+                or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -966,14 +951,13 @@
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-none">none</a></code> or
-                <a href=
-                "#index-aria-presentation"><code>presentation</code></a><span class="changed-feature">(changed)</span>
+                Roles:
+                <a href="#index-aria-none">`none`</a> or
+                <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
                 <strong class="nosupport">No `aria-*` attributes</strong> except
-                <code>aria-hidden</code> <span class=
-                "changed-feature">(changed)</span>
+                `aria-hidden`.
               </p>
             </td>
           </tr>
@@ -986,47 +970,44 @@
             </td>
             <td>
               <p>
-                <strong>Any</strong> `role`
-                <span class="changed-feature">(changed)</span>
+                <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-input-button" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#button-state-(type=button)">`button`</a></code>
+              <a data-cite="html/input.html#button-state-(type=button)">`input type=button`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-link">link</a>, <a href=
-                "#index-aria-menuitem">menuitem</a>, <a href=
-                "#index-aria-menuitemcheckbox">menuitemcheckbox</a>, <a href=
-                "#index-aria-menuitemradio">menuitemradio</a>, <a href=
-                "#index-aria-option">option</a></code> - <span class=
-                "changed-feature">(changed)</span><code>, <a href=
-                "#index-aria-radio">radio</a>,</code> <a href=
-                "#index-aria-switch"><code>switch</code></a> or <a href=
-                "#index-aria-tab"><code>tab</code></a>
+                Roles:
+                <a href="#index-aria-link">`link`</a>,
+                <a href="#index-aria-menuitem">`menuitem`</a>,
+                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                <a href="#index-aria-option">`option`</a>,
+                <a href="#index-aria-radio">`radio`</a>,
+                <a href="#index-aria-switch">`switch`</a>
+                or <a href="#index-aria-tab">`tab`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-input-checkbox" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#checkbox-state-(type=checkbox)">checkbox</a></code>
+              <a data-cite="html/input.html#checkbox-state-(type=checkbox)">`input type=checkbox`</a>
             </td>
             <td>
               <p>
@@ -1035,49 +1016,45 @@
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-button">button</a></code>
-                (when used in conjunction with <code>aria-pressed</code>),
-                <code><a href=
-                "#index-aria-menuitemcheckbox">menuitemcheckbox</a></code>,
-                <code><a href="#index-aria-option">option</a></code> -
-                <span class="changed-feature">(changed)</span> or
-                <code><a href="#index-aria-switch">switch</a></code>
+                Roles:
+                <a href="#index-aria-button">`button` (when used with `aria-pressed`)</a>,
+                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                <a href="#index-aria-option">`option`</a>
+                or <a href="#index-aria-switch">`switch`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
               <p>
-                <strong>Note:</strong> the HTML <a data-cite=
-                "html/input.html#attr-input-checked"><code>checked</code></a>
-                attribute may be used instead of the <code>aria-checked</code>
-                attribute for <code>menuitemcheckbox</code>,
-                <code>option</code> or <code>switch</code> when used on
-                <code>type=checkbox</code>. <span class=
-                "changed-feature">(changed)</span>
+                <strong>Note:</strong> the HTML
+                <a data-cite="html/input.html#attr-input-checked">`checked`</a>
+                attribute may be used instead of the `aria-checked`
+                attribute for `menuitemcheckbox`, `option` or `switch` when used on
+                `type=checkbox`.
               </p>
             </td>
           </tr>
           <tr id="el-input-color" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#color-state-(type=color)">color</a></code>
+              <a data-cite="html/input.html#color-state-(type=color)">`input type=color`</a>
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role`</strong>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a>
+                <strong class="nosupport">No `role`</strong>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a>
               </p>
             </td>
           </tr>
           <tr id="el-input-date" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#date-state-(type=date)">date</a></code>
+              <a data-cite="html/input.html#date-state-(type=date)">`input type=date`</a>
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1087,14 +1064,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a>
+                <a href="#index-aria-global">Global `aria-*` attributes</a>
               </p>
             </td>
           </tr>
           <tr id="el-input-datetime-local" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#local-date-and-time-state-(type=datetime-local)">datetime-local</a></code>
+              <a data-cite="html/input.html#local-date-and-time-state-(type=datetime-local)">`input type=datetime-local`</a>
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1104,16 +1080,16 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a>
+                <a href="#index-aria-global">Global `aria-*` attributes</a>
               </p>
             </td>
           </tr>
           <tr id="el-input-email" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#e-mail-state-(type=email)">email</a></code> with
-              no <a data-cite=
-              "html/input.html#attr-input-list"><code>list</code></a> attribute
+              <a data-cite=
+              "html/input.html#e-mail-state-(type=email)">`input type=email`</a>
+              with no
+              <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
             </td>
             <td>
               <code>role=<a href="#index-aria-checkbox">textbox</a></code>
@@ -1123,16 +1099,14 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code>textbox</code>
-                role
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-file" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#file-upload-state-(type=file)">file</a></code>
+              <a data-cite="html/input.html#file-upload-state-(type=file)">`input type=file`</a>
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1142,14 +1116,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a>
+                <a href="#index-aria-global">Global `aria-*` attributes</a>
               </p>
             </td>
           </tr>
           <tr id="el-input-hidden" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#hidden-state-(type=hidden)">hidden</a></code>
+              <a data-cite="html/input.html#hidden-state-(type=hidden)">`input type=hidden`</a>
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1160,32 +1133,31 @@
           </tr>
           <tr id="el-input-image" tabindex="-1">
             <td>
-              <code>input type=</code><a data-cite=
-              "html/input.html#image-button-state-(type=image)"><code>image</code></a>
+              <a data-cite="html/input.html#image-button-state-(type=image)">`input type=image`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-link">link</a>, <a href=
-                "#index-aria-menuitem">menuitem</a>, <a href=
-                "#index-aria-menuitemcheckbox">menuitemcheckbox</a>, <a href=
-                "#index-aria-menuitemradio">menuitemradio</a>, <a href=
-                "#index-aria-radio">radio</a> or</code> <a href=
-                "#index-aria-switch"><code>switch</code></a>
+                Roles:
+                <a href="#index-aria-link">`link`</a>,
+                <a href="#index-aria-menuitem">`menuitem`</a>,
+                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                <a href="#index-aria-radio">`radio`</a>
+                or <a href="#index-aria-switch">`switch`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-input-month" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#month-state-(type=month)">month</a></code>
+              <a data-cite="html/input.html#month-state-(type=month)">`input type=month`</a>
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1201,8 +1173,7 @@
           </tr>
           <tr id="el-input-number" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#number-state-(type=number)">number</a></code>
+              <a data-cite="html/input.html#number-state-(type=number)">`input type=number`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-spinbutton">spinbutton</a></code>
@@ -1212,63 +1183,55 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the
-                <code>spinbutton</code> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `spinbutton` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-password" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#password-state-(type=password)">password</a></code>
+              <a data-cite="html/input.html#password-state-(type=password)">`input type=password`</a>
             </td>
             <td>
-              <a>No corresponding role</a> - <span class=
-              "changed-feature">(changed)</span>
+              <a>No corresponding role</a>
             </td>
             <td>
               <p>
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                <code>aria-required</code> - <span class=
-                "changed-feature">(changed)</span>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and `aria-required`
               </p>
             </td>
           </tr>
           <tr id="el-input-radio" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#radio-button-state-(type=radio)">radio</a></code>
+              <a data-cite=
+              "html/input.html#radio-button-state-(type=radio)">`input type=radio`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-radio">radio</a></code>
             </td>
             <td>
               <p>
-                <code>Role:<a href=
-                "#index-aria-menuitemradio">menuitemradio</a></code>
+                Role:
+                <a href="#index-aria-menuitemradio">`menuitemradio`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the
-                <code>menuitemradio</code> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `menuitemradio` role.
               </p>
               <p>
                 <strong>Note:</strong> the HTML <a data-cite=
                 "html/input.html#attr-input-checked">`checked`</a>
                 attribute may be used instead of the `aria-checked` attribute
                 for `menuitemradio` when used on `type=radio`.
-                <span class="changed-feature">(changed)</span>
               </p>
             </td>
           </tr>
           <tr id="el-input-range" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#range-state-(type=range)">range</a></code>
+              <a data-cite="html/input.html#range-state-(type=range)">`input type=range`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-slider">slider</a></code>
@@ -1278,15 +1241,14 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `slider` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-reset" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#reset-button-state-(type=reset)">reset</a></code>
+              <a data-cite="html/input.html#reset-button-state-(type=reset)">`input type=reset`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
@@ -1296,37 +1258,32 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `button` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-search" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#text-(type=text)-state-and-search-state-(type=search)">search</a></code>,
-              with no <a data-cite=
-              "html/input.html#attr-input-list"><code>list</code></a> attribute
+              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=search`</a>,
+              with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
             </td>
             <td>
-              <code>role=<a href="#index-aria-searchbox">searchbox</a></code> -
-              <span class="new-feature">(new)</span>
+              <code>role=<a href="#index-aria-searchbox">searchbox</a></code>
             </td>
             <td>
               <p>
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `searchbox` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-submit" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#submit-button-state-(type=submit)" title=
-              "attr-input-type-submit">submit</a></code>
+              <a data-cite="html/input.html#submit-button-state-(type=submit)">input type=submit</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
@@ -1336,17 +1293,16 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `button` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-tel" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#telephone-state-(type=tel)">tel</a></code>, with
-              no <a data-cite=
-              "html/input.html#attr-input-list"><code>list</code></a> attribute
+              <a data-cite=
+              "html/input.html#telephone-state-(type=tel)">`input type=tel`</a>,
+              with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
             </td>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -1356,47 +1312,42 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-text" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#text-(type=text)-state-and-search-state-(type=search)">text</a></code>,
-              with no <a data-cite=
-              "html/input.html#attr-input-list"><code>list</code></a> attribute
+              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>,
+              with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
             </td>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-combobox">combobox</a>,
-                <a href="#index-aria-searchbox">searchbox</a></code> and
-                <code><a href="#index-aria-spinbutton">spinbutton</a></code>
+                Roles:
+                <a href="#index-aria-combobox">`combobox`</a>,
+                <a href="#index-aria-searchbox">`searchbox`</a></code>
+                or <a href="#index-aria-spinbutton">`spinbutton`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
           <tr id="el-input-text-list" tabindex="-1">
             <td>
-              <code>input type=</code> <a data-cite=
-              "html/input.html#text-(type=text)-state-and-search-state-(type=search)">
-              <code>text</code></a><code>, <a data-cite=
-              "html/input.html#text-(type=text)-state-and-search-state-(type=search)">
-              search</a>, <a data-cite=
-              "html/input.html#telephone-state-(type=tel)">tel</a>,
-              <a data-cite=
-              "html/input.html#url-state-(type=url)">url</a>,</code> or
-              <code><a data-cite=
-              "html/input.html#e-mail-state-(type=email)">email</a></code> with
-              a <a data-cite=
-              "html/input.html#attr-input-list"><code>list</code></a> attribute
+              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">
+              `input type=text`</a>,
+              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">
+              `search`</a>,
+              <a data-cite="html/input.html#telephone-state-(type=tel)">`tel`</a>,
+              <a data-cite="html/input.html#url-state-(type=url)">`url`</a>,
+              or <a data-cite="html/input.html#e-mail-state-(type=email)">`email`</a>
+              with a <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
             </td>
             <td>
               <code>role=<a href="#index-aria-combobox">combobox</a></code>
@@ -1406,16 +1357,14 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code>combobox</code>
-                role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `combobox` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-time" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#time-state-(type=time)">time</a></code>
+              <a data-cite="html/input.html#time-state-(type=time)">`input type=time`</a>
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1431,10 +1380,9 @@
           </tr>
           <tr id="el-input-url" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#url-state-(type=url)">url</a></code> with no
-              <a data-cite="html/input.html#attr-input-list" title=
-              "concept-input-list"><code>list</code></a> attribute
+              <a data-cite="html/input.html#url-state-(type=url)">`input type=url`</a>
+              with no
+              <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
             </td>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -1444,15 +1392,14 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
           <tr id="el-input-week" tabindex="-1">
             <td>
-              <code>input type=<a data-cite=
-              "html/input.html#week-state-(type=week)">week</a></code>
+              <a data-cite="html/input.html#week-state-(type=week)">`input type=week`</a>
             </td>
             <td>
               <a>No corresponding role</a>
@@ -1475,12 +1422,12 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">Any `role`</strong>
+                <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -1525,35 +1472,34 @@
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-menuitem">menuitem</a>,
-                <a href="#index-aria-menuitemcheckbox">menuitemcheckbox</a>,
-                <a href="#index-aria-menuitemradio">menuitemradio</a>, <a href=
-                "#index-aria-option">option</a>, <a href=
-                "#index-aria-none">none</a></code>, <a href=
-                "#index-aria-presentation"><code>presentation</code></a>,
-                <code><a href="#index-aria-radio">radio</a></code> - <span class=
-                "changed-feature">(changed)</span>, <code><a href=
-                "#index-aria-separator">separator</a>, <a href=
-                "#index-aria-tab">tab</a>, or <a href=
-                "#index-aria-treeitem">treeitem</a></code>
+                Roles:
+                <a href="#index-aria-menuitem">`menuitem`</a>,
+                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                <a href="#index-aria-option">`option`</a>,
+                <a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>,
+                <a href="#index-aria-radio">`radio`</a>,
+                <a href="#index-aria-separator">`separator`</a>,
+                <a href="#index-aria-tab">`tab`</a>
+                or <a href="#index-aria-treeitem">`treeitem`</a>
               </p>
               <p>
-                DPub Roles: <a data-cite=
-                "dpub-aria-1.0#doc-biblioentry"><code>doc-biblioentry</code></a><code>,
-                <a data-cite="dpub-aria-1.0#doc-endnote">doc-endnote</a></code>
-                - <span class="new-feature">(new)</span>
+                DPub Roles:
+                <a data-cite="dpub-aria-1.0#doc-biblioentry">`doc-biblioentry`</a>,
+                <a data-cite="dpub-aria-1.0#doc-endnote">`doc-endnote`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-link" tabindex="-1">
             <td>
-              [^link^] element with a <a data-cite=
-              "html/semantics.html#attr-link-href"><code>href</code></a>
+              [^link^] element with a
+              <a data-cite="html/semantics.html#attr-link-href">`href`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
@@ -1574,7 +1520,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `main` role.
               </p>
             </td>
@@ -1602,7 +1548,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `math` role.
               </p>
             </td>
@@ -1616,28 +1562,28 @@
             </td>
             <td>
               <p>
-                <b>Note</b> that some user agents suppress a list's
+                <strong>Note</strong> that some user agents suppress a list's
                 <a>implicit ARIA semantics</a> if list markers are removed.
-                Authors can use `role="list"` to reinstate the role, if necessary.
+                Authors can use `role=list` to reinstate the role, if necessary.
               </p>
               <p>
-                Role: <code><a href="#index-aria-directory">directory</a>,
-                <a href="#index-aria-group">group</a>,
-                <a href="#index-aria-listbox">listbox</a>,
-                <a href="#index-aria-menu">menu</a>,
-                <a href="#index-aria-menubar">menubar</a>,
-                <a href="#index-aria-radiogroup">radiogroup</a></code> - <span class=
-                "changed-feature">(changed)</span>,
-                <code><a href="#index-aria-tablist">tablist</a>,
-                <a href="#index-aria-toolbar">toolbar</a>,
-                <a href="#index-aria-tree">tree</a>,
-                <a href="#index-aria-presentation">presentation</a></code> or
-                <code><a href="#index-aria-none">none</a></code>
+                Roles:
+                <a href="#index-aria-directory">`directory`</a>,
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-listbox">`listbox`</a>,
+                <a href="#index-aria-menu">`menu`</a>,
+                <a href="#index-aria-menubar">`menubar`</a>,
+                <a href="#index-aria-radiogroup">`radiogroup`</a>,
+                <a href="#index-aria-tablist">`tablist`</a>,
+                <a href="#index-aria-toolbar">`toolbar`</a>,
+                <a href="#index-aria-tree">`tree`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -1677,16 +1623,14 @@
             </td>
             <td>
               <p>
-                DPub Roles: <a data-cite=
-                "dpub-aria-1.0#doc-index"><code>doc-index</code></a><code>,
-                <a data-cite="dpub-aria-1.0#doc-pagelist">doc-pagelist</a>,
-                <a data-cite="dpub-aria-1.0#doc-toc">doc-toc</a></code> -
-                <span class="new-feature">(new)</span>
+                DPub Roles:
+                <a data-cite="dpub-aria-1.0#doc-index">`doc-index`</a>,
+                <a data-cite="dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a>,
+                <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the
-                <code>navigation</code> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `navigation` role.
               </p>
             </td>
           </tr>
@@ -1710,14 +1654,15 @@
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-application">application</a>,
-                <a href="#index-aria-document">document</a>,</code> or
-                <code><a href="#index-aria-img">img</a></code>
+                Roles:
+                <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-document">`document`</a>,
+                or <a href="#index-aria-img">`img`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -1728,29 +1673,30 @@
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
               <p>
-                <b>Note</b> that some user agents suppress a list's
+                <strong>Note</strong> that some user agents suppress a list's
                 <a>implicit ARIA semantics</a> if list markers are removed.
-                Authors can use `role="list"` to reinstate the role, if necessary.
+                Authors can use `role=list` to reinstate the role, if necessary.
               </p>
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-directory">directory</a>,
-                <a href="#index-aria-group">group</a>, <a href=
-                "#index-aria-listbox">listbox</a>, <a href=
-                "#index-aria-menu">menu</a>, <a href=
-                "#index-aria-menubar">menubar</a>,<a href=
-                "#index-aria-none">none</a></code>, <a href=
-                "#index-aria-presentation"><code>presentation</code></a><code>,</code><a href="#index-aria-radiogroup">radiogroup</a>
-                - <span class="changed-feature">(changed)</span><code>,
-                <a href="#index-aria-tablist">tablist</a>, <a href=
-                "#index-aria-toolbar">toolbar</a></code> or <a href=
-                "#index-aria-tree"><code>tree</code></a>
+                Roles:
+                <a href="#index-aria-directory">`directory`</a>,
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-listbox">`listbox`</a>,
+                <a href="#index-aria-menu">`menu`</a>,
+                <a href="#index-aria-menubar">`menubar`</a>,
+                <a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>,
+                <a href="#index-aria-radiogroup">`radiogroup`</a>,
+                <a href="#index-aria-tablist">`tablist`</a>,
+                <a href="#index-aria-toolbar">`toolbar`</a>
+                or <a href="#index-aria-tree">`tree`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -1766,7 +1712,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `group` role.
               </p>
             </td>
@@ -1785,7 +1731,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `option` role.
               </p>
             </td>
@@ -1802,27 +1748,27 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-p" tabindex="-1">
             <td>
-              <a><code>p</code></a>
+              [^p^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                <strong class="nosupport">Any `role`</strong>
+                <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -1850,19 +1796,19 @@
           </tr>
           <tr id="el-pre" tabindex="-1">
             <td>
-              <a><code>pre</code></a>
+              [^pre^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                <strong class="nosupport">Any `role`</strong>
+                <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -1878,7 +1824,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `progressbar` role.
               </p>
             </td>
@@ -1900,10 +1846,9 @@
             </td>
             <td>
               <code>role=<a href="#index-aria-region">region</a></code> if the
-              <a>section</a> element has an <a data-cite=
+              [^section^] element has an <a data-cite=
               "html-aam-1.0#dfn-accessible-name" data-link-type=
-              "dfn">accessible name</a>. Otherwise, <a>no corresponding
-              role</a>.
+              "dfn">accessible name</a>. Otherwise, <a>no corresponding role</a>.
             </td>
             <td>
               <p>
@@ -1916,8 +1861,7 @@
                 <a href="#index-aria-contentinfo">`contentinfo`</a>,
                 <a href="#index-aria-dialog">`dialog`</a>,
                 <a href="#index-aria-document">`document`</a>,
-                <a href="#index-aria-feed">`feed`</a> - <span class=
-                "new-feature">(new)</span>,
+                <a href="#index-aria-feed">`feed`</a>,
                 <a href="#index-aria-log">`log`</a>,
                 <a href="#index-aria-main">`main`</a>,
                 <a href="#index-aria-marquee">`marquee`</a>,
@@ -1926,77 +1870,68 @@
                 <a href="#index-aria-note">`note`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>,
                 <a href="#index-aria-search">`search`</a>,
-                <a href="#index-aria-status">`status`</a> or
-                <a href="#index-aria-tabpanel">`tabpanel`</a> - <span class=
-                "changed-feature">(changed)</span>
+                <a href="#index-aria-status">`status`</a>
+                or <a href="#index-aria-tabpanel">`tabpanel`</a>
               </p>
               <p>
-                DPub Roles: <a data-cite=
-                "dpub-aria-1.0#doc-abstract"><code>doc-abstract</code></a><code>,
-                <a data-cite=
-                "dpub-aria-1.0#doc-acknowledgments">doc-acknowledgments</a>,
-                <a data-cite="dpub-aria-1.0#doc-afterword">doc-afterword</a>,
-                <a data-cite="dpub-aria-1.0#doc-appendix">doc-appendix</a>,
-                <a data-cite=
-                "dpub-aria-1.0#doc-bibliography">doc-bibliography</a>,
-                <a data-cite="dpub-aria-1.0#doc-chapter">doc-chapter</a>,
-                <a data-cite="dpub-aria-1.0#doc-colophon">doc-colophon</a>,
-                <a data-cite="dpub-aria-1.0#doc-conclusion">doc-conclusion</a>,
-                <a data-cite="dpub-aria-1.0#doc-credit">doc-credit</a>,
-                <a data-cite="dpub-aria-1.0#doc-credits">doc-credits</a>,
-                <a data-cite="dpub-aria-1.0#doc-dedication">doc-dedication</a>,
-                <a data-cite="dpub-aria-1.0#doc-endnotes">doc-endnotes</a>,
-                <a data-cite="dpub-aria-1.0#doc-epilogue">doc-epilogue</a>,
-                <a data-cite="dpub-aria-1.0#doc-errata">doc-errata</a>,
-                <a data-cite="dpub-aria-1.0#doc-example">doc-example</a>,
-                <a data-cite="dpub-aria-1.0#doc-foreword">doc-foreword</a>, doc-glossary,
-                <a data-cite="dpub-aria-1.0#doc-index">doc-index</a>,
-                <a data-cite=
-                "dpub-aria-1.0#doc-introduction">doc-introduction</a>,
-                <a data-cite="dpub-aria-1.0#doc-notice">doc-notice</a>,
-                <a data-cite="dpub-aria-1.0#doc-pagelist">doc-pagelist</a>,
-                <a data-cite="dpub-aria-1.0#doc-part">doc-part</a>,
-                <a data-cite="dpub-aria-1.0#doc-preface">doc-preface</a>,
-                <a data-cite="dpub-aria-1.0#doc-prologue">doc-prologue</a>,
-                <a data-cite="dpub-aria-1.0#doc-pullquote">doc-pullquote</a>,
-                <a data-cite="dpub-aria-1.0#doc-qna">doc-qna</a>, <a data-cite=
-                "dpub-aria-1.0#doc-toc">doc-toc</a></code> - <span class=
-                "new-feature">(new)</span>
+                DPub Roles:
+                <a data-cite="dpub-aria-1.0#doc-abstract">`doc-abstract`</a>,
+                <a data-cite="dpub-aria-1.0#doc-acknowledgments">`doc-acknowledgments`</a>,
+                <a data-cite="dpub-aria-1.0#doc-afterword">`doc-afterword`</a>,
+                <a data-cite="dpub-aria-1.0#doc-appendix">`doc-appendix`</a>,
+                <a data-cite="dpub-aria-1.0#doc-bibliography">`doc-bibliography`</a>,
+                <a data-cite="dpub-aria-1.0#doc-chapter">`doc-chapter`</a>,
+                <a data-cite="dpub-aria-1.0#doc-colophon">`doc-colophon`</a>,
+                <a data-cite="dpub-aria-1.0#doc-conclusion">`doc-conclusion`</a>,
+                <a data-cite="dpub-aria-1.0#doc-credit">`doc-credit`</a>,
+                <a data-cite="dpub-aria-1.0#doc-credits">`doc-credits`</a>,
+                <a data-cite="dpub-aria-1.0#doc-dedication">`doc-dedication`</a>,
+                <a data-cite="dpub-aria-1.0#doc-endnotes">`doc-endnotes`</a>,
+                <a data-cite="dpub-aria-1.0#doc-epilogue">`doc-epilogue`</a>,
+                <a data-cite="dpub-aria-1.0#doc-errata">`doc-errata`</a>,
+                <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>,
+                <a data-cite="dpub-aria-1.0#doc-foreword">`doc-foreword`</a>,
+                <a data-cite="dpub-aria-1.0#doc-glossary">`doc-glossary`</a>,
+                <a data-cite="dpub-aria-1.0#doc-index">`doc-index`</a>,
+                <a data-cite="dpub-aria-1.0#doc-introduction">`doc-introduction`</a>,
+                <a data-cite="dpub-aria-1.0#doc-notice">`doc-notice`</a>,
+                <a data-cite="dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a>,
+                <a data-cite="dpub-aria-1.0#doc-part">`doc-part`</a>,
+                <a data-cite="dpub-aria-1.0#doc-preface">`doc-preface`</a>,
+                <a data-cite="dpub-aria-1.0#doc-prologue">`doc-prologue`</a>,
+                <a data-cite="dpub-aria-1.0#doc-pullquote">`doc-pullquote`</a>,
+                <a data-cite="dpub-aria-1.0#doc-qna">`doc-qna`</a>,
+                <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-select" tabindex="-1">
             <td>
               [^select^] (with NO `multiple` attribute and NO `size`
-              attribute having value greater than `1`) <span class=
-              "changed-feature">(changed)</span>
+              attribute having value greater than `1`)
             </td>
             <td>
-              `role=<a href="#index-aria-combobox">combobox</a>`
+              <code>role=<a href="#index-aria-combobox">combobox</a></code>
             </td>
             <td>
               <p>
-                Role: `<a href="#index-aria-menu">menu</a>`
+                Role: <a href="#index-aria-menu">`menu`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `combobox`
-                or `menu` role. - <span class=
-                "changed-feature">(changed)</span>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `combobox` or `menu` role.
               </p>
             </td>
           </tr>
           <tr id="el-select-multiple-or-size-greater-1" tabindex="-1">
             <td>
-              <code><a data-xref-for="HTMLElement">select</a></code> (with a
-              <code>multiple</code> attribute or a <code>size</code> attribute
-              having value greater than <code>1</code>) <span class=
-              "new-feature">(new)</span>
+              [^select^] (with a `multiple` attribute or a `size` attribute
+              having value greater than `1`)
             </td>
             <td>
               <code>role=<a href="#index-aria-list">listbox</a></code>
@@ -2006,20 +1941,19 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <code>listbox</code>
-                role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `listbox` role.
               </p>
             </td>
           </tr>
           <tr id="el-slot" tabindex="-1">
-            <td><code><a>slot</a></code></td>
+            <td>[^slot^]</td>
             <td><a>No corresponding role</a></td>
             <td><strong class="nosupport">No `role` or `aria-*` attributes</strong></td>
           </tr>
           <tr id="el-source" tabindex="-1">
             <td>
-              <code><a>source</a></code>
+              [^source^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -2030,7 +1964,7 @@
           </tr>
           <tr id="el-span" tabindex="-1">
             <td>
-              <a><code>span</code></a>
+              [^span^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -2040,15 +1974,15 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-strong" tabindex="-1">
             <td>
-              <a><code>strong</code></a>
+              [^strong^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -2058,9 +1992,9 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2077,28 +2011,27 @@
           </tr>
           <tr id="el-svg" tabindex="-1">
             <td>
-              <code><a data-cite=
-              "html/embedded-content-other.html#svg-0">SVG</a></code>
+              <a data-cite="html/embedded-content-other.html#svg-0">`SVG`</a>
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                Role: <code><a href="#index-aria-application">application</a>,
-                <a href="#index-aria-document">document</a>, or <a href=
-                "#index-aria-img">img</a></code>
+                Role: <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-document">`document`</a>, or <a href=
+                "#index-aria-img">`img`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-sub" tabindex="-1">
             <td>
-              <code><a data-cite="html/text-level-semantics.html#the-sub-and-sup-elements">sub</a></code>
+              [^sub^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -2108,9 +2041,9 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2123,21 +2056,20 @@
             </td>
             <td>
               <p>
-                Role: `button` with <code>aria-expanded="true"</code> if the
-                parent (<code>details</code>) element's <a data-cite=
-                "html/interactive-elements.html#attr-details-open"><code>open</code></a>
-                attribute is present, <code>aria-expanded="false"</code>
-                otherwise.
+                Role: `button` with `aria-expanded="true"` if the
+                parent (`details`) element's <a data-cite=
+                "html/interactive-elements.html#attr-details-open">`open`</a>
+                attribute is present, `aria-expanded="false"` otherwise.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `button` role.
               </p>
             </td>
           </tr>
           <tr id="el-sup" tabindex="-1">
             <td>
-              <code><a data-cite="html/text-level-semantics.html#the-sub-and-sup-elements">sup</a></code>
+              [^sup^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -2147,9 +2079,9 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2158,17 +2090,16 @@
               [^table^]
             </td>
             <td>
-              <code>role=<a href="#index-aria-table">table</a></code> -
-              <span class="new-feature">(new)</span>
+              <code>role=<a href="#index-aria-table">table</a></code>
             </td>
             <td>
               <p>
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2184,8 +2115,8 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*`attributes applicable to the allowed roles and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
                 implied role (if any).
               </p>
             </td>
@@ -2213,7 +2144,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
@@ -2230,8 +2161,8 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*`attributes applicable to the allowed roles and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
                 implied role (if any).
               </p>
             </td>
@@ -2248,15 +2179,15 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*`attributes applicable to the allowed roles and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
                 implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-time" tabindex="-1">
             <td>
-              <a><code>time</code></a>
+              [^time^]
             </td>
             <td>
               <a>No corresponding role</a>
@@ -2266,9 +2197,9 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2290,18 +2221,18 @@
             <td>
               <p>
                 <code>role=<a href="#index-aria-cell">cell</a></code> if a
-                descendant of a <code>table</code> element
+                descendant of a `table` element.
               </p>
-              <!--<p><code>role=<a href="#index-aria-cell">gridcell</a></code> if a descendant of a <code>table</code> elementwith <code>role=grid</code> - <span class="new-feature">(new)</span></p>-->
+              <!--<p><code>role=<a href="#index-aria-cell">gridcell</a></code> if a descendant of a <code>table</code> elementwith <code>role=grid</code></p>-->
             </td>
             <td>
               <p>
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2324,9 +2255,9 @@
             <td>
               <a><strong>Any</strong> `role`</a>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2335,18 +2266,17 @@
               [^th^]
             </td>
             <td>
-              <code>role=<a href=
-              "#index-aria-columnheader">columnheader</a></code> or
-              <code><a href="#index-aria-rowheader">rowheader</a></code>
+              <code>role=<a href="#index-aria-columnheader">columnheader</a></code> or
+              <a href="#index-aria-rowheader">`rowheader`</a>
             </td>
             <td>
               <p>
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2355,18 +2285,18 @@
               [^tr^]
             </td>
             <td>
-              <code>role=<a href="#index-aria-row">row</a></code>, may be
-              explicitly declared when child of a <code>table</code> element
-              with <code>role=grid</code>
+              <a href="#index-aria-row">`role=row`</a>, may be
+              explicitly declared when child of a `table` element
+              with `role=grid`
             </td>
             <td>
               <p>
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2390,161 +2320,143 @@
             </td>
             <td>
               <p>
-                <b>Note</b> that some user agents suppress a list's
+                <strong>Note</strong> that some user agents suppress a list's
                 <a>implicit ARIA semantics</a> if list markers are removed.
-                Authors can use `role="list"` to reinstate the role, if necessary.
+                Authors can use `role=list` to reinstate the role, if necessary.
               </p>
               <p>
-                Role: <code><a href="#index-aria-directory">directory</a>,
-                <a href="#index-aria-group">group</a>, <a href=
-                "#index-aria-listbox">listbox</a>, <a href=
-                "#index-aria-menu">menu</a>, <a href=
-                "#index-aria-menubar">menubar</a>, <a href=
-                "#index-aria-radiogroup">radiogroup</a></code> - <span class=
-                "changed-feature">(changed)</span>, <code><a href=
-                "#index-aria-tablist">tablist</a>, <a href=
-                "#index-aria-toolbar">toolbar</a>, <a href=
-                "#index-aria-tree">tree</a>, <a href=
-                "#index-aria-presentation">presentation</a></code> or
-                <code><a href="#index-aria-none">none</a></code>
+                Role:
+                <a href="#index-aria-directory">`directory`</a>,
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-listbox">`listbox`</a>,
+                <a href="#index-aria-menu">`menu`</a>,
+                <a href="#index-aria-menubar">`menubar`</a>,
+                <a href="#index-aria-radiogroup">`radiogroup`</a>,
+                <a href="#index-aria-tablist">`tablist`</a>,
+                <a href="#index-aria-toolbar">`toolbar`</a>,
+                <a href="#index-aria-tree">`tree`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>.
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any)
+                implied role (if any).
               </p>
             </td>
           </tr>
           <tr id="el-video" tabindex="-1">
             <td>
-              <a><code>video</code></a>
+              [^video^]
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                Role: <a href=
-                "#index-aria-application"><code>application</code></a>
+                Role: <a href="#index-aria-application">`application`</a>
               </p>
               <p>
-                <a href="#index-aria-global">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the
-                <code>application</code> role.
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the `application` role.
               </p>
             </td>
           </tr>
           <tr id="att-disabled" tabindex="-1">
             <td>
-              Element with a <a data-cite=
-              "html/form-control-infrastructure.html#attr-fe-disabled">
-              <code>disabled</code></a> attribute
+              Element with a
+              <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`disabled`</a> attribute
             </td>
             <td>
-              <code>aria-disabled="true"</code>
+              `aria-disabled="true"`
             </td>
             <td>
               <p>
-                Use the <code>disabled</code> attribute on any element that is
-                <a data-cite=
-                "html/form-control-infrastructure.html#attr-fe-disabled">
-                allowed the <code>disabled</code> attribute</a> in HTML5.
+                Use the `disabled` attribute on any element that is
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">
+                allowed the `disabled` attribute</a> in HTML.
               </p>
               <p>
-                Only use the <code>aria-disabled</code> attribute for elements
-                that are <strong>not allowed</strong> to have a
-                <code>disabled</code> attribute in HTML5
+                Only use the `aria-disabled` attribute for elements
+                that are <strong>not allowed</strong> to have a `disabled` attribute in HTML.
               </p>
             </td>
           </tr>
           <tr id="att-placeholder" tabindex="-1">
             <td>
-              Element with a <a data-cite=
-              "html/input.html#the-placeholder-attribute"><code>placeholder</code></a>
-              attribute -<span class="new-feature">(new)</span>
+              Element with a <a data-cite="html/input.html#the-placeholder-attribute">`placeholder`</a> attribute
             </td>
             <td>
-              <code>aria-placeholder=""</code>
+              `aria-placeholder=""`
             </td>
             <td>
               <p>
-                Use the <code>placeholder</code> attribute on any element that
-                is allowed the <a data-cite=
-                "html/form-control-infrastructure.html#attr-fe-disabled">
-                <code>placeholder</code></a> attribute in HTML5.
+                Use the `placeholder` attribute on any element that is allowed the
+                <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">`placeholder`</a> attribute in HTML.
               </p>
               <p>
-                Only use the <code>aria-placeholder</code> attribute on
-                elements that are <strong>not allowed</strong> to have a
-                <code>placeholder</code> attribute in HTML5.
+                Only use the `aria-placeholder` attribute on elements that are
+                <strong>not allowed</strong> to have a `placeholder` attribute in HTML.
               </p>
             </td>
           </tr>
           <tr id="att-required" tabindex="-1">
             <td>
-              Element with a <a data-cite=
-              "html/input.html#attr-input-required"><code>required</code></a>
-              attribute
+              Element with a
+              <a data-cite="html/input.html#attr-input-required">`required`</a> attribute
             </td>
             <td>
-              <code>aria-required="true"</code>
+              `aria-required="true"`
             </td>
             <td>
               <p>
-                Use the <code>aria-required</code> attribute on any element
-                that is <a data-cite=
-                "html/input.html#attr-input-required">allowed the
-                <code>required</code> attribute</a> in HTML5. MUST NOT be set
-                to <code>false</code> if the <a data-cite=
-                "html/input.html#attr-input-required"><code>required</code></a>
-                attribute is set. - <span class=
-                "changed-feature">(changed)</span>
+                Use the `aria-required` attribute on any element
+                that is <a data-cite="html/input.html#attr-input-required">allowed the
+                `required` attribute</a> in HTML. MUST NOT be set
+                to `false` if the <a data-cite="html/input.html#attr-input-required">`required`</a>
+                attribute is set.
               </p>
               <p>
                 MAY also be used for elements that have an ARIA role which
-                allows the <code>aria-required</code> attribute.
+                allows the `aria-required` attribute.
               </p>
             </td>
           </tr>
           <tr id="att-readonly" tabindex="-1">
             <td>
-              Element with a <a data-cite=
-              "html/input.html#attr-input-readonly"><code>readonly</code></a>
+              Element with a <a data-cite="html/input.html#attr-input-readonly">`readonly`</a>
               attribute
             </td>
             <td>
-              <code>aria-readonly="true"</code>
+              `aria-readonly="true"`
             </td>
             <td>
               <p>
-                Use the <code>readonly</code> attribute on any element that is
-                <a data-cite="html/input.html#attr-input-readonly">allowed
-                the <code>readonly</code> attribute</a> in HTML5.
+                Use the `readonly` attribute on any element that is
+                <a data-cite="html/input.html#attr-input-readonly">allowed the `readonly` attribute</a> in HTML.
               </p>
               <p>
-                Only use the <code>aria-readonly</code> attribute for elements
-                that are <em>not allowed</em> to have a <code>readonly</code>
-                attribute in HTML5
+                Only use the `aria-readonly` attribute for elements
+                that are <em>not allowed</em> to have a `readonly`
+                attribute in HTML.
               </p>
             </td>
           </tr>
           <tr id="att-hidden" tabindex="-1">
             <td>
-              Element with a <a data-cite=
-              "html/interaction.html#the-hidden-attribute"><code>hidden</code></a>
+              Element with a <a data-cite="html/interaction.html#the-hidden-attribute">`hidden`</a>
               attribute
             </td>
             <td>
-              <code>aria-hidden="true"</code>
+              `aria-hidden="true"`
             </td>
             <td>
               <p>
-                Use the <code>aria-hidden</code> attribute on any HTML element.
+                Use the `aria-hidden` attribute on any HTML element.
               </p>
               <p>
-                <strong>Note:</strong> If an element has a <code>hidden</code>
-                attribute, an <code>aria-hidden</code> attribute is not
-                required.
+                <strong>Note:</strong> If an element has a `hidden`
+                attribute, an `aria-hidden` attribute is not required.
               </p>
             </td>
           </tr>
@@ -2557,48 +2469,45 @@
               constraints</a>
             </td>
             <td>
-              <code>aria-invalid="true"</code>
+              `aria-invalid="true"`
             </td>
             <td>
               <p>
-                The <code>aria-invalid</code> attribute may be used on any
-                HTML5 element that allows <a href="#index-aria-global">global
+                The `aria-invalid` attribute may be used on any
+                HTML element that allows <a href="#index-aria-global">global
                 `aria-*` attributes</a> except for a <a data-cite=
                 "html/forms.html#category-submit">submittable element</a> that
                 does not satisfy its <a data-cite=
                 "html/form-control-infrastructure.html#constraints">validation
-                constraints</a>. - <span class=
-                "changed-feature">(changed)</span>
+                constraints</a>.
               </p>
             </td>
           </tr>
           <tr id="att-contenteditable" tabindex="-1">
             <td>
-              Element with <code><a data-cite=
-              "html/interaction.html#attr-contenteditable">contenteditable</a></code>
+              Element with <a data-cite=
+              "html/interaction.html#attr-contenteditable">`contenteditable`</a>
               attribute
             </td>
             <td>
-              <code>aria-readonly="false"</code>
+              `aria-readonly="false"`
             </td>
             <td>
-              Do not set <code>aria-readonly="true"</code> on an element that
-              has a <code>contenteditable</code> attribute set. - <span class=
-              "new-feature">(new)</span>
+              Do not set `aria-readonly="true"` on an element that
+              has a `contenteditable` attribute set.
             </td>
           </tr>
         </tbody>
       </table>
       <p>
         The elements marked with <dfn>No corresponding role</dfn>, in the
-        second column of the table do not have any <a>implicit ARIA
-        semantics</a>, but they do have meaning and this meaning may be
+        second column of the table do not have any <a>implicit ARIA semantics</a>,
+        but they do have meaning and this meaning may be
         represented in roles, states and properties not provided by ARIA, and
         exposed to users of assistive technology via accessibility APIs. It is
         therefore recommended that web developers add a `role` attribute to a
-        semantically neutral element such as a <code>div</code> or
-        <code>span</code>, rather than overriding the semantics of the listed
-        elements.
+        semantically neutral element such as a `div` or `span`, rather than
+        overriding the semantics of the listed elements.
       </p>
       <div class="note">
         <p>
@@ -2688,8 +2597,7 @@
         reference to the ARIA roles, states and properties permitted for use in
         HTML. All ARIA roles, states and properties are normatively defined in
         the [[[wai-aria-1.1]]] specification. Links to ARIA roles, states and
-        properties in the table reference the normative [[[wai-aria-1.1]]]
-        definitions.
+        properties in the table reference the normative [[[wai-aria-1.1]]] definitions.
       </p>
       <p>
         Column 5 of the <a href="#aria-table">ARIA Roles, States and
@@ -2701,11 +2609,11 @@
         explicit `role` value.
       </p>
       <p>
-        For example, an element with <code>role=button</code> is interactive
+        For example, an element with `role=button` is interactive
         content and therefore cannot contain <a data-cite=
         "html/dom.html#interactive-content-2">interactive content</a>
         descendants. A `button` element has an implicit
-        <code>role=button</code>, so cannot contain any elements with role
+        `role=button`, so cannot contain any elements with role
         values that are in the interactive content category (identified in
         Column 3).
       </p>
@@ -2727,12 +2635,7 @@
 &lt;/div&gt;
 </pre>
       </div>
-      <p class="note">
-        The <span class="new-feature">(new)</span> and <span class=
-        "changed-feature">(changed)</span> markers in the following table
-        indicate new (in ARIA 1.1) or changed (between ARIA 1.0/1.1) ARIA
-        roles, states and properties
-      </p>
+
       <table id="aria-table" class="simple">
         <caption>
           <abbr title="Accessible Rich Internet Applications">ARIA</abbr>
@@ -2753,10 +2656,10 @@
               Supported Properties
             </th>
             <th>
-              Kind of content - <span class="new-feature">(new)</span>
+              Kind of content
             </th>
             <th>
-              Descendant restrictions - <span class="new-feature">(new)</span>
+              Descendant restrictions
             </th>
           </tr>
         </thead>
@@ -2775,92 +2678,67 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-atomic"><code>aria-atomic</code></a>
+                  <a data-cite="wai-aria-1.1#aria-atomic">`aria-atomic`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-busy">aria-busy
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-busy">`aria-busy` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-controls">aria-controls</a></code>
+                  <a data-cite="wai-aria-1.1#aria-controls">`aria-controls`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-current">aria-current
-                  (state)</a></code> - <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-current">`aria-current` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-describedby">aria-describedby</a></code>
+                  <a data-cite="wai-aria-1.1#aria-describedby">`aria-describedby`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-details">aria-details</a></code> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-details">`aria-details`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-disabled">aria-disabled
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-dropeffect">aria-dropeffect</a></code>
+                  <a data-cite="wai-aria-1.1#aria-dropeffect">`aria-dropeffect`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-errormessage">aria-errormessage</a></code>
-                  - <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-flowto">aria-flowto</a></code>
+                  <a data-cite="wai-aria-1.1#aria-flowto">`aria-flowto`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-grabbed">aria-grabbed
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-grabbed">`aria-grabbed` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-haspopup">aria-haspopup</a></code>
+                  <a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-hidden">aria-hidden
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-invalid">aria-invalid
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-keyshortcuts">aria-keyshortcuts</a></code>
-                  - <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-keyshortcuts">`aria-keyshortcuts`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-label">aria-label</a></code>
+                  <a data-cite="wai-aria-1.1#aria-label">`aria-label`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-labelledby">aria-labelledby</a></code>
+                  <a data-cite="wai-aria-1.1#aria-labelledby">`aria-labelledby`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-live">aria-live</a></code>
+                  <a data-cite="wai-aria-1.1#aria-live">`aria-live`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-owns">aria-owns</a></code>
+                  <a data-cite="wai-aria-1.1#aria-owns">`aria-owns`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-relevant">aria-relevant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-relevant">`aria-relevant`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-roledescription">aria-roledescription</a></code>
-                  - <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-roledescription">`aria-roledescription`</a>
                 </li>
               </ul>
             </td>
@@ -2873,21 +2751,18 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-alert">
-              <code><a data-cite="wai-aria-1.1#alert">alert</a></code>
+              <a data-cite="wai-aria-1.1#alert">`alert`</a>
             </td>
             <td>
-              A type of <code>live region</code> with important, and usually
-              time-sensitive, information. See related <code>alertdialog</code>
-              and <code>status</code>.
+              A type of live region with important, and usually
+              time-sensitive, information. See related `alertdialog`
+              and `status`.
             </td>
             <td>
               none
             </td>
             <td>
-              <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
-              </p>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -2898,13 +2773,12 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-alertdialog">
-              <code><a data-cite=
-              "wai-aria-1.1#alertdialog">alertdialog</a></code>
+              <a data-cite="wai-aria-1.1#alertdialog">`alertdialog`</a>
             </td>
             <td>
               A type of dialog that contains an alert message, where initial
               focus goes to an element within the dialog. See related
-              <code>alert</code> and <code>dialog</code>.
+              `alert` and `dialog`.
             </td>
             <td>
               none
@@ -2912,13 +2786,10 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-modal"><code>aria-modal</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-modal">`aria-modal`</a>
                 </li>
               </ul>
             </td>
@@ -2931,23 +2802,25 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-application">
-              <code><a data-cite=
-              "wai-aria-1.1#application">application</a></code>
+              <a data-cite="wai-aria-1.1#application">`application`</a>
             </td>
             <td>
               A structure containing one or more focusable elements requiring
               user input, such as keyboard or gesture events, that do not
               follow a standard interaction pattern supported by a widget role.
-              - <span class="changed-feature">changed)</span>
             </td>
             <td>
               none
             </td>
             <td>
-              <p>
-                <code><a data-cite=
-                "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded</a></code>
-              </p>
+              <ul>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
+                </li>
+              </ul>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -2958,7 +2831,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-article">
-              <code><a data-cite="wai-aria-1.1#article">article</a></code>
+              <a data-cite="wai-aria-1.1#article">`article`</a>
             </td>
             <td>
               A section of a page that consists of a composition that forms an
@@ -2969,8 +2842,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -2982,7 +2854,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-banner">
-              <code><a data-cite="wai-aria-1.1#banner">banner</a></code>
+              <a data-cite="wai-aria-1.1#banner">`banner`</a>
             </td>
             <td>
               A region that contains mostly site-oriented content, rather than
@@ -2992,28 +2864,25 @@
               none
             </td>
             <td>
-              <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
-              </p>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
               Document region
             </td>
             <td>
               no <a>main</a> element descendants, or <a>header</a>,
-              <a>footer</a> elements that are not descendants of <a data-cite=
-              "html/dom.html#sectioning-content-2">sectioning content</a> which
-              is a descendant of the <a>header</a>.
+              <a>footer</a> elements that are not descendants of
+              <a data-cite="html/dom.html#sectioning-content-2">sectioning content</a>
+              which is a descendant of the <a>header</a>.
             </td>
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-button">
-              <code><a data-cite="wai-aria-1.1#button">button</a></code>
+              <a data-cite="wai-aria-1.1#button">`button`</a>
             </td>
             <td>
               An input that allows for user-triggered actions when clicked or
-              pressed. See related <code>link</code>.
+              pressed. See related `link`.
             </td>
             <td>
               none
@@ -3021,67 +2890,47 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-pressed">aria-pressed
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-pressed">`aria-pressed` (state)</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
-            </td>
-            <td>
-              <a data-cite="html/dom.html#flow-content">Flow
-              content</a>,
-              but there must be no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
-              descendant.
-            </td>
-          </tr>
-          <tr>
-            <td tabindex="-1" id="index-aria-checkbox">
-              <code><a data-cite="wai-aria-1.1#checkbox">checkbox</a></code>
-            </td>
-            <td>
-              A checkable input that has three possible values: true, false, or
-              mixed.
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-checked"><code>aria-checked
-                  (state)</code></a>
-                </li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
-                  <span class="new-feature">(new)</span>
-                </li>
-              </ul>
-            </td>
-            <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>,
               but there must be no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
-              descendant.
+              "html/dom.html#interactive-content-2">interactive content</a> descendant.
+            </td>
+          </tr>
+          <tr>
+            <td tabindex="-1" id="index-aria-checkbox">
+              <a data-cite="wai-aria-1.1#checkbox">`checkbox`</a>
+            </td>
+            <td>
+              A checkable input that has three possible values: true, false, or mixed.
+            </td>
+            <td>
+              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` (state)</a>
+            </td>
+            <td>
+              <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+            </td>
+            <td>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+            </td>
+            <td>
+              <a data-cite="html/dom.html#flow-content">Flow content</a>,
+              but there must be no <a data-cite=
+              "html/dom.html#interactive-content-2">interactive content</a> descendant.
             </td>
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-cell">
-              <a data-cite="wai-aria-1.1#cell"><code>cell</code></a> -
-              <span class="new-feature">(new)</span>
+              <a data-cite="wai-aria-1.1#cell">`cell`</a>
             </td>
             <td>
               A cell in a tabular container.
@@ -3092,24 +2941,16 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colspan"><code>aria-colspan</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colindex"><code>aria-colindex</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-rowindex"><code>aria-rowindex</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-rowspan"><code>aria-rowspan</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a>
                 </li>
               </ul>
             </td>
@@ -3122,8 +2963,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-columnheader">
-              <code><a data-cite=
-              "wai-aria-1.1#columnheader">columnheader</a></code>
+              <a data-cite="wai-aria-1.1#columnheader">`columnheader`</a>
             </td>
             <td>
               A cell containing header information for a column.
@@ -3134,44 +2974,31 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-sort">aria-sort</a></code>
+                  <a data-cite="wai-aria-1.1#aria-sort">`aria-sort`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-selected">aria-selected
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colspan"><code>aria-colspan</code></a>
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colindex"><code>aria-colindex</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-rowindex"><code>aria-rowindex</code></a>
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-rowspan"><code>aria-rowspan</code></a>
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a>
                 </li>
               </ul>
             </td>
@@ -3184,51 +3011,41 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-combobox">
-              <code><a data-cite="wai-aria-1.1#combobox">combobox</a></code>
+              <a data-cite="wai-aria-1.1#combobox">`combobox`</a>
             </td>
             <td>
               A presentation of a select; usually similar to a textbox where
               users can type ahead to select an option, or type to enter
-              arbitrary text as a new item in the list. See related
-              <code>listbox</code>.
+              arbitrary text as a new item in the list. See related `listbox`.
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-controls"><code>aria-controls</code></a> -
-                  <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-controls">`aria-controls`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded"><code>aria-expanded
-                  (state)</code></a>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-autocomplete">aria-autocomplete</a></code>
+                  <a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  - <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -3236,8 +3053,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-complementary">
-              <code><a data-cite=
-              "wai-aria-1.1#complementary">complementary</a></code>
+              <a data-cite="wai-aria-1.1#complementary">`complementary`</a>
             </td>
             <td>
               A supporting section of the document, designed to be
@@ -3249,10 +3065,7 @@
               none
             </td>
             <td>
-              <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
-              </p>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -3264,8 +3077,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-contentinfo">
-              <code><a data-cite=
-              "wai-aria-1.1#contentinfo">contentinfo</a></code>
+              <a data-cite="wai-aria-1.1#contentinfo">`contentinfo`</a>
             </td>
             <td>
               A large perceivable region that contains information about the
@@ -3275,10 +3087,7 @@
               none
             </td>
             <td>
-              <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
-              </p>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -3293,8 +3102,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-definition">
-              <code><a data-cite=
-              "wai-aria-1.1#definition">definition</a></code>
+              <a data-cite="wai-aria-1.1#definition">`definition`</a>
             </td>
             <td>
               A definition of a term or concept.
@@ -3304,28 +3112,24 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing
-              content</a>
+              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing
-              content</a>
+              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
             </td>
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-dialog">
-              <code><a data-cite="wai-aria-1.1#dialog">dialog</a></code>
+              <a data-cite="wai-aria-1.1#dialog">`dialog`</a>
             </td>
             <td>
               A dialog is an application window that is designed to interrupt
               the current processing of an application in order to prompt the
-              user to enter information or require a response. See related
-              <code>alertdialog</code>.
+              user to enter information or require a response. See related `alertdialog`.
             </td>
             <td>
               none
@@ -3333,19 +3137,15 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-modal"><code>aria-modal</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-modal">`aria-modal`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow
-              content</a>
+              <a data-cite="html/dom.html#flow-content">Flow content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -3353,7 +3153,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-directory">
-              <code><a data-cite="wai-aria-1.1#directory">directory</a></code>
+              <a data-cite="wai-aria-1.1#directory">`directory`</a>
             </td>
             <td>
               A list of references to members of a group, such as a static
@@ -3363,10 +3163,7 @@
               none
             </td>
             <td>
-              <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
-              </p>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -3377,7 +3174,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-document">
-              <code><a data-cite="wai-aria-1.1#document">document</a></code>
+             <a data-cite="wai-aria-1.1#document">`document`</a>
             </td>
             <td>
               A region containing related information that is declared as
@@ -3388,8 +3185,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3401,8 +3197,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-feed">
-              <code><a data-cite="wai-aria-1.1#feed">feed</a></code> -
-              <span class="new-feature">(new)</span>
+              <a data-cite="wai-aria-1.1#feed">`feed`</a>
             </td>
             <td>
               A scrollable list of articles where scrolling may cause articles
@@ -3412,8 +3207,7 @@
               none
             </td>
             <td>
-              <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-              (state)</a></code>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -3424,8 +3218,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-figure">
-              <a data-cite="wai-aria-1.1#figure"><code>figure</code></a> -
-              <span class="new-feature">(new)</span>
+              <a data-cite="wai-aria-1.1#figure">`figure`</a>
             </td>
             <td>
               A perceivable section of content that typically contains a
@@ -3435,8 +3228,7 @@
               none
             </td>
             <td>
-              <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-              (state)</a></code>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -3447,20 +3239,18 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-form">
-              <code><a data-cite="wai-aria-1.1#form">form</a></code>
+              <a data-cite="wai-aria-1.1#form">`form`</a>
             </td>
             <td>
               A landmark region that contains a collection of items and objects
-              that, as a whole, combine to create a form. See related
-              <code>search</code>.
+              that, as a whole, combine to create a form. See related `search`.
             </td>
             <td>
               none
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3472,7 +3262,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-grid">
-              <code><a data-cite="wai-aria-1.1#grid">grid</a></code>
+              <a data-cite="wai-aria-1.1#grid">`grid`</a>
             </td>
             <td>
               A grid is an interactive control which contains cells of tabular
@@ -3484,34 +3274,25 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-level">aria-level</a></code>
+                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-multiselectable">aria-multiselectable</a></code>
+                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a title="aria-colcount" data-cite=
-                  "wai-aria-1.1#aria-colcount"><code>aria-colcount</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a>
                 </li>
                 <li>
-                  <a title="aria-rowcount" data-cite=
-                  "wai-aria-1.1#aria-rowcount"><code>aria-rowcount</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a>
                 </li>
               </ul>
             </td>
@@ -3520,8 +3301,7 @@
                 <a data-cite="html/dom.html#flow-content">Flow content</a>
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
@@ -3530,10 +3310,10 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-gridcell">
-              <code><a data-cite="wai-aria-1.1#gridcell">gridcell</a></code>
+              <a data-cite="wai-aria-1.1#gridcell">`gridcell`</a>
             </td>
             <td>
-              A cell in a grid or treegrid.
+              A cell in a `grid` or `treegrid`.
             </td>
             <td>
               none
@@ -3541,40 +3321,28 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-selected">aria-selected
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colindex"><code>aria-colindex</code></a>
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colspan"><code>aria-colspan</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-rowindex"><code>aria-rowindex</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-rowspan"><code>aria-rowspan</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a>
                 </li>
               </ul>
             </td>
@@ -3583,8 +3351,7 @@
                 <a data-cite="html/dom.html#flow-content">Flow content</a>
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
@@ -3593,12 +3360,11 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-group">
-              <code><a data-cite="wai-aria-1.1#group">group</a></code>
+              <a data-cite="wai-aria-1.1#group">`group`</a>
             </td>
             <td>
               A set of user interface objects which are not intended to be
-              included in a page summary or table of contents by assistive
-              technologies.
+              included in a page summary or table of contents by assistive technologies.
             </td>
             <td>
               none
@@ -3606,12 +3372,10 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
               </ul>
             </td>
@@ -3624,7 +3388,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-heading">
-              <code><a data-cite="wai-aria-1.1#heading">heading</a></code>
+              <a data-cite="wai-aria-1.1#heading">`heading`</a>
             </td>
             <td>
               A heading for a section of the page.
@@ -3635,12 +3399,10 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-level">aria-level</a></code>
+                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
               </ul>
             </td>
@@ -3649,17 +3411,14 @@
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
-              with no <a data-cite="html/dom.html#heading-content">Heading
-              content</a>, <a data-cite=
-              "html/dom.html#sectioning-content-2">Sectioning
-              content</a>,
-              <a data-cite="html/sections.html#sectioning-root">Sectioning
-              roots</a>
+              with no <a data-cite="html/dom.html#heading-content">Heading content</a>,
+              <a data-cite="html/dom.html#sectioning-content-2">Sectioning content</a>,
+              <a data-cite="html/sections.html#sectioning-root">Sectioning roots</a>.
             </td>
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-img">
-              <code><a data-cite="wai-aria-1.1#img">img</a></code>
+              <a data-cite="wai-aria-1.1#img">`img`</a>
             </td>
             <td>
               A container for a collection of elements that form an image.
@@ -3669,8 +3428,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3682,7 +3440,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-link">
-              <code><a data-cite="wai-aria-1.1#link">link</a></code>
+              <a data-cite="wai-aria-1.1#link">`link`</a>
             </td>
             <td>
               An interactive reference to an internal or external resource
@@ -3694,8 +3452,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3710,19 +3467,17 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-list">
-              <code><a data-cite="wai-aria-1.1#list">list</a></code>
+              <a data-cite="wai-aria-1.1#list">`list`</a>
             </td>
             <td>
-              A group of non-interactive list items. See related
-              <code>listbox</code>.
+              A group of non-interactive list items. See related `listbox`.
             </td>
             <td>
               none
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3734,12 +3489,11 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-listbox">
-              <code><a data-cite="wai-aria-1.1#listbox">listbox</a></code>
+              <a data-cite="wai-aria-1.1#listbox">`listbox`</a>
             </td>
             <td>
               A widget that allows the user to select one or more items from a
-              list of choices. See related <code>combobox</code> and
-              <code>list</code>.
+              list of choices. See related `combobox` and `list`.
             </td>
             <td>
               none
@@ -3747,25 +3501,19 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-multiselectable">aria-multiselectable</a></code>
+                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -3774,8 +3522,7 @@
                 <a data-cite="html/dom.html#flow-content">Flow content</a>
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
@@ -3784,10 +3531,10 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-listitem">
-              <code><a data-cite="wai-aria-1.1#listitem">listitem</a></code>
+              <a data-cite="wai-aria-1.1#listitem">`listitem`</a>
             </td>
             <td>
-              A single item in a <code>list</code> or <code>directory</code>.
+              A single item in a `list` or `directory`.
             </td>
             <td>
               none
@@ -3795,20 +3542,16 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-level">aria-level</a></code>
+                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-posinset">aria-posinset</a></code>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-setsize">aria-setsize</a></code>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
               </ul>
             </td>
@@ -3821,20 +3564,18 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-log">
-              <code><a data-cite="wai-aria-1.1#log">log</a></code>
+              <a data-cite="wai-aria-1.1#log">`log`</a>
             </td>
             <td>
-              A type of live region where new information is added in
-              meaningful order and old information may disappear. See related
-              <code>marquee</code>.
+              A type of live region where new information is added in meaningful
+              order and old information may disappear. See related `marquee`.
             </td>
             <td>
               none
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3856,8 +3597,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3870,19 +3610,18 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-marquee">
-              <code><a data-cite="wai-aria-1.1#marquee">marquee</a></code>
+              <a data-cite="wai-aria-1.1#marquee">`marquee`</a>
             </td>
             <td>
               A type of live region where non-essential information changes
-              frequently. See related <code>log</code>.
+              frequently. See related `log`.
             </td>
             <td>
               none
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3894,7 +3633,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-math">
-              <code><a data-cite="wai-aria-1.1#math">math</a></code>
+              <a data-cite="wai-aria-1.1#math">`math`</a>
             </td>
             <td>
               Content that represents a mathematical expression.
@@ -3904,8 +3643,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -3917,7 +3655,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-menu">
-              <code><a data-cite="wai-aria-1.1#menu">menu</a></code>
+              <a data-cite="wai-aria-1.1#menu">`menu`</a>
             </td>
             <td>
               A type of widget that offers a list of choices to the user.
@@ -3928,17 +3666,13 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  - <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -3947,8 +3681,7 @@
                 <a data-cite="html/dom.html#flow-content">Flow content</a>
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
@@ -3957,7 +3690,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-menubar">
-              <code><a data-cite="wai-aria-1.1#menubar">menubar</a></code>
+              <a data-cite="wai-aria-1.1#menubar">`menubar`</a>
             </td>
             <td>
               A presentation of menu that usually remains visible and is
@@ -3969,17 +3702,13 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  - <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -3988,8 +3717,7 @@
                 <a data-cite="html/dom.html#flow-content">Flow content</a>
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
@@ -3998,11 +3726,10 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-menuitem">
-              <code><a data-cite="wai-aria-1.1#menuitem">menuitem</a></code>
+              <a data-cite="wai-aria-1.1#menuitem">`menuitem`</a>
             </td>
             <td>
-              An option in a group of choices contained by a <code>menu</code>
-              or <code>menubar</code>.
+              An option in a group of choices contained by a `menu` or `menubar`.
             </td>
             <td>
               none
@@ -4010,18 +3737,15 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-posinset"><code>aria-posinset</code></a>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-setsize"><code>aria-setsize</code></a>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
@@ -4032,36 +3756,27 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-menuitemcheckbox">
-              <code><a data-cite=
-              "wai-aria-1.1#menuitemcheckbox">menuitemcheckbox</a></code>
+              <a data-cite="wai-aria-1.1#menuitemcheckbox">`menuitemcheckbox`</a>
             </td>
             <td>
               A checkable menuitem that has three possible values: true, false,
               or mixed.
             </td>
             <td>
-              <ul>
-                <li>
-                  <code><a data-cite="wai-aria-1.1#aria-checked">aria-checked
-                  (state)</a></code>
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` (state)</a>
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-posinset">aria-posinset</a></code>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-setsize"><code>aria-setsize</code></a>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
@@ -4072,36 +3787,27 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-menuitemradio">
-              <code><a data-cite=
-              "wai-aria-1.1#menuitemradio">menuitemradio</a></code>
+              <a data-cite="wai-aria-1.1#menuitemradio">`menuitemradio`</a>
             </td>
             <td>
-              A checkable menuitem in a group of <code>menuitemradio</code>
+              A checkable `menuitem` in a group of `menuitemradio`
               roles, only one of which can be checked at a time.
             </td>
             <td>
-              <ul>
-                <li>
-                  <code><a data-cite="wai-aria-1.1#aria-checked">aria-checked
-                  (state)</a></code>
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` (state)</a>
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-posinset">aria-posinset</a></code>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-setsize">aria-setsize</a></code>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
@@ -4112,8 +3818,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-navigation">
-              <code><a data-cite=
-              "wai-aria-1.1#navigation">navigation</a></code>
+              <a data-cite="wai-aria-1.1#navigation">`navigation`</a>
             </td>
             <td>
               A collection of navigational elements (usually links) for
@@ -4124,8 +3829,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -4138,20 +3842,18 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-none">
-              <code><a data-cite="wai-aria-1.1#none">none</a></code> -
-              <span class="new-feature">(new)</span>
+              <a data-cite="wai-aria-1.1#none">`none`</a>
             </td>
             <td>
               An element whose implicit native role semantics will not be
-              mapped to the accessibility <abbr title=
-              "Application Programing Interfaces">API</abbr>. See synonym
-              <a href="#index-aria-presentation">presentation</a>
+              mapped to the accessibility
+              <abbr title= "Application Programing Interfaces">API</abbr>.
+              See synonym <a href="#index-aria-presentation">`presentation`</a>
             </td>
             <td>
               none
             </td>
             <td>&nbsp;
-
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -4162,7 +3864,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-note">
-              <code><a data-cite="wai-aria-1.1#note">note</a></code>
+              <a data-cite="wai-aria-1.1#note">`note`</a>
             </td>
             <td>
               A section whose content is parenthetic or ancillary to the main
@@ -4173,8 +3875,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -4186,7 +3887,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-option">
-              <code><a data-cite="wai-aria-1.1#option">option</a></code>
+              <a data-cite="wai-aria-1.1#option">`option`</a>
             </td>
             <td>
               A selectable item in a select list.
@@ -4197,26 +3898,21 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-checked">aria-checked
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-posinset">aria-posinset</a></code>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-selected">aria-selected
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-setsize">aria-setsize</a></code>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
@@ -4227,8 +3923,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-presentation">
-              <code><a data-cite=
-              "wai-aria-1.1#presentation">presentation</a></code>
+              <a data-cite="wai-aria-1.1#presentation">`presentation`</a>
             </td>
             <td>
               An element whose implicit native role semantics will not be
@@ -4247,8 +3942,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-progressbar">
-              <code><a data-cite=
-              "wai-aria-1.1#progressbar">progressbar</a></code>
+              <a data-cite="wai-aria-1.1#progressbar">`progressbar`</a>
             </td>
             <td>
               An element that displays the progress status for tasks that take
@@ -4260,20 +3954,16 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuemax">aria-valuemax</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuemin">aria-valuemin</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuenow">aria-valuenow</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuetext">aria-valuetext</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a>
                 </li>
               </ul>
             </td>
@@ -4286,39 +3976,30 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-radio">
-              <code><a data-cite="wai-aria-1.1#radio">radio</a></code>
+              <a data-cite="wai-aria-1.1#radio">`radio`</a>
             </td>
             <td>
               A checkable input in a group of radio roles, only one of which
               can be checked at a time.
             </td>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-checked"><code>aria-checked
-                  (state)</code></a>
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` (state)</a>
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-posinset">aria-posinset</a></code>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-selected">aria-selected
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-setsize">aria-setsize</a></code>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
@@ -4329,8 +4010,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-radiogroup">
-              <code><a data-cite=
-              "wai-aria-1.1#radiogroup">radiogroup</a></code>
+              <a data-cite="wai-aria-1.1#radiogroup">`radiogroup`</a>
             </td>
             <td>
               A group of radio buttons.
@@ -4341,21 +4021,16 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  - <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -4368,7 +4043,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-region">
-              <code><a data-cite="wai-aria-1.1#region">region</a></code>
+              <a data-cite="wai-aria-1.1#region">`region`</a>
             </td>
             <td>
               A large perceivable section of a web page or document, that the
@@ -4381,8 +4056,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -4394,7 +4068,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-row">
-              <code><a data-cite="wai-aria-1.1#row">row</a></code>
+              <a data-cite="wai-aria-1.1#row">`row`</a>
             </td>
             <td>
               <p>
@@ -4407,30 +4081,22 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colindex"><code>aria-colindex</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
                 </li>
                 <li>
-                  <code><a title="aria-rowindex" data-cite=
-                  "wai-aria-1.1#aria-rowindex">aria-rowindex</a></code> -
-                  <span class="new-feature">(new)</span>
+                  <a title="aria-rowindex" data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-level">aria-level</a></code>
+                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-selected">aria-selected
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
               </ul>
             </td>
@@ -4443,7 +4109,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-rowgroup">
-              <code><a data-cite="wai-aria-1.1#rowgroup">rowgroup</a></code>
+              <a data-cite="wai-aria-1.1#rowgroup">`rowgroup`</a>
             </td>
             <td>
               A group containing one or more row elements in a grid.
@@ -4463,7 +4129,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-rowheader">
-              <code><a data-cite="wai-aria-1.1#rowheader">rowheader</a></code>
+              <a data-cite="wai-aria-1.1#rowheader">`rowheader`</a>
             </td>
             <td>
               A cell containing header information for a row in a grid.
@@ -4474,40 +4140,28 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-selected">aria-selected
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colspan"><code>aria-colspan</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-colindex"><code>aria-colindex</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-rowindex"><code>aria-rowindex</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-rowspan"><code>aria-rowspan</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a>
                 </li>
               </ul>
             </td>
@@ -4520,7 +4174,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-scrollbar">
-              <code><a data-cite="wai-aria-1.1#scrollbar">scrollbar</a></code>
+              <a data-cite="wai-aria-1.1#scrollbar">`scrollbar`</a>
             </td>
             <td>
               A graphical object that controls the scrolling of content within
@@ -4530,36 +4184,29 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-controls">aria-controls</a></code>
+                  <a data-cite="wai-aria-1.1#aria-controls">`aria-controls`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-orientation">aria-orientation</a></code>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuemax">aria-valuemax</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuemin">aria-valuemin</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuenow">aria-valuenow</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a>
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuetext">aria-valuetext</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a>
                 </li>
               </ul>
             </td>
@@ -4568,8 +4215,7 @@
                 <a data-cite="html/dom.html#flow-content">Flow content</a>
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
@@ -4578,23 +4224,18 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-search">
-              <code><a data-cite="wai-aria-1.1#search">search</a></code>
+              <a data-cite="wai-aria-1.1#search">`search`</a>
             </td>
             <td>
               A landmark region that contains a collection of items and objects
               that, as a whole, combine to create a search facility. See
-              related <code>form</code> .
+              related `form`.
             </td>
             <td>
               none
             </td>
             <td>
-              <ul>
-                <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
               <p>
@@ -4607,8 +4248,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-searchbox">
-              <code><a data-cite="wai-aria-1.1#searchbox">searchbox</a></code>
-              - <span class="new-feature">(new)</span>
+              <a data-cite="wai-aria-1.1#searchbox">`searchbox`</a>
             </td>
             <td>
               A type of textbox intended for specifying search criteria.
@@ -4619,34 +4259,27 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-autocomplete">aria-autocomplete</a></code>
+                  <a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-multiline">aria-multiline</a></code>
+                  <a data-cite="wai-aria-1.1#aria-multiline">`aria-multiline`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-placeholder">aria-placeholder</a></code>
+                  <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
@@ -4657,7 +4290,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-separator">
-              <code><a data-cite="wai-aria-1.1#separator">separator</a></code>
+              <a data-cite="wai-aria-1.1#separator">`separator`</a>
             </td>
             <td>
               A divider that separates and distinguishes sections of content or
@@ -4666,46 +4299,33 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-valuemax"><code>aria-valuemax</code></a>
-                  (if focusable) - <span class=
-                  "changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a> (if
+                  focusable)
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-valuemin"><code>aria-valuemin</code></a>
-                  (if focusable) - <span class=
-                  "changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a> (if
+                  focusable)
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-valuenow"><code>aria-valuenow</code></a>
-                  (if focusable) - <span class=
-                  "changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a> (if
+                  focusable)
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuetext">aria-valuetext</a></code> (if
+                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a> (if
                   focusable)
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <p>&nbsp;
-
-              </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a> (if focusable)
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a> (if focusable)
               </p>
             </td>
             <td>
@@ -4714,43 +4334,36 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-slider">
-              <code><a data-cite="wai-aria-1.1#slider">slider</a></code>
+              <a data-cite="wai-aria-1.1#slider">`slider`</a>
             </td>
             <td>
-              A user input where the user selects a value from within a given
-              range.
+              A user input where the user selects a value from within a given range.
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuemax">aria-valuemax</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuemin">aria-valuemin</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuenow">aria-valuenow</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a>
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-orientation">aria-orientation</a></code>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuetext">aria-valuetext</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -4758,42 +4371,34 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-spinbutton">
-              <code><a data-cite=
-              "wai-aria-1.1#spinbutton">spinbutton</a></code>
+              <a data-cite="wai-aria-1.1#spinbutton">`spinbutton`</a>
             </td>
             <td>
-              A form of range that expects the user to select from among
-              discrete choices.
+              A form of range that expects the user to select from among discrete choices.
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuemax">aria-valuemax</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuemin">aria-valuemin</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuenow">aria-valuenow</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a>
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-valuetext">aria-valuetext</a></code>
+                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a>
                 </li>
               </ul>
             </td>
@@ -4802,8 +4407,7 @@
                 <a data-cite="html/dom.html#flow-content">Flow content</a>
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
@@ -4812,21 +4416,19 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-status">
-              <code><a data-cite="wai-aria-1.1#status">status</a></code>
+              <a data-cite="wai-aria-1.1#status">`status`</a>
             </td>
             <td>
               A container whose content is advisory information for the user
               but is not important enough to justify an alert, often but not
-              necessarily presented as a status bar. See related
-              <code>alert</code>.
+              necessarily presented as a status bar. See related `alert`.
             </td>
             <td>
               none
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -4840,41 +4442,32 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-switch">
-              <a data-cite="wai-aria-1.1#switch"><code>switch</code></a> -
-              <span class="new-feature">(new)</span>
+              <a data-cite="wai-aria-1.1#switch">`switch`</a>
             </td>
             <td>
               A type of checkbox that represents on/off values, as opposed to
               checked/unchecked values.
             </td>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-checked"><code>aria-checked
-                  (state)</code></a>
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` (state)</a>
             </td>
             <td>
-              <code><a data-cite=
-              "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+              <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
+              with no <a data-cite="html/dom.html#interactive-content-2">interactive content</a>
               descendants.
             </td>
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-tab">
-              <code><a data-cite="wai-aria-1.1#tab">tab</a></code>
+              <a data-cite="wai-aria-1.1#tab">`tab`</a>
             </td>
             <td>
               A grouping label providing a mechanism for selecting the tab
@@ -4886,27 +4479,22 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-selected">aria-selected
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-posinset"><code>aria-posinset</code></a>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-setsize"><code>aria-setsize</code></a>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
               </ul>
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive
-                content</a>
+                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
               </p>
             </td>
             <td>
@@ -4915,13 +4503,11 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-table">
-              <a data-cite="wai-aria-1.1#table"><code>table</code></a> -
-              <span class="new-feature">(new)</span>
+              <a data-cite="wai-aria-1.1#table">`table`</a>
             </td>
             <td>
               A section containing data arranged in rows and columns. The table
-              role is intended for tabular containers which are not
-              interactive.
+              role is intended for tabular containers which are not interactive.
             </td>
             <td>
               none
@@ -4929,14 +4515,10 @@
             <td>
               <ul>
                 <li>
-                  <a title="aria-colcount" data-cite=
-                  "wai-aria-1.1#aria-colcount"><code>aria-colcount</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a title="aria-colcount" data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a>
                 </li>
                 <li>
-                  <a title="aria-rowcount" data-cite=
-                  "wai-aria-1.1#aria-rowcount"><code>aria-rowcount</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a title="aria-rowcount" data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a>
                 </li>
               </ul>
             </td>
@@ -4949,11 +4531,10 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-tablist">
-              <code><a data-cite="wai-aria-1.1#tablist">tablist</a></code>
+              <a data-cite="wai-aria-1.1#tablist">`tablist`</a>
             </td>
             <td>
-              A list of tab elements, which are references to tabpanel
-              elements.
+              A list of `tab` elements, which are references to `tabpanel` elements.
             </td>
             <td>
               none
@@ -4961,21 +4542,16 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-level">aria-level</a></code>
+                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  - <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-multiselectable"><code>aria-multiselectable</code></a>
+                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
                 </li>
               </ul>
             </td>
@@ -4988,20 +4564,18 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-tabpanel">
-              <code><a data-cite="wai-aria-1.1#tabpanel">tabpanel</a></code>
+              <a data-cite="wai-aria-1.1#tabpanel">`tabpanel`</a>
             </td>
             <td>
-              A container for the resources associated with a <code>tab</code>,
-              where each <code>tab</code> is contained in a
-              <code>tablist</code>.
+              A container for the resources associated with a `tab`,
+              where each `tab` is contained in a `tablist`.
             </td>
             <td>
               none
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -5013,32 +4587,28 @@
           </tr>
           <tr>
             <td id="index-aria-term" tabindex="-1">
-              <a data-cite="wai-aria-1.1#term"><code>term</code></a> -
-              <span class="new-feature">(new)</span>
+              <a data-cite="wai-aria-1.1#term">`term`</a>
             </td>
             <td>
               A word or phrase with a corresponding definition. See related
-              <a href="#index-aria-definition">definition</a>.
+              <a href="#index-aria-definition">`definition`</a>.
             </td>
             <td>
               none
             </td>
             <td>
-              <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-              (state)</a></code>
+              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing
-              content</a>
+              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing
-              content</a>
+              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
             </td>
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-textbox">
-              <code><a data-cite="wai-aria-1.1#textbox">textbox</a></code>
+              <a data-cite="wai-aria-1.1#textbox">`textbox`</a>
             </td>
             <td>
               Input that allows free-form text as its value.
@@ -5049,35 +4619,27 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-autocomplete">aria-autocomplete</a></code>
+                  <a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-multiline">aria-multiline</a></code>
+                  <a data-cite="wai-aria-1.1#aria-multiline">`aria-multiline`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-placeholder">aria-placeholder</a></code> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
@@ -5088,7 +4650,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-timer">
-              <code><a data-cite="wai-aria-1.1#timer">timer</a></code>
+              <a data-cite="wai-aria-1.1#timer">`timer`</a>
             </td>
             <td>
               A type of live region containing a numerical counter which
@@ -5100,8 +4662,7 @@
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -5113,7 +4674,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-toolbar">
-              <code><a data-cite="wai-aria-1.1#toolbar">toolbar</a></code>
+              <a data-cite="wai-aria-1.1#toolbar">`toolbar`</a>
             </td>
             <td>
               A collection of commonly used function buttons represented in
@@ -5125,17 +4686,13 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  - <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -5148,18 +4705,17 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-tooltip">
-              <code><a data-cite="wai-aria-1.1#tooltip">tooltip</a></code>
+              <a data-cite="wai-aria-1.1#tooltip">`tooltip`</a>
             </td>
             <td>
-              A contextual popup that displays a description for an element.
+              A contextual pop-up that displays a description for an element.
             </td>
             <td>
               none
             </td>
             <td>
               <p>
-                <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                (state)</a></code>
+                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
               </p>
             </td>
             <td>
@@ -5183,25 +4739,19 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-multiselectable">aria-multiselectable</a></code>
+                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  - <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -5214,7 +4764,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-treegrid">
-              <code><a data-cite="wai-aria-1.1#treegrid">treegrid</a></code>
+              <a data-cite="wai-aria-1.1#treegrid">`treegrid`</a>
             </td>
             <td>
               A grid whose rows can be expanded and collapsed in the same
@@ -5226,43 +4776,31 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-level">aria-level</a></code>
+                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-multiselectable">aria-multiselectable</a></code>
+                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-readonly">aria-readonly</a></code>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-activedescendant">aria-activedescendant</a></code>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-required">aria-required</a></code>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <a data-cite=
-                  "wai-aria-1.1#aria-orientation"><code>aria-orientation</code></a>
-                  - <span class="changed-feature">(changed)</span>
+                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
                 </li>
                 <li>
-                  <a title="aria-colcount" data-cite=
-                  "wai-aria-1.1#aria-colcount"><code>aria-colcount</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a>
                 </li>
                 <li>
-                  <a title="aria-rowcount" data-cite=
-                  "wai-aria-1.1#aria-rowcount"><code>aria-rowcount</code></a> -
-                  <span class="new-feature">(new)</span>
+                  <a data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a>
                 </li>
               </ul>
             </td>
@@ -5275,7 +4813,7 @@
           </tr>
           <tr>
             <td tabindex="-1" id="index-aria-treeitem">
-              <code><a data-cite="wai-aria-1.1#treeitem">treeitem</a></code>
+              <a data-cite="wai-aria-1.1#treeitem">`treeitem`</a>
             </td>
             <td>
               An option item of a tree. This is an element within a tree that
@@ -5288,34 +4826,27 @@
             <td>
               <ul>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-level">aria-level</a></code>
+                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-posinset">aria-posinset</a></code>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <code><a data-cite=
-                  "wai-aria-1.1#aria-setsize">aria-setsize</a></code>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-expanded">aria-expanded
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-checked">aria-checked
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` (state)</a>
                 </li>
                 <li>
-                  <code><a data-cite="wai-aria-1.1#aria-selected">aria-selected
-                  (state)</a></code>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive
-              content</a>
+              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
             </td>
             <td>
               <a data-cite="html/dom.html#flow-content">Flow content</a>
@@ -5332,7 +4863,7 @@
         in this specification.
       </p>
       <p>
-        Documents MUST NOT use any <code data-x="attr-aria-role">role</code>
+        Documents MUST NOT use any `role`
         values with elements in the [[[#docconformance]]] table, other than the
         corresponding role value (if any) as listed for that element in the
         third column, other than those indicated in the second column, which


### PR DESCRIPTION
Notes:
- for now, where there are additional id's for an element, such as `a-no-href`, I just kept the additional id's as-is but prepended `el-`
- reordered and renamed the `img` entries as follows:
  1. `el-img` (img alt="some text")
  2. `el-img-empty-alt` (img alt="")
  3. `el-img-no-alt`
- renamed `select2` to `el-select-multiple-or-size-greater-1` (even though that's crazy long, but at least the initial entry for select is just `el-select`)
- split `el-col-colgroup`, `el-p-pre-blockquote`, `el-ins-del`, and `el-tbody-thead-tfoot` into their constituent elements and gave each element an entry in the table
  - (did not split up `el-h1-h6`)
- removed `strong`, `em`, `sub`, `sup`, and `time` from `text-level-semantics` and gave each of them their own table entry, but left the remaining elements listed in `text-level-semantics` as-is
  - (so for now: i, small, s, cite, q, dfn, abbr, code, var, samp, kbd, b, u, mark, ruby, rp, rt, bdi, bdo, br, and wbr are still lumped together)
- left `autonomous-custom-element` and `IDL-ValidityState` id's unchanged


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aria/pull/183.html" title="Last updated on Oct 8, 2019, 5:17 PM UTC (fa3f2bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/183/e349cb4...carmacleod:fa3f2bc.html" title="Last updated on Oct 8, 2019, 5:17 PM UTC (fa3f2bc)">Diff</a>