### PR TITLE
update allowances for figure

### DIFF
--- a/index.html
+++ b/index.html
@@ -804,27 +804,6 @@
               </p>
             </td>
           </tr>
-          <tr id="el-figcaption" tabindex="-1">
-            <td>
-              [^figcaption^]
-            </td>
-            <td>
-              <a>No corresponding role</a>
-            </td>
-            <td>
-              <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>.
-              </p>
-              <p>
-                <a href="#index-aria-global">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any).
-              </p>
-            </td>
-          </tr>
           <tr id="el-fieldset" tabindex="-1">
             <td>
               [^fieldset^]
@@ -846,6 +825,27 @@
               </p>
             </td>
           </tr>
+          <tr id="el-figcaption" tabindex="-1">
+            <td>
+              [^figcaption^]
+            </td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>.
+              </p>
+              <p>
+                <a href="#index-aria-global">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
+              </p>
+            </td>
+          </tr>
           <tr id="el-figure" tabindex="-1">
             <td>
               [^figure^]
@@ -855,10 +855,14 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                If the `figure` has no `figcaption` descendant:
+                <br>
+                Roles: <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                If the `figure` has a `figcaption` descendant:
+                <br>
+                <strong class="nosupport">No `role`</strong>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
@@ -887,7 +891,7 @@
               </p>
               <p>
                 DPub Roles:
-                <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
+                <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and


### PR DESCRIPTION
if a figure has a figcaption descendant, the expected parent/child relationship needs to be maintained, so the figure cannot have a role.

if there is no figcaption descendant, then the figure can receive any role.

this commit also alphabetizes fieldset and figcaption correctly in the table.

note the issue branch is incorrect, this update will close #99


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/209.html" title="Last updated on Feb 15, 2020, 3:29 PM UTC (e46aae9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/209/67c4b9d...e46aae9.html" title="Last updated on Feb 15, 2020, 3:29 PM UTC (e46aae9)">Diff</a>