### PR TITLE
add allowed roles for nav element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1845,6 +1845,18 @@
             </td>
             <td>
               <p>
+                Roles:
+                <a href="#index-aria-group">`group`</a>,
+                <a href="#index-aria-menu">`menu`</a>,
+                <a href="#index-aria-menubar">`menubar`</a>,
+                <a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-presentation">`presentation`</a>,
+                <a href="#index-aria-region">`region`</a>,
+                <a href="#index-aria-tablist">`tablist`</a>,
+                <a href="#index-aria-toolbar">`toolbar`</a>,
+                or <a href="#index-aria-tree">`tree`</a>.
+              </p>
+              <p>
                 DPub Roles:
                 <a data-cite="dpub-aria-1.0#doc-index">`doc-index`</a>,
                 <a data-cite="dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a>,
@@ -1852,7 +1864,8 @@
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `navigation` role.
+                any `aria-*` attributes applicable to the allowed roles and
+                implied role (if any).
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -1865,11 +1865,8 @@
                 <a href="#index-aria-menu">`menu`</a>,
                 <a href="#index-aria-menubar">`menubar`</a>,
                 <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>,
-                <a href="#index-aria-region">`region`</a>,
-                <a href="#index-aria-tablist">`tablist`</a>,
-                <a href="#index-aria-toolbar">`toolbar`</a>,
-                or <a href="#index-aria-tree">`tree`</a>.
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-tablist">`tablist`</a>.
               </p>
               <p>
                 DPub Roles:

--- a/index.html
+++ b/index.html
@@ -5242,8 +5242,7 @@
             </td>
             <td>
               An option item of a tree. This is an element within a tree that
-              may be expanded or collapsed if it contains a sub-level group of
-              treeitems.
+              may be expanded or collapsed if it contains a sub-level group of treeitems.
             </td>
             <td>
               none


### PR DESCRIPTION
closes #185

as noted in the linked issue, `nav` element was missing allowed ARIA roles.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/211.html" title="Last updated on Aug 6, 2020, 7:33 PM UTC (2afefd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/211/fd0a72e...2afefd4.html" title="Last updated on Aug 6, 2020, 7:33 PM UTC (2afefd4)">Diff</a>