### PR TITLE
Use isContentEditable rather than contenteditable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,5 +55,5 @@ Once you have confirmed (make sure you have committed your changes before
 running tidy, as the changes are destructive ... in a good way:)):
 
 ```bash
-tidy -config tidyconf.txt -o index.html index.html
+tidy -config tidyconfig.txt -o index.html index.html
 ```

--- a/index.html
+++ b/index.html
@@ -2881,15 +2881,15 @@
           <tr id="att-contenteditable" tabindex="-1">
             <td>
               Element with <a data-cite=
-              "html/interaction.html#attr-contenteditable">`contenteditable`</a>
-              attribute
+              "html/interaction.html#attr-contenteditable">`isContentEditable`</a>
+              ="true"
             </td>
             <td>
               `aria-readonly="false"`
             </td>
             <td>
               Do not set `aria-readonly="true"` on an element that
-              has a `contenteditable` attribute set.
+              has `isContentEditable="true"`.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1534,7 +1534,7 @@
               <p>
                 Roles:
                 <a href="#index-aria-combobox">`combobox`</a>,
-                <a href="#index-aria-searchbox">`searchbox`</a></code>
+                <a href="#index-aria-searchbox">`searchbox`</a>
                 or <a href="#index-aria-spinbutton">`spinbutton`</a>.
               </p>
               <p>
@@ -2880,16 +2880,26 @@
           </tr>
           <tr id="att-contenteditable" tabindex="-1">
             <td>
-              Element with <a data-cite=
-              "html/interaction.html#attr-contenteditable">`isContentEditable`</a>
-              ="true"
+              <p>
+                Element with <code><a data-cite=
+                "html/interaction.html#attr-contenteditable">contenteditable</a>="true"</code>;
+                or<br>
+                Element without `contenteditable` attribute whose closest
+                ancestor with a `contenteditable` attribute has
+                `contenteditable="true"`.
+              </p>
+              <p>
+                Note: this is equivalent to the <a data-cite=
+                "html/interaction.html#dom-iscontenteditable">`isContentEditable`</a>
+                IDL attribute.
+              </p>
             </td>
             <td>
               `aria-readonly="false"`
             </td>
             <td>
-              Do not set `aria-readonly="true"` on an element that
-              has `isContentEditable="true"`.
+              Do not set `aria-readonly="true"` on an element that has
+              `isContentEditable="true"`.
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
1. isContentEditable covers the case when the contenteditable property is inherited from an ancestor
2. "Element with contenteditable attribute" sounds like it also covers `contenteditable="false"` or `contenteditable="inherit"`, but it doesn't make sense that `aria-readonly="false"` in this case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexLloyd0/html-aria/pull/235.html" title="Last updated on Jul 14, 2020, 11:40 AM UTC (b89980d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/235/09f9eab...AlexLloyd0:b89980d.html" title="Last updated on Jul 14, 2020, 11:40 AM UTC (b89980d)">Diff</a>