### PR TITLE
Add implicit roles to td, th, and simplify tr

### DIFF
--- a/index.html
+++ b/index.html
@@ -2635,7 +2635,9 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                element has `role=table`, `grid`, or `treegrid`; otherwise
+                <a><strong>any</strong> `role`</a>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
@@ -2660,7 +2662,9 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                element has `role=table`, `grid`, or `treegrid`; otherwise
+                <a><strong>any</strong> `role`</a>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
@@ -2678,7 +2682,9 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                element has `role=table`, `grid`, or `treegrid`; otherwise
+                <a><strong>any</strong> `role`</a>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and

--- a/index.html
+++ b/index.html
@@ -2228,7 +2228,10 @@
                 <code>role=<a href="#index-aria-cell">cell</a></code> if a
                 descendant of a `table` element.
               </p>
-              <!--<p><code>role=<a href="#index-aria-cell">gridcell</a></code> if a descendant of a <code>table</code> elementwith <code>role=grid</code></p>-->
+              <p>
+                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if a
+                descendant of a `table` element with `role=grid` or `treegrid`.
+              </p>
             </td>
             <td>
               <p>
@@ -2271,8 +2274,14 @@
               [^th^]
             </td>
             <td>
-              <code>role=<a href="#index-aria-columnheader">columnheader</a></code> or
-              <a href="#index-aria-rowheader">`rowheader`</a>
+              <p>
+                If a descendant of a `table` element, <code>role=<a href="#index-aria-columnheader">columnheader</a></code> or
+                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a> (if not a header).
+             </p>
+              <p>
+                If a descendant of a `table` element with `role=grid` or `treegrid`, <code>role=<a href="#index-aria-columnheader">columnheader</a></code> or
+                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a> (if not a header).
+             </p>
             </td>
             <td>
               <p>
@@ -2290,9 +2299,7 @@
               [^tr^]
             </td>
             <td>
-              <a href="#index-aria-row">`role=row`</a>, may be
-              explicitly declared when child of a `table` element
-              with `role=grid` or `treegrid`
+              <a href="#index-aria-row">`role=row`</a>
             </td>
             <td>
               <p>


### PR DESCRIPTION
Resolves #195.
- add gridcell to td
- add cell and gridcell to th
- simplify tr


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aria/pull/196.html" title="Last updated on Aug 13, 2020, 2:59 PM UTC (1058ce8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/196/a7bf6c0...carmacleod:1058ce8.html" title="Last updated on Aug 13, 2020, 2:59 PM UTC (1058ce8)">Diff</a>