### PR TITLE
re-add doc-cover to img

### DIFF
--- a/index.html
+++ b/index.html
@@ -1137,6 +1137,10 @@
                 <a href="#index-aria-treeitem">`treeitem`</a>
               </p>
               <p>
+                DPub Role:
+                <a data-cite="dpub-aria-1.0#doc-cover">`doc-cover`</a>.
+              </p>
+              <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
                 implied role (if any).


### PR DESCRIPTION
closes #230


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/231.html" title="Last updated on May 20, 2020, 4:51 PM UTC (30f8e6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/231/8854c6b...30f8e6d.html" title="Last updated on May 20, 2020, 4:51 PM UTC (30f8e6d)">Diff</a>