### PR TITLE
updates table element allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -2926,7 +2926,11 @@
         Document conformance requirements for use of ARIA attributes with HTML attributes
       </h3>
       <p>
-        Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a `button` rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together. As stated in <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>, user agents MUST ignore WAI-ARIA attributes and use the host language (HTML) attribute with the same <a>implicit ARIA semantics</a>.
+        Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where 
+        the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a `button` rather than the 
+        `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together. 
+        As stated in <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>, 
+        user agents MUST ignore WAI-ARIA attributes and use the host language (HTML) attribute with the same <a>implicit ARIA semantics</a>.
       </p>
       <p>
         The following table represents HTML elements and their attributes which have `aria-*` attribute parity.
@@ -2934,7 +2938,8 @@
       <p>
         Each language feature (element and attribute) in a cell in the first column implies the
         ARIA semantics (states, and properties) given in the cell in the second column
-        of the same row. The third cell in each row defines how authors can use the native HTML feature, along with requirements for using the `aria-*` attributes that supply the same <a>implicit ARIA semantics</a>.
+        of the same row. The third cell in each row defines how authors can use the native HTML feature, along with requirements for 
+        using the `aria-*` attributes that supply the same <a>implicit ARIA semantics</a>.
       </p>
       <table class="simple">
         <caption>
@@ -3036,7 +3041,8 @@
                 `placeholder` attribute</a> in HTML.
               </p>
               <p>
-                Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
+                Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, 
+                or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
               </p>
               <p>
                 Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
@@ -3054,7 +3060,8 @@
             <td>
               <p>
                 Use the `max` attribute on any element that is
-                <a data-cite="html/input.html#attr-input-max">allowed the `max` attribute</a> in HTML. It is NOT RECOMMENDED to use the <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax` attribute</a> on these elements.
+                <a data-cite="html/input.html#attr-input-max">allowed the `max` attribute</a> in HTML. 
+                It is NOT RECOMMENDED to use the <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax` attribute</a> on these elements.
               </p>
               <p>
                 Authors MAY use the `aria-valuemax` attribute on any other element with a WAI-ARIA role which allows the  attribute.

--- a/index.html
+++ b/index.html
@@ -2515,11 +2515,19 @@
               [^tbody^]
             </td>
             <td>
-              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+              <p>
+                If the ancestor `table` element is exposed as a `role=table`, `grid` or `treegrid` then:
+                <code><a href="#index-aria-rowgroup">`role=rowgroup`</a></code>
+              </p>
+              <p>
+                If the ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid` then: <a>no corresponding role</a>.
+              </p>
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                element has `role=table`, `grid`, or `treegrid`; otherwise
+                <a><strong>any</strong> `role`</a>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
@@ -2561,11 +2569,19 @@
               [^tfoot^]
             </td>
             <td>
-              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+              <p>
+                If the ancestor `table` element is exposed as a `role=table`, `grid` or `treegrid` then:
+                <code><a href="#index-aria-rowgroup">`role=rowgroup`</a></code>
+              </p>
+              <p>
+                If the ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid` then: <a>no corresponding role</a>.
+              </p>
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                element has `role=table`, `grid`, or `treegrid`; otherwise
+                <a><strong>any</strong> `role`</a>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
@@ -2579,11 +2595,19 @@
               [^thead^]
             </td>
             <td>
-              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+              <p>
+                If the ancestor `table` element is exposed as a `role=table`, `grid` or `treegrid` then:
+                <code><a href="#index-aria-rowgroup">`role=rowgroup`</a></code>
+              </p>
+              <p>
+                If the ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid` then: <a>no corresponding role</a>.
+              </p>
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                element has `role=table`, `grid`, or `treegrid`; otherwise
+                <a><strong>any</strong> `role`</a>.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
@@ -2627,12 +2651,13 @@
             </td>
             <td>
               <p>
-                <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
-                `table` element is exposed as a `role=table`.
+                If the ancestor `table` element is exposed as a `role=table` then: <code>role=<a href="#index-aria-cell">cell</a></code>.
               </p>
               <p>
-                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
-                `table` element is exposed as a `role=grid` or `treegrid`.
+                If the ancestor `table` element is exposed as a `role=grid` or `treegrid` then: <code>role=<a href="#index-aria-cell">gridcell</a></code>.
+              </p>
+              <p>
+                If the ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid` then: <a>no corresponding role</a>.
               </p>
             </td>
             <td>
@@ -2654,20 +2679,21 @@
             </td>
             <td>
               <p>
-                If the ancestor `table` element is exposed as a `role=table`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a> according to
-                <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
-             </p>
+                If the ancestor `table` element is exposed as a `role=table` then: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a>.
+              </p>
               <p>
-                If the ancestor `table` element is exposed as a `role=grid` or `treegrid`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a> according to
-                <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
-             </p>
+                If the ancestor `table` element is exposed as a `role=grid` or `treegrid` then: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a>.
+              </p>
+              <p>
+                If the ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid` then: <a>no corresponding role</a>.
+              </p>
             </td>
             <td>
               <p>
                 <strong class="nosupport">No `role`</strong> if the ancestor `table`
-                element has `role=table`, `grid`, or `treegrid`; otherwise
+                element is exposed as a `role=table`, `grid`, or `treegrid`; otherwise
                 <a><strong>any</strong> `role`</a>.
               </p>
               <p>
@@ -2682,7 +2708,13 @@
               [^tr^]
             </td>
             <td>
-              <a href="#index-aria-row">`role=row`</a>
+              <p>
+                If the ancestor `table` element is exposed as a `role=table`, `grid` or `treegrid` then:
+                <code><a href="#index-aria-row">`role=row`</a></code>
+              </p>
+              <p>
+                If the ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid` then: <a>no corresponding role</a>.
+              </p>
             </td>
             <td>
               <p>


### PR DESCRIPTION
closes #258 by revising allowed roles on `tbody`, `tfoot`, `thead` when they are children of an ancestor `table` exposed as having a role of `table`, `grid` or `treegrid`.

This PR also updates the following:
* update `tr` to note that it is exposed as a `row` if ancestor `table` is exposed as a `table`, `grid` or `treegrid`. otherwise on corresponding role.
* update `th` and `td` role columns to be consistent.  remove link to HTML AAM in `th` - it wasn’t in the `td` one, and we already indicate that implicit semantics are defined in HTML AAM in other areas of the spec.  indicate that `th`/`td` have no corresponding role if the ancestor `table` is not exposed as a `table`, `grid` or `treegrid`

Further updates can likely be made to the allowed roles on these elements, as I indicated in my comments within #258.  But I think those decisions can be made later.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/265.html" title="Last updated on Feb 24, 2021, 8:14 PM UTC (9787194)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/265/d382ab9...9787194.html" title="Last updated on Feb 24, 2021, 8:14 PM UTC (9787194)">Diff</a>