### PR TITLE
Include <input> with <input type=text>

### DIFF
--- a/index.html
+++ b/index.html
@@ -1574,8 +1574,9 @@
           </tr>
           <tr id="el-input-text" tabindex="-1">
             <td>
-              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>,
-              with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
+              <a data-cite="html/input.html">`input`</a> with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute,
+              and with <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`type=text`</a>,
+              or a missing or invalid `type`.
             </td>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -1596,13 +1597,14 @@
           <tr id="el-input-text-list" tabindex="-1">
             <td>
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">
-              `input type=text`</a>,
+              `input` with a <a data-cite="html/input.html#attr-input-list">`list`</a> attribute and with
+              `type=text`</a>,
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">
               `search`</a>,
               <a data-cite="html/input.html#telephone-state-(type=tel)">`tel`</a>,
               <a data-cite="html/input.html#url-state-(type=url)">`url`</a>,
-              or <a data-cite="html/input.html#e-mail-state-(type=email)">`email`</a>
-              with a <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
+              <a data-cite="html/input.html#e-mail-state-(type=email)">`email`</a>,
+              or a missing or invalid `type`.
             </td>
             <td>
               <code>role=<a href="#index-aria-combobox">combobox</a></code>

--- a/index.html
+++ b/index.html
@@ -1574,9 +1574,8 @@
           </tr>
           <tr id="el-input-text" tabindex="-1">
             <td>
-              <a data-cite="html/input.html">`input`</a> with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute,
-              and with <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`type=text`</a>,
-              or a missing or invalid `type`.
+              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>
+              or with a missing or invalid `type`, with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
             </td>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -1597,14 +1596,13 @@
           <tr id="el-input-text-list" tabindex="-1">
             <td>
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">
-              `input` with a <a data-cite="html/input.html#attr-input-list">`list`</a> attribute and with
-              `type=text`</a>,
+              `input type=text`</a>,
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">
               `search`</a>,
               <a data-cite="html/input.html#telephone-state-(type=tel)">`tel`</a>,
               <a data-cite="html/input.html#url-state-(type=url)">`url`</a>,
               <a data-cite="html/input.html#e-mail-state-(type=email)">`email`</a>,
-              or a missing or invalid `type`.
+              or with a missing or invalid `type`, with a <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
             </td>
             <td>
               <code>role=<a href="#index-aria-combobox">combobox</a></code>


### PR DESCRIPTION
According to https://html.spec.whatwg.org/multipage/input.html, `type=text` is both the `missing value default` and the `invalid value default`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexLloyd0/html-aria/pull/242.html" title="Last updated on Oct 20, 2020, 11:49 AM UTC (8df3f14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/242/ed9c6a8...AlexLloyd0:8df3f14.html" title="Last updated on Oct 20, 2020, 11:49 AM UTC (8df3f14)">Diff</a>