### PR TITLE
limit the allowed roles on img elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1108,7 +1108,7 @@
           </tr>
           <tr id="el-img" tabindex="-1">
             <td>
-              <code><a>img</a> with <a data-cite=
+              <code><a>img</a></code> with <code><a data-cite=
               "html/embedded-content.html#attr-img-alt">alt</a>="some text"</code>
             </td>
             <td>
@@ -1116,9 +1116,21 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a> except
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                Roles:
+                <a href="#index-aria-button">`button`</a>,
+                <a href="#index-aria-checkbox">`checkbox`</a>,
+                <a href="#index-aria-link">`link`</a>,
+                <a href="#index-aria-menuitem">`menuitem`</a>,
+                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                <a href="#index-aria-option">`option`</a>,
+                <a href="#index-aria-progressbar">`progressbar`</a>,
+                <a href="#index-aria-scrollbar">`scrollbar`</a>,
+                <a href="#index-aria-separator">`separator`</a>,
+                <a href="#index-aria-slider">`slider`</a>,
+                <a href="#index-aria-switch">`switch`</a>,
+                <a href="#index-aria-tab">`tab`</a> or
+                <a href="#index-aria-treeitem">`treeitem`</a>
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
@@ -1129,7 +1141,7 @@
           </tr>
           <tr id="el-img-empty-alt" tabindex="-1">
             <td>
-              <code><a>img</a> with <a data-cite=
+              <code><a>img</a></code> with <code><a data-cite=
               "html/embedded-content.html#attr-img-alt">alt</a>=""</code>
             </td>
             <td>
@@ -1149,19 +1161,18 @@
           </tr>
           <tr id="el-img-no-alt" tabindex="-1">
             <td>
-              <code><a>img</a> with no <a data-cite="html/images.html#unknown-images">alt</a>=""</code>
+              <code><a>img</a></code> without <code><a data-cite="html/images.html#unknown-images">alt</a></code> attribute
             </td>
             <td>
               <code>role=<a href="#index-aria-img">img</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                If not provided an author defined accessible name by other methods: <strong class="nosupport">No `role`</strong>, and <strong>no `aria-*` attributes</strong> except
+                `aria-hidden`.
               </p>
               <p>
-                <a href="#index-aria-global">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles and
-                implied role (if any).
+                Otherwise, if the `img` has an author defined accessible name, see <a href="#el-img">`img alt="some text"`</a>.
               </p>
             </td>
           </tr>


### PR DESCRIPTION
closes #166

this PR does the following:

* limits the allowed roles on an `img` with `alt=some_text`.
  - button
  - link
  - menuitem
  - menuitemcheckbox
  - menuitemradio
  - option
  - radio
  - switch
  - tab
* disallows any role on an `img` without an `alt` attribute (some screen readers will ignore an `img` without an `alt`.  some will announce the file name.  rather we not allow a `role=button` without an accessible name, or with a name "photo-1.jpg").  

  If an `img` is provided an authored defined accessible name via other means (`aria-label`, `aria-labelledby`, `title`) then same allowances as `img alt="some text"`.

I'd be more than open to whittling the allowed roles down further, or hearing reasons to add some back in.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/212.html" title="Last updated on Feb 15, 2020, 11:37 AM UTC (dfb3259)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/212/9599ae9...dfb3259.html" title="Last updated on Feb 15, 2020, 11:37 AM UTC (dfb3259)">Diff</a>