### PR TITLE
fix inconsistency nit

### DIFF
--- a/index.html
+++ b/index.html
@@ -1780,13 +1780,13 @@
             </td>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
+              <p>
+                <strong>Note:</strong> some user agents suppress a list's
+                <a>implicit ARIA semantics</a> if list markers are removed.
+                Authors can use `role=list` to reinstate the role if necessary.
+              </p>
             </td>
             <td>
-              <p>
-                <strong>Note</strong> that some user agents suppress a list's
-                <a>implicit ARIA semantics</a> if list markers are removed.
-                Authors can use `role=list` to reinstate the role, if necessary.
-              </p>
               <p>
                 Roles:
                 <a href="#index-aria-directory">`directory`</a>,
@@ -1894,9 +1894,9 @@
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
               <p>
-                <strong>Note</strong> that some user agents suppress a list's
+                <strong>Note:</strong> some user agents suppress a list's
                 <a>implicit ARIA semantics</a> if list markers are removed.
-                Authors can use `role=list` to reinstate the role, if necessary.
+                Authors can use `role=list` to reinstate the role if necessary.
               </p>
             </td>
             <td>
@@ -2659,13 +2659,13 @@
             </td>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
+              <p>
+                <strong>Note:</strong> some user agents suppress a list's
+                <a>implicit ARIA semantics</a> if list markers are removed.
+                Authors can use `role=list` to reinstate the role if necessary.
+              </p>
             </td>
             <td>
-              <p>
-                <strong>Note</strong> that some user agents suppress a list's
-                <a>implicit ARIA semantics</a> if list markers are removed.
-                Authors can use `role=list` to reinstate the role, if necessary.
-              </p>
               <p>
                 Roles:
                 <a href="#index-aria-directory">`directory`</a>,


### PR DESCRIPTION
- use **Note:** instead of **Note that** (for consistency with other notes in the table)
- move `menu` and `ul` note to "implicit role" column for consistency with `ol`

The "implicit role" column seems like a better place for the "reinstate role=list if necessary" note, because it is saying that the author can override the "SHOULD NOT be used" for the implicit role in that specific case. This note was already in the "implicit role" column for `ol`, so this just makes `ul` and `menu` consistent with `ol`.

The Diff below seems to have a bug - it doesn't show the 2 notes that changed columns. To see the old note location, you need to look at [the current row for `menu`](https://w3c.github.io/html-aria/#el-menu) and [the current row for `ul`](https://w3c.github.io/html-aria/#el-ul)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aria/pull/206.html" title="Last updated on Jan 5, 2020, 5:19 PM UTC (2959ba1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/206/08b5ec7...carmacleod:2959ba1.html" title="Last updated on Jan 5, 2020, 5:19 PM UTC (2959ba1)">Diff</a>