### PR TITLE
update allowances for image with empty alt

### DIFF
--- a/index.html
+++ b/index.html
@@ -1206,7 +1206,7 @@
             </td>
             <td>
               <strong class="nosupport">No `role` or `aria-*` attributes</strong> 
-              except `aria-hidden`.
+              except `aria-hidden="true"`.
             </td>
           </tr>
           <tr id="el-img-no-alt" tabindex="-1">

--- a/index.html
+++ b/index.html
@@ -1198,22 +1198,15 @@
           </tr>
           <tr id="el-img-empty-alt" tabindex="-1">
             <td>
-              <code><a>img</a></code> with <code><a data-cite=
-              "html/embedded-content.html#attr-img-alt">alt</a>=""</code>
+              <code><a>img</a></code> with 
+              <code><a data-cite="html/embedded-content.html#attr-img-alt">alt</a>=""</code>
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <p>
-                Roles:
-                <a href="#index-aria-none">`none`</a> or
-                <a href="#index-aria-presentation">`presentation`</a>.
-              </p>
-              <p>
-                <strong class="nosupport">No `aria-*` attributes</strong> except
-                `aria-hidden`.
-              </p>
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong> 
+              except `aria-hidden`.
             </td>
           </tr>
           <tr id="el-img-no-alt" tabindex="-1">


### PR DESCRIPTION
commit to remove allowance for `role=presentation` and `role=none` on an `<img src=... alt="">`.  Declaring these roles _should_ be considered redundant/unnecessary per the `alt=""`.  

If there are situations where an image with `alt=""` is not being set to decorative, (thinking an img with a .svg source in webkit) then authors can still use `aria-hidden=true` to force the element to be hidden to the a11y tree (and would have needed to use that anyway).

closes #229


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/243.html" title="Last updated on Oct 20, 2020, 1:21 PM UTC (7694d34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/243/8d10192...7694d34.html" title="Last updated on Oct 20, 2020, 1:21 PM UTC (7694d34)">Diff</a>