### PR TITLE
Add link to HTML AAM to determine the role of <th>

### DIFF
--- a/index.html
+++ b/index.html
@@ -2637,7 +2637,7 @@
             <td>
               <p>
                 <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
-                `table` element has `role=table`.
+                `table` element is exposed as a `role=table`.
               </p>
               <p>
                 <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor

--- a/index.html
+++ b/index.html
@@ -2641,7 +2641,7 @@
               </p>
               <p>
                 <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
-                `table` element has `role=grid` or `treegrid`.
+                `table` element is exposed as a `role=grid` or `treegrid`.
               </p>
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -2668,7 +2668,7 @@
                 <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
              </p>
               <p>
-                If the ancestor `table` element has `role=grid` or `treegrid`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                If the ancestor `table` element is exposed as a `role=grid` or `treegrid`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
                 <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a> according to
                 <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
              </p>

--- a/index.html
+++ b/index.html
@@ -2663,7 +2663,7 @@
             </td>
             <td>
               <p>
-                If the ancestor `table` element has `role=table`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                If the ancestor `table` element is exposed as a `role=table`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
                 <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a> according to
                 <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
              </p>

--- a/index.html
+++ b/index.html
@@ -2636,12 +2636,12 @@
             </td>
             <td>
               <p>
-                <code>role=<a href="#index-aria-cell">cell</a></code> if a
-                descendant of a `table` element.
+                <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
+                `table` element has `role=table`.
               </p>
               <p>
-                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if a
-                descendant of a `table` element with `role=grid` or `treegrid`.
+                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
+                `table` element has `role=grid` or `treegrid`.
               </p>
             </td>
             <td>
@@ -2663,12 +2663,14 @@
             </td>
             <td>
               <p>
-                If a descendant of a `table` element, <code>role=<a href="#index-aria-columnheader">columnheader</a></code> or
-                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a> (if not a header).
+                If the ancestor `table` element has `role=table`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a> according to
+                <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
              </p>
               <p>
-                If a descendant of a `table` element with `role=grid` or `treegrid`, <code>role=<a href="#index-aria-columnheader">columnheader</a></code> or
-                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a> (if not a header).
+                If the ancestor `table` element has `role=grid` or `treegrid`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a> according to
+                <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
              </p>
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>ARIA in HTML</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script class="remove">
     var respecConfig = {
       editors: [


### PR DESCRIPTION
See #244 

Also clarify the wording for `<th>` and `<td>`.

Old: if a descendant of a `table` element.
New: if the ancestor `table` element has `role=table`.

`<th>` and `<tr>` must be descendants of a `<table>` so the old condition is always true.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AlexLloyd0/html-aria/pull/246.html" title="Last updated on Oct 6, 2020, 3:46 PM UTC (14ac1ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/246/c808be9...AlexLloyd0:14ac1ad.html" title="Last updated on Oct 6, 2020, 3:46 PM UTC (14ac1ad)">Diff</a>