### PR TITLE
add missing aria-label to example 6 markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1199,14 +1199,14 @@
           </tr>
           <tr id="el-img-empty-alt" tabindex="-1">
             <td>
-              <code><a>img</a></code> with 
+              <code><a>img</a></code> with
               <code><a data-cite="html/embedded-content.html#attr-img-alt">alt</a>=""</code>
             </td>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong> 
+              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
               except `aria-hidden="true"`.
             </td>
           </tr>
@@ -2994,7 +2994,7 @@
         </p>
         <pre>
 &lt;figure&gt;
-  &lt;pre role="img"&gt;
+  &lt;pre role="img" aria-label="An ASCII art fish"&gt;
   o           .'`/
     '      /  (
   O    .-'` ` `'-._      .')
@@ -3009,7 +3009,7 @@
     October 1997. ASCII on electrons. 28×8.
   &lt;/figcaption&gt;
 &lt;/figure&gt;
-</pre><!-- source: http://www.geocities.com/SoHo/7373/aquatic.htm#fish -->
+</pre><!-- source: https://web.archive.org/web/20130313111807/http://www.geocities.com/SoHo/7373/aquatic.htm -->
       </aside>
     </section>
     <section>


### PR DESCRIPTION
closes #222


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/260.html" title="Last updated on Feb 13, 2021, 9:30 PM UTC (8402c47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/260/3a0d3dc...8402c47.html" title="Last updated on Feb 13, 2021, 9:30 PM UTC (8402c47)">Diff</a>