### PR TITLE
Split out text level semantics

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,6 +633,22 @@
               </p>
             </td>
           </tr>
+          <tr id="el-dfn" tabindex="-1">
+            <td>
+              [^dfn^]
+            </td>
+            <td>
+              <code>role=<a href="#index-aria-term">term</a></code>
+            </td>
+            <td>
+              <a><strong>Any</strong> `role`</a>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-details" tabindex="-1">
             <td>
               [^details^]

--- a/index.html
+++ b/index.html
@@ -2213,6 +2213,24 @@
             <td><a>No corresponding role</a></td>
             <td><strong class="nosupport">No `role` or `aria-*` attributes</strong></td>
           </tr>
+          <tr id="el-small" tabindex="-1">
+            <td>
+              [^small^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-source" tabindex="-1">
             <td>
               [^source^]
@@ -2492,31 +2510,6 @@
               <p>
                 <a><strong>Any</strong> `role`</a>
               </p>
-              <p>
-                <a href="#index-aria-global">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any).
-              </p>
-            </td>
-          </tr>
-          <tr id="text-level-semantics" tabindex="-1">
-            <td>
-              <p>
-                Text level semantic elements not listed elsewhere:
-              </p>
-              <p>
-                <code>
-                <a>abbr</a>, <a>b</a>, <a>bdi</a>, <a>bdo</a>, <a>br</a>, <a>cite</a>, <a>code</a>,
-                <a>data</a>, <a>dfn</a>, <a>i</a>, <a>kbd</a>, <a>mark</a>, <a>q</a>, <a>rp</a>, <a>rt</a>,
-                <a>ruby</a>, <a>s</a>, <a>samp</a>, <a>small</a>, <a>u</a>, <a>var</a>, <a>wbr</a>
-                </code>
-              </p>
-            </td>
-            <td>
-              <a>No corresponding role</a>
-            </td>
-            <td>
-              <a><strong>Any</strong> `role`</a>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and

--- a/index.html
+++ b/index.html
@@ -445,6 +445,26 @@
               </p>
             </td>
           </tr>
+          <tr id="el-br" tabindex="-1">
+            <td>
+              [^br^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>.
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-button" tabindex="-1">
             <td>
               [^button^]

--- a/index.html
+++ b/index.html
@@ -350,6 +350,22 @@
               </p>
             </td>
           </tr>
+          <tr id="el-b" tabindex="-1">
+            <td>
+              [^b^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <a><strong>Any</strong> `role`</a>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-base" tabindex="-1">
             <td>
               [^base^]
@@ -359,6 +375,38 @@
             </td>
             <td>
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+            </td>
+          </tr>
+          <tr id="el-bdi" tabindex="-1">
+            <td>
+              [^bdi^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <a><strong>Any</strong> `role`</a>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-bdo" tabindex="-1">
+            <td>
+              [^bdo^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <a><strong>Any</strong> `role`</a>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
             </td>
           </tr>
           <tr id="el-blockquote" tabindex="-1">
@@ -458,6 +506,38 @@
               </p>
             </td>
           </tr>
+          <tr id="el-cite" tabindex="-1">
+            <td>
+              [^cite^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <a><strong>Any</strong> `role`</a>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-code" tabindex="-1">
+            <td>
+              [^code^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <a><strong>Any</strong> `role`</a>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-col" tabindex="-1">
             <td>
               <p>
@@ -482,6 +562,22 @@
             </td>
             <td>
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+            </td>
+          </tr>
+          <tr id="el-data" tabindex="-1">
+            <td>
+              [^data^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <a><strong>Any</strong> `role`</a>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
             </td>
           </tr>
           <tr id="el-datalist" tabindex="-1">
@@ -898,6 +994,24 @@
             </td>
             <td>
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+            </td>
+          </tr>
+          <tr id="el-i" tabindex="-1">
+            <td>
+              [^i^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
             </td>
           </tr>
           <tr id="el-iframe" tabindex="-1">
@@ -1434,6 +1548,24 @@
               </p>
             </td>
           </tr>
+          <tr id="el-kbd" tabindex="-1">
+            <td>
+              [^kbd^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-label" tabindex="-1">
             <td>
               [^label^]
@@ -1553,6 +1685,24 @@
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `math` role.
+              </p>
+            </td>
+          </tr>
+          <tr id="el-mark" tabindex="-1">
+            <td>
+              [^mark^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -1829,6 +1979,114 @@
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `progressbar` role.
+              </p>
+            </td>
+          </tr>
+          <tr id="el-q" tabindex="-1">
+            <td>
+              [^q^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-rp" tabindex="-1">
+            <td>
+              [^rp^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-rt" tabindex="-1">
+            <td>
+              [^rt^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-ruby" tabindex="-1">
+            <td>
+              [^ruby^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-s" tabindex="-1">
+            <td>
+              [^s^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-samp" tabindex="-1">
+            <td>
+              [^samp^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
               </p>
             </td>
           </tr>
@@ -2316,6 +2574,24 @@
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
             </td>
           </tr>
+          <tr id="el-u" tabindex="-1">
+            <td>
+              [^u^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-ul" tabindex="-1">
             <td>
               [^ul^]
@@ -2350,6 +2626,24 @@
               </p>
             </td>
           </tr>
+          <tr id="el-var" tabindex="-1">
+            <td>
+              [^var^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-video" tabindex="-1">
             <td>
               [^video^]
@@ -2364,6 +2658,24 @@
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the `application` role.
+              </p>
+            </td>
+          </tr>
+          <tr id="el-wbr" tabindex="-1">
+            <td>
+              [^wbr^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -1436,7 +1436,7 @@
           </tr>
           <tr id="el-input-submit" tabindex="-1">
             <td>
-              <a data-cite="html/input.html#submit-button-state-(type=submit)">input type=submit</a>
+              <a data-cite="html/input.html#submit-button-state-(type=submit)">`input type=submit`</a>
             </td>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>


### PR DESCRIPTION
This PR takes the single row of text level semantics elements and provides them each with their own unique `id` and place in the table of elements.

`dfn` and `br` have updated information associated with them.

`abbr` was already listed separately, so this fixes the duplication of that element.

`code` will have a corresponding role when ARIA 1.2 is released, so this will be updated further in the future.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/202.html" title="Last updated on Dec 6, 2019, 4:39 PM UTC (42e2e83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/202/8e51c39...42e2e83.html" title="Last updated on Dec 6, 2019, 4:39 PM UTC (42e2e83)">Diff</a>