### PR TITLE
Add entry for form-associated custom element

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
               </p>
             </td>
           </tr>
-          <tr id="autonomous-custom-element" tabindex="-1">
+          <tr id="el-autonomous-custom-element" tabindex="-1">
             <td>
               <a>autonomous custom element</a>
             </td>
@@ -779,6 +779,36 @@
                 <a href="#index-aria-search">`search`</a>,
                 <a href="#index-aria-none">`none`</a>
                 or <a href="#index-aria-presentation">`presentation`</a>.
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
+          <tr id="el-form-associated-custom-element" tabindex="-1">
+            <td>
+              <a>form-associated custom element</a>
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-button">`button`</a>,
+                <a href="#index-aria-checkbox">`checkbox`</a>,
+                <a href="#index-aria-combobox">`combobox`</a>,
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-listbox">`listbox`</a>,
+                <a href="#index-aria-progressbar">`progressbar`</a>,
+                <a href="#index-aria-radio">`radio`</a>,
+                <a href="#index-aria-searchbox">`searchbox`</a>,
+                <a href="#index-aria-slider">`slider`</a>,
+                <a href="#index-aria-spinbutton">`spinbutton`</a>
+                or <a href="#index-aria-textbox">`textbox`</a>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and

--- a/index.html
+++ b/index.html
@@ -940,6 +940,7 @@
                 <a href="#index-aria-searchbox">`searchbox`</a>,
                 <a href="#index-aria-slider">`slider`</a>,
                 <a href="#index-aria-spinbutton">`spinbutton`</a>
+                <a href="#index-aria-switch">`switch`</a>
                 or <a href="#index-aria-textbox">`textbox`</a>.
               </p>
               <p>

--- a/index.html
+++ b/index.html
@@ -921,7 +921,7 @@
           </tr>
           <tr id="el-form-associated-custom-element" tabindex="-1">
             <td>
-              <a>form-associated custom element</a>
+              <a data-cite="html">form-associated custom element</a>
             </td>
             <td>
               <a>No corresponding role</a>

--- a/index.html
+++ b/index.html
@@ -789,7 +789,7 @@
           </tr>
           <tr id="el-form-associated-custom-element" tabindex="-1">
             <td>
-              <a>form-associated custom element</a>
+              <a>form associated custom element</a>
             </td>
             <td>
               <a>No corresponding role</a>

--- a/index.html
+++ b/index.html
@@ -921,7 +921,7 @@
           </tr>
           <tr id="el-form-associated-custom-element" tabindex="-1">
             <td>
-              <a data-cite="html">form-associated custom element</a>
+              <a>form-associated custom element</a>
             </td>
             <td>
               <a>No corresponding role</a>

--- a/index.html
+++ b/index.html
@@ -789,7 +789,7 @@
           </tr>
           <tr id="el-form-associated-custom-element" tabindex="-1">
             <td>
-              <a>form associated custom element</a>
+              <a>form-associated custom element</a>
             </td>
             <td>
               <a>No corresponding role</a>

--- a/index.html
+++ b/index.html
@@ -937,9 +937,10 @@
                 <a href="#index-aria-listbox">`listbox`</a>,
                 <a href="#index-aria-progressbar">`progressbar`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
+                <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-searchbox">`searchbox`</a>,
                 <a href="#index-aria-slider">`slider`</a>,
-                <a href="#index-aria-spinbutton">`spinbutton`</a>
+                <a href="#index-aria-spinbutton">`spinbutton`</a>,
                 <a href="#index-aria-switch">`switch`</a>
                 or <a href="#index-aria-textbox">`textbox`</a>.
               </p>


### PR DESCRIPTION
Closes #203 

- Add entry for form-associated custom element
- Prefix autonomous custom element id with 'el-' for consistency with other elements and with html-aam.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aria/pull/204.html" title="Last updated on Dec 14, 2019, 8:50 PM UTC (a2bb14d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/204/bb66bc6...carmacleod:a2bb14d.html" title="Last updated on Dec 14, 2019, 8:50 PM UTC (a2bb14d)">Diff</a>