### PR TITLE
allow aria-setsize and aria-posinset on tr in treegrid

### DIFF
--- a/index.html
+++ b/index.html
@@ -2290,7 +2290,7 @@
             <td>
               <a href="#index-aria-row">`role=row`</a>, may be
               explicitly declared when child of a `table` element
-              with `role=grid`
+              with `role=grid` or `treegrid`
             </td>
             <td>
               <p>
@@ -4082,6 +4082,7 @@
               none
             </td>
             <td>
+              <p>If child of `role=grid`, `rowgroup`, `table` or `treegrid`:</p>
               <ul>
                 <li>
                   <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
@@ -4090,16 +4091,25 @@
                   <a title="aria-rowindex" data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
-                </li>
-                <li>
                   <a data-cite="wai-aria-1.1#aria-selected">`aria-selected` (state)</a>
                 </li>
                 <li>
                   <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
+              </ul>
+              <p>Also, if child of `role=treegrid`:</p>
+              <ul>
                 <li>
                   <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>


### PR DESCRIPTION
- resolves #190

Note: Not quite sure how you want to add the slightly complicated semantics of some row properties only being allowed in context of a treegrid. I put everything into the same "Supported properties" cell (because it's more compact), but maybe you prefer splitting it into 2 rows (one for `role="row" if child of treegrid` and another for `role="row" if not child of treegrid`)?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aria/pull/191.html" title="Last updated on Nov 21, 2019, 11:57 PM UTC (82425f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/191/010683d...carmacleod:82425f4.html" title="Last updated on Nov 21, 2019, 11:57 PM UTC (82425f4)">Diff</a>