### PR TITLE
update summary element role allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -2406,10 +2406,7 @@
             </td>
             <td>
               <p>
-                Role: `button` with `aria-expanded=true` if the
-                parent (`details`) element's <a data-cite=
-                "html/interactive-elements.html#attr-details-open">`open`</a>
-                attribute is present, `aria-expanded=false` otherwise.
+                <strong class="nosupport">No `role`</strong>
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and


### PR DESCRIPTION
closes #85

Removed the allowance for `role=button` with `aria-expanded=true/false` on `summary`.  Authors who need to support IE11 with polyfills may still need this, but as noted in the issue for this PR, they're likely already getting various other conformance errors already.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/213.html" title="Last updated on Feb 15, 2020, 5:07 AM UTC (87969c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/213/46fece9...87969c0.html" title="Last updated on Feb 15, 2020, 5:07 AM UTC (87969c0)">Diff</a>