### PR TITLE
updates to custom elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,7 +946,7 @@
                 <a href="#index-aria-switch">`switch`</a>
                 or <a href="#index-aria-textbox">`textbox`</a>.
               </p>
-              <p>Otherwise only allowed roles to the role exposed by the custom element's `ElementInternals`.</p>
+              <p>Otherwise only allowed roles for the role exposed by the custom element's `ElementInternals`.</p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and

--- a/index.html
+++ b/index.html
@@ -337,12 +337,14 @@
               <a>autonomous custom element</a>
             </td>
             <td>
-              <a>No corresponding role</a>
+              Role exposed from author defined <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">`ElementInternals`</a>.
+              Otherwise <a>no corresponding role</a>.
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                If no author defined role,<br><a><strong>Any</strong> `role`</a>
               </p>
+              <p>Otherwise only allowed roles to the role exposed by the custom element's `ElementInternals`.</p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
@@ -924,11 +926,11 @@
               <a>form-associated custom element</a>
             </td>
             <td>
-              <a>No corresponding role</a>
+              Role exposed from author defined <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">`ElementInternals`</a>.
+              Otherwise <a>no corresponding role</a>.
             </td>
             <td>
-              <p>
-                Roles:
+              <p>If no author defined role,<br> Roles:
                 <a href="#index-aria-application">`application`</a>,
                 <a href="#index-aria-button">`button`</a>,
                 <a href="#index-aria-checkbox">`checkbox`</a>,
@@ -944,6 +946,7 @@
                 <a href="#index-aria-switch">`switch`</a>
                 or <a href="#index-aria-textbox">`textbox`</a>.
               </p>
+              <p>Otherwise only allowed roles to the role exposed by the custom element's `ElementInternals`.</p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and

--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@
               <p>
                 If no author defined role,<br><a><strong>Any</strong> `role`</a>
               </p>
-              <p>Otherwise only allowed roles to the role exposed by the custom element's `ElementInternals`.</p>
+              <p>Otherwise only allowed roles for the role exposed by the custom element's `ElementInternals`.</p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and


### PR DESCRIPTION
Closes #180 

Updates autonomous custom elements and form associated custom elements to indicate that they have no corresponding role if an author did not define a role in the custom element’s `ElementInternals`.

The allowed roles and properties column has been updated to indicate that if a custom element has an author defined role, then the allowed roles to that element must adhere to the defined role of the custom element.

I'm thinking it's probably a good idea to add an example, at the end of section 2, to help demonstrate proper conformance here.

e.g.
`<my-element>` with no role defined from its `ElementInternals` can accept any role.

but if `<my-check>` were created and had its role defined via its internals...
```js
class MyCheckbox extends HTMLElement {
  static get formAssociated() { return true; }
  static get observedAttributes() { return ['checked']; }

  constructor() {
    super();
    this._internals = this.attachInternals();
    this.addEventListener('click', this._onClick.bind(this));

    this._internals.role = 'checkbox';
    this._internals.ariaChecked = false;
  }
  // ...
```
(example from the [pending PR to the HTML spec](https://whatpr.org/html/4658/custom-elements.html#custom-elements-accessibility-example))
Then only roles allowed on a checkbox would be allowed on this custom element.


That all said, we shouldn't merge this update until the linked HTML and ARIA issues in #180 are merged.

cc @carmacleod


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/210.html" title="Last updated on Feb 13, 2021, 9:02 PM UTC (5b3d26f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/210/123406d...5b3d26f.html" title="Last updated on Feb 13, 2021, 9:02 PM UTC (5b3d26f)">Diff</a>