### PR TITLE
Standardise table structure, minor markup fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
         <dfn><a data-cite="wai-aria-1.1#host_general_conflict">strong native semantics</a></dfn>
         or are equal to the
         <dfn><a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a></dfn>
-        of a given HTML element. The <a>implicit ARIA semantics</a> for an HTML element are defined in the <dfn>[[html-aam-1.0|HTML Accessibility API Mappings]] specification.
+        of a given HTML element. The <a>implicit ARIA semantics</a> for an HTML element are defined in the <dfn>[[html-aam-1.0|HTML Accessibility API Mappings]]</dfn> specification.
       </p>
       <p>
         The constraints defined in this specification are intended to prevent
@@ -188,9 +188,9 @@
         </thead>
         <tbody>
           <tr id="el-a" tabindex="-1">
-            <td>
+            <th>
               [^a^] with <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
             </td>
@@ -224,9 +224,9 @@
             </td>
           </tr>
           <tr id="el-a-no-href" tabindex="-1">
-            <td>
+            <th>
               [^a^] without <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
-            </td>
+            </th>
             <td>
               <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn">No corresponding role</a>
             </td>
@@ -242,9 +242,9 @@
             </td>
           </tr>
           <tr id="el-abbr" tabindex="-1">
-            <td>
+            <th>
               [^abbr^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -260,9 +260,9 @@
             </td>
           </tr>
           <tr id="el-address" tabindex="-1">
-            <td>
+            <th>
               [^address^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -278,9 +278,9 @@
             </td>
           </tr>
           <tr id="el-area" tabindex="-1">
-            <td>
+            <th>
               [^area^] with <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
             </td>
@@ -296,9 +296,9 @@
             </td>
           </tr>
           <tr id="el-area-no-href" tabindex="-1">
-            <td>
+            <th>
               [^area^] without <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
-            </td>
+            </th>
             <td><a>No corresponding role</a></td>
             <td>
               <p><strong class="nosupport">No `role`</strong></p>
@@ -308,9 +308,9 @@
             </td>
           </tr>
           <tr id="el-article" tabindex="-1">
-            <td>
+            <th>
               [^article^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-article">article</a></code>
             </td>
@@ -333,9 +333,9 @@
             </td>
           </tr>
           <tr id="el-aside" tabindex="-1">
-            <td>
+            <th>
               [^aside^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-complementary">complementary</a></code>
             </td>
@@ -365,9 +365,9 @@
             </td>
           </tr>
           <tr id="el-audio" tabindex="-1">
-            <td>
+            <th>
               [^audio^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -384,9 +384,9 @@
             </td>
           </tr>
           <tr id="el-autonomous-custom-element" tabindex="-1">
-            <td>
+            <th>
               <a>autonomous custom element</a>
-            </td>
+            </th>
             <td>
               Role exposed from author defined <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">`ElementInternals`</a>.
               Otherwise <a>no corresponding role</a>.
@@ -404,9 +404,9 @@
             </td>
           </tr>
           <tr id="el-b" tabindex="-1">
-            <td>
+            <th>
               [^b^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -420,9 +420,9 @@
             </td>
           </tr>
           <tr id="el-base" tabindex="-1">
-            <td>
+            <th>
               [^base^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -431,9 +431,9 @@
             </td>
           </tr>
           <tr id="el-bdi" tabindex="-1">
-            <td>
+            <th>
               [^bdi^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -447,9 +447,9 @@
             </td>
           </tr>
           <tr id="el-bdo" tabindex="-1">
-            <td>
+            <th>
               [^bdo^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -463,9 +463,9 @@
             </td>
           </tr>
           <tr id="el-blockquote" tabindex="-1">
-            <td>
+            <th>
               [^blockquote^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -481,9 +481,9 @@
             </td>
           </tr>
           <tr id="el-body" tabindex="-1">
-            <td>
+            <th>
               [^body^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-document">document</a></code>
             </td>
@@ -499,9 +499,9 @@
             </td>
           </tr>
           <tr id="el-br" tabindex="-1">
-            <td>
+            <th>
               [^br^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -519,9 +519,9 @@
             </td>
           </tr>
           <tr id="el-button" tabindex="-1">
-            <td>
+            <th>
               [^button^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
@@ -546,9 +546,9 @@
             </td>
           </tr>
           <tr id="el-canvas" tabindex="-1">
-            <td>
+            <th>
               [^canvas^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -564,9 +564,9 @@
             </td>
           </tr>
           <tr id="el-caption" tabindex="-1">
-            <td>
+            <th>
               [^caption^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -580,9 +580,9 @@
             </td>
           </tr>
           <tr id="el-cite" tabindex="-1">
-            <td>
+            <th>
               [^cite^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -596,9 +596,9 @@
             </td>
           </tr>
           <tr id="el-code" tabindex="-1">
-            <td>
+            <th>
               [^code^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -612,11 +612,9 @@
             </td>
           </tr>
           <tr id="el-col" tabindex="-1">
-            <td>
-              <p>
-                [^col^]
-              </p>
-            </td>
+            <th>
+              [^col^]
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -625,11 +623,9 @@
             </td>
           </tr>
           <tr id="el-colgroup" tabindex="-1">
-            <td>
-              <p>
-                [^colgroup^]
-              </p>
-            </td>
+            <th>
+              [^colgroup^]
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -638,9 +634,9 @@
             </td>
           </tr>
           <tr id="el-data" tabindex="-1">
-            <td>
+            <th>
               [^data^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -654,9 +650,9 @@
             </td>
           </tr>
           <tr id="el-datalist" tabindex="-1">
-            <td>
+            <th>
               [^datalist^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-listbox">listbox</a></code>
             </td>
@@ -672,9 +668,9 @@
             </td>
           </tr>
           <tr id="el-dd" tabindex="-1">
-            <td>
+            <th>
               [^dd^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-definition">definition</a></code>
             </td>
@@ -689,9 +685,9 @@
             </td>
           </tr>
           <tr id="el-del" tabindex="-1">
-            <td>
+            <th>
               [^del^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -707,9 +703,9 @@
             </td>
           </tr>
           <tr id="el-dfn" tabindex="-1">
-            <td>
+            <th>
               [^dfn^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-term">term</a></code>
             </td>
@@ -723,9 +719,9 @@
             </td>
           </tr>
           <tr id="el-details" tabindex="-1">
-            <td>
+            <th>
               [^details^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-group">group</a></code>
             </td>
@@ -740,9 +736,9 @@
             </td>
           </tr>
           <tr id="el-dialog" tabindex="-1">
-            <td>
+            <th>
               [^dialog^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-dialog">dialog</a></code>
             </td>
@@ -758,9 +754,9 @@
             </td>
           </tr>
           <tr id="el-div" tabindex="-1">
-            <td>
+            <th>
               [^div^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -776,9 +772,9 @@
             </td>
           </tr>
           <tr id="el-dl" tabindex="-1">
-            <td>
+            <th>
               [^dl^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -798,9 +794,9 @@
             </td>
           </tr>
           <tr id="el-dt" tabindex="-1">
-            <td>
+            <th>
               [^dt^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-term">term</a></code>
             </td>
@@ -817,9 +813,9 @@
             </td>
           </tr>
           <tr id="el-em" tabindex="-1">
-            <td>
+            <th>
               [^em^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -835,9 +831,9 @@
             </td>
           </tr>
           <tr id="el-embed" tabindex="-1">
-            <td>
+            <th>
               [^embed^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -858,9 +854,9 @@
             </td>
           </tr>
           <tr id="el-fieldset" tabindex="-1">
-            <td>
+            <th>
               [^fieldset^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-group">group</a></code>
             </td>
@@ -879,9 +875,9 @@
             </td>
           </tr>
           <tr id="el-figcaption" tabindex="-1">
-            <td>
+            <th>
               [^figcaption^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -900,9 +896,9 @@
             </td>
           </tr>
           <tr id="el-figure" tabindex="-1">
-            <td>
+            <th>
               [^figure^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-figure">figure</a></code>
             </td>
@@ -925,9 +921,9 @@
             </td>
           </tr>
           <tr id="el-footer" tabindex="-1">
-            <td>
+            <th>
               [^footer^]
-            </td>
+            </th>
             <td>
               If not a descendant of an `article`, `aside`, `main`, `nav`
               or `section` element, or an element with `role=article`, `complementary`,
@@ -953,9 +949,9 @@
             </td>
           </tr>
           <tr id="el-form" tabindex="-1">
-            <td>
+            <th>
               [^form^]
-            </td>
+            </th>
             <td>
               If the [^form^] element has an
               <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>:
@@ -977,9 +973,9 @@
             </td>
           </tr>
           <tr id="el-form-associated-custom-element" tabindex="-1">
-            <td>
+            <th>
               <a>form-associated custom element</a>
-            </td>
+            </th>
             <td>
               Role exposed from author defined <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">`ElementInternals`</a>.
               Otherwise <a>no corresponding role</a>.
@@ -1010,9 +1006,9 @@
             </td>
           </tr>
           <tr id="el-h1-h6" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1 to h6`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-heading">heading</a></code>,
               with the `aria-level` = positive integer.
@@ -1036,9 +1032,9 @@
             </td>
           </tr>
           <tr id="el-head" tabindex="-1">
-            <td>
+            <th>
               [^head^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1047,9 +1043,9 @@
             </td>
           </tr>
           <tr id="el-header" tabindex="-1">
-            <td>
+            <th>
               [^header^]
-            </td>
+            </th>
             <td>
               If not a descendant of an `article`, `aside`, `main`,
               `nav` or `section` element, or an element with `role=article`,
@@ -1076,9 +1072,9 @@
             </td>
           </tr>
           <tr id="el-hgroup" tabindex="-1">
-            <td>
+            <th>
               [^hgroup^]
-            </td>
+            </th>
             <td><a>No corresponding role</a></td>
             <td>
               <p><a><strong>Any</strong> `role`</a>.</p>
@@ -1090,9 +1086,9 @@
             </td>
           </tr>
           <tr id="el-hr" tabindex="-1">
-            <td>
+            <th>
               [^hr^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-separator">separator</a></code>
             </td>
@@ -1113,9 +1109,9 @@
             </td>
           </tr>
           <tr id="el-html" tabindex="-1">
-            <td>
+            <th>
               [^html^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1124,9 +1120,9 @@
             </td>
           </tr>
           <tr id="el-i" tabindex="-1">
-            <td>
+            <th>
               [^i^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1142,9 +1138,9 @@
             </td>
           </tr>
           <tr id="el-iframe" tabindex="-1">
-            <td>
+            <th>
               [^iframe^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1165,10 +1161,10 @@
             </td>
           </tr>
           <tr id="el-img" tabindex="-1">
-            <td>
+            <th>
               <code><a>img</a></code> with <code><a data-cite=
               "html/embedded-content.html#attr-img-alt">alt</a>="some text"</code>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-img">img</a></code>
             </td>
@@ -1202,10 +1198,10 @@
             </td>
           </tr>
           <tr id="el-img-empty-alt" tabindex="-1">
-            <td>
+            <th>
               <code><a>img</a></code> with
               <code><a data-cite="html/embedded-content.html#attr-img-alt">alt</a>=""</code>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1215,9 +1211,9 @@
             </td>
           </tr>
           <tr id="el-img-no-alt" tabindex="-1">
-            <td>
+            <th>
               <code><a>img</a></code> without <code><a data-cite="html/images.html#unknown-images">alt</a></code> attribute
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-img">img</a></code>
             </td>
@@ -1233,9 +1229,9 @@
             </td>
           </tr>
           <tr id="el-input-button" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#button-state-(type=button)">`input type=button`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
@@ -1259,9 +1255,9 @@
             </td>
           </tr>
           <tr id="el-input-checkbox" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#checkbox-state-(type=checkbox)">`input type=checkbox`</a>
-            </td>
+            </th>
             <td>
               <p>
                 <code>role=<a href="#index-aria-checkbox">checkbox</a></code>
@@ -1293,9 +1289,9 @@
             </td>
           </tr>
           <tr id="el-input-color" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#color-state-(type=color)">`input type=color`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1309,9 +1305,9 @@
             </td>
           </tr>
           <tr id="el-input-date" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#date-state-(type=date)">`input type=date`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1325,9 +1321,9 @@
             </td>
           </tr>
           <tr id="el-input-datetime-local" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#local-date-and-time-state-(type=datetime-local)">`input type=datetime-local`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1341,12 +1337,12 @@
             </td>
           </tr>
           <tr id="el-input-email" tabindex="-1">
-            <td>
+            <th>
               <a data-cite=
               "html/input.html#e-mail-state-(type=email)">`input type=email`</a>
               with no
               <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-checkbox">textbox</a></code>
             </td>
@@ -1361,9 +1357,9 @@
             </td>
           </tr>
           <tr id="el-input-file" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#file-upload-state-(type=file)">`input type=file`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1377,9 +1373,9 @@
             </td>
           </tr>
           <tr id="el-input-hidden" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#hidden-state-(type=hidden)">`input type=hidden`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1388,9 +1384,9 @@
             </td>
           </tr>
           <tr id="el-input-image" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#image-button-state-(type=image)">`input type=image`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
@@ -1412,9 +1408,9 @@
             </td>
           </tr>
           <tr id="el-input-month" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#month-state-(type=month)">`input type=month`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1428,9 +1424,9 @@
             </td>
           </tr>
           <tr id="el-input-number" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#number-state-(type=number)">`input type=number`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-spinbutton">spinbutton</a></code>
             </td>
@@ -1445,9 +1441,9 @@
             </td>
           </tr>
           <tr id="el-input-password" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#password-state-(type=password)">`input type=password`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1461,10 +1457,10 @@
             </td>
           </tr>
           <tr id="el-input-radio" tabindex="-1">
-            <td>
+            <th>
               <a data-cite=
               "html/input.html#radio-button-state-(type=radio)">`input type=radio`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-radio">radio</a></code>
             </td>
@@ -1489,9 +1485,9 @@
             </td>
           </tr>
           <tr id="el-input-range" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#range-state-(type=range)">`input type=range`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-slider">slider</a></code>
             </td>
@@ -1500,7 +1496,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or <a href="#att-min">`aria-valuemin`</a> attributes on `input type=range` elements</a>.
+                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or <a href="#att-min">`aria-valuemin`</a> attributes on <a href="#el-input-range">`input type=range` elements</a>.
               </p>
               <p>
                 Otherwise, any <a href="#index-aria-global">global `aria-*` attributes</a> and
@@ -1509,9 +1505,9 @@
             </td>
           </tr>
           <tr id="el-input-reset" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#reset-button-state-(type=reset)">`input type=reset`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
@@ -1526,10 +1522,10 @@
             </td>
           </tr>
           <tr id="el-input-search" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=search`</a>,
               with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-searchbox">searchbox</a></code>
             </td>
@@ -1544,9 +1540,9 @@
             </td>
           </tr>
           <tr id="el-input-submit" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#submit-button-state-(type=submit)">`input type=submit`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
@@ -1561,11 +1557,11 @@
             </td>
           </tr>
           <tr id="el-input-tel" tabindex="-1">
-            <td>
+            <th>
               <a data-cite=
               "html/input.html#telephone-state-(type=tel)">`input type=tel`</a>,
               with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
@@ -1580,10 +1576,10 @@
             </td>
           </tr>
           <tr id="el-input-text" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>
               or with a missing or invalid `type`, with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
@@ -1601,7 +1597,7 @@
             </td>
           </tr>
           <tr id="el-input-text-list" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">
               `input type=text`</a>,
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">
@@ -1610,7 +1606,7 @@
               <a data-cite="html/input.html#url-state-(type=url)">`url`</a>,
               <a data-cite="html/input.html#e-mail-state-(type=email)">`email`</a>,
               or with a missing or invalid `type`, <strong>with a <a data-cite="html/input.html#attr-input-list">`list`</a> attribute</strong>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-combobox">combobox</a></code>
             </td>
@@ -1631,9 +1627,9 @@
             </td>
           </tr>
           <tr id="el-input-time" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#time-state-(type=time)">`input type=time`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1647,11 +1643,11 @@
             </td>
           </tr>
           <tr id="el-input-url" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#url-state-(type=url)">`input type=url`</a>
               with no
               <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
@@ -1666,9 +1662,9 @@
             </td>
           </tr>
           <tr id="el-input-week" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/input.html#week-state-(type=week)">`input type=week`</a>
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1682,9 +1678,9 @@
             </td>
           </tr>
           <tr id="el-ins" tabindex="-1">
-            <td>
+            <th>
               [^ins^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1700,9 +1696,9 @@
             </td>
           </tr>
           <tr id="el-kbd" tabindex="-1">
-            <td>
+            <th>
               [^kbd^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1718,9 +1714,9 @@
             </td>
           </tr>
           <tr id="el-label" tabindex="-1">
-            <td>
+            <th>
               [^label^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1734,9 +1730,9 @@
             </td>
           </tr>
           <tr id="el-legend" tabindex="-1">
-            <td>
+            <th>
               [^legend^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1750,9 +1746,9 @@
             </td>
           </tr>
           <tr id="el-li" tabindex="-1">
-            <td>
+            <th>
               [^li^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-listitem">listitem</a></code>
             </td>
@@ -1783,9 +1779,9 @@
             </td>
           </tr>
           <tr id="el-link" tabindex="-1">
-            <td>
+            <th>
               [^link^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1794,9 +1790,9 @@
             </td>
           </tr>
           <tr id="el-main" tabindex="-1">
-            <td>
+            <th>
               [^main^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-main">main</a></code>
             </td>
@@ -1811,9 +1807,9 @@
             </td>
           </tr>
           <tr id="el-map" tabindex="-1">
-            <td>
+            <th>
               [^map^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1822,9 +1818,9 @@
             </td>
           </tr>
           <tr id="el-math" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-math">math</a></code>
             </td>
@@ -1839,9 +1835,9 @@
             </td>
           </tr>
           <tr id="el-mark" tabindex="-1">
-            <td>
+            <th>
               [^mark^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1857,9 +1853,9 @@
             </td>
           </tr>
           <tr id="el-menu" tabindex="-1">
-            <td>
+            <th>
               [^menu^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
             </td>
@@ -1886,9 +1882,9 @@
             </td>
           </tr>
           <tr id="el-meta" tabindex="-1">
-            <td>
+            <th>
               [^meta^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1897,9 +1893,9 @@
             </td>
           </tr>
           <tr id="el-meter" tabindex="-1">
-            <td>
+            <th>
               [^meter^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1913,9 +1909,9 @@
             </td>
           </tr>
           <tr id="el-nav" tabindex="-1">
-            <td>
+            <th>
               [^nav^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-navigation">navigation</a></code>
             </td>
@@ -1943,9 +1939,9 @@
             </td>
           </tr>
           <tr id="el-noscript" tabindex="-1">
-            <td>
+            <th>
               [^noscript^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1954,9 +1950,9 @@
             </td>
           </tr>
           <tr id="el-object" tabindex="-1">
-            <td>
+            <th>
               [^object^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -1975,9 +1971,9 @@
             </td>
           </tr>
           <tr id="el-ol" tabindex="-1">
-            <td>
+            <th>
               [^ol^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
             </td>
@@ -2004,9 +2000,9 @@
             </td>
           </tr>
           <tr id="el-optgroup" tabindex="-1">
-            <td>
+            <th>
               [^optgroup^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-group">group</a></code>
             </td>
@@ -2021,11 +2017,11 @@
             </td>
           </tr>
           <tr id="el-option" tabindex="-1">
-            <td>
+            <th>
               [^option^] element that is in a <a data-cite=
               "html/input.html#attr-input-list">list of options</a> or that
               represents a suggestion in a [^datalist^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-option">option</a></code>
             </td>
@@ -2043,9 +2039,9 @@
             </td>
           </tr>
           <tr id="el-output" tabindex="-1">
-            <td>
+            <th>
               [^output^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-status">status</a></code>
             </td>
@@ -2061,9 +2057,9 @@
             </td>
           </tr>
           <tr id="el-p" tabindex="-1">
-            <td>
+            <th>
               [^p^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2079,9 +2075,9 @@
             </td>
           </tr>
           <tr id="el-param" tabindex="-1">
-            <td>
+            <th>
               [^param^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2090,9 +2086,9 @@
             </td>
           </tr>
           <tr id="el-picture" tabindex="-1">
-            <td>
+            <th>
               [^picture^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2101,9 +2097,9 @@
             </td>
           </tr>
           <tr id="el-pre" tabindex="-1">
-            <td>
+            <th>
               [^pre^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2119,9 +2115,9 @@
             </td>
           </tr>
           <tr id="el-progress" tabindex="-1">
-            <td>
+            <th>
               [^progress^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-progressbar">progressbar</a></code>
             </td>
@@ -2136,9 +2132,9 @@
             </td>
           </tr>
           <tr id="el-q" tabindex="-1">
-            <td>
+            <th>
               [^q^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2154,9 +2150,9 @@
             </td>
           </tr>
           <tr id="el-rp" tabindex="-1">
-            <td>
+            <th>
               [^rp^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2172,9 +2168,9 @@
             </td>
           </tr>
           <tr id="el-rt" tabindex="-1">
-            <td>
+            <th>
               [^rt^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2190,9 +2186,9 @@
             </td>
           </tr>
           <tr id="el-ruby" tabindex="-1">
-            <td>
+            <th>
               [^ruby^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2208,9 +2204,9 @@
             </td>
           </tr>
           <tr id="el-s" tabindex="-1">
-            <td>
+            <th>
               [^s^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2226,9 +2222,9 @@
             </td>
           </tr>
           <tr id="el-samp" tabindex="-1">
-            <td>
+            <th>
               [^samp^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2244,9 +2240,9 @@
             </td>
           </tr>
           <tr id="el-script" tabindex="-1">
-            <td>
+            <th>
               [^script^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2255,9 +2251,9 @@
             </td>
           </tr>
           <tr id="el-section" tabindex="-1">
-            <td>
+            <th>
               [^section^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-region">region</a></code> if the
               [^section^] element has an <a data-cite=
@@ -2326,10 +2322,10 @@
             </td>
           </tr>
           <tr id="el-select" tabindex="-1">
-            <td>
+            <th>
               [^select^] (with NO `multiple` attribute and NO `size`
               attribute having value greater than `1`)
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-combobox">combobox</a></code>
             </td>
@@ -2345,10 +2341,10 @@
             </td>
           </tr>
           <tr id="el-select-multiple-or-size-greater-1" tabindex="-1">
-            <td>
+            <th>
               [^select^] (with a `multiple` attribute or a `size` attribute
               having value greater than `1`)
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-list">listbox</a></code>
             </td>
@@ -2364,14 +2360,16 @@
             </td>
           </tr>
           <tr id="el-slot" tabindex="-1">
-            <td>[^slot^]</td>
+            <th>
+              [^slot^]
+            </th>
             <td><a>No corresponding role</a></td>
             <td><strong class="nosupport">No `role` or `aria-*` attributes</strong></td>
           </tr>
           <tr id="el-small" tabindex="-1">
-            <td>
+            <th>
               [^small^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2387,9 +2385,9 @@
             </td>
           </tr>
           <tr id="el-source" tabindex="-1">
-            <td>
+            <th>
               [^source^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2398,9 +2396,9 @@
             </td>
           </tr>
           <tr id="el-span" tabindex="-1">
-            <td>
+            <th>
               [^span^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2416,9 +2414,9 @@
             </td>
           </tr>
           <tr id="el-strong" tabindex="-1">
-            <td>
+            <th>
               [^strong^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2434,9 +2432,9 @@
             </td>
           </tr>
           <tr id="el-style" tabindex="-1">
-            <td>
+            <th>
               [^style^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2445,9 +2443,9 @@
             </td>
           </tr>
           <tr id="el-svg" tabindex="-1">
-            <td>
+            <th>
               <a data-cite="html/embedded-content-other.html#svg-0">`SVG`</a>
-            </td>
+            </th>
             <td>
               `role=graphics-document` as defined by
               <a data-cite="svg-aam-1.0/#details-id-66">SVG AAM</a>
@@ -2464,9 +2462,9 @@
             </td>
           </tr>
           <tr id="el-sub" tabindex="-1">
-            <td>
+            <th>
               [^sub^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2482,9 +2480,9 @@
             </td>
           </tr>
           <tr id="el-summary" tabindex="-1">
-            <td>
+            <th>
               [^summary^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
@@ -2499,9 +2497,9 @@
             </td>
           </tr>
           <tr id="el-sup" tabindex="-1">
-            <td>
+            <th>
               [^sup^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2517,9 +2515,9 @@
             </td>
           </tr>
           <tr id="el-table" tabindex="-1">
-            <td>
+            <th>
               [^table^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-table">table</a></code>
             </td>
@@ -2535,9 +2533,9 @@
             </td>
           </tr>
           <tr id="el-tbody" tabindex="-1">
-            <td>
+            <th>
               [^tbody^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
             </td>
@@ -2553,9 +2551,9 @@
             </td>
           </tr>
           <tr id="el-template" tabindex="-1">
-            <td>
+            <th>
               [^template^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2564,9 +2562,9 @@
             </td>
           </tr>
           <tr id="el-textarea" tabindex="-1">
-            <td>
+            <th>
               [^textarea^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
@@ -2581,9 +2579,9 @@
             </td>
           </tr>
           <tr id="el-tfoot" tabindex="-1">
-            <td>
+            <th>
               [^tfoot^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
             </td>
@@ -2599,9 +2597,9 @@
             </td>
           </tr>
           <tr id="el-thead" tabindex="-1">
-            <td>
+            <th>
               [^thead^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
             </td>
@@ -2617,9 +2615,9 @@
             </td>
           </tr>
           <tr id="el-time" tabindex="-1">
-            <td>
+            <th>
               [^time^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2635,9 +2633,9 @@
             </td>
           </tr>
           <tr id="el-title" tabindex="-1">
-            <td>
+            <th>
               [^title^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2646,9 +2644,9 @@
             </td>
           </tr>
           <tr id="el-td" tabindex="-1">
-            <td>
+            <th>
               [^td^]
-            </td>
+            </th>
             <td>
               <p>
                 <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
@@ -2673,9 +2671,9 @@
             </td>
           </tr>
           <tr id="el-th" tabindex="-1">
-            <td>
+            <th>
               [^th^]
-            </td>
+            </th>
             <td>
               <p>
                 If the ancestor `table` element is exposed as a `role=table`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
@@ -2702,9 +2700,9 @@
             </td>
           </tr>
           <tr id="el-tr" tabindex="-1">
-            <td>
+            <th>
               [^tr^]
-            </td>
+            </th>
             <td>
               <a href="#index-aria-row">`role=row`</a>
             </td>
@@ -2722,9 +2720,9 @@
             </td>
           </tr>
           <tr id="el-track" tabindex="-1">
-            <td>
+            <th>
               [^track^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2733,9 +2731,9 @@
             </td>
           </tr>
           <tr id="el-u" tabindex="-1">
-            <td>
+            <th>
               [^u^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2751,9 +2749,9 @@
             </td>
           </tr>
           <tr id="el-ul" tabindex="-1">
-            <td>
+            <th>
               [^ul^]
-            </td>
+            </th>
             <td>
               <code>role=<a href="#index-aria-list">list</a></code>
             </td>
@@ -2780,9 +2778,9 @@
             </td>
           </tr>
           <tr id="el-var" tabindex="-1">
-            <td>
+            <th>
               [^var^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2798,9 +2796,9 @@
             </td>
           </tr>
           <tr id="el-video" tabindex="-1">
-            <td>
+            <th>
               [^video^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -2815,9 +2813,9 @@
             </td>
           </tr>
           <tr id="el-wbr" tabindex="-1">
-            <td>
+            <th>
               [^wbr^]
-            </td>
+            </th>
             <td>
               <a>No corresponding role</a>
             </td>
@@ -3313,9 +3311,9 @@
         </thead>
         <tbody>
           <tr>
-            <td tabindex="-1" id="index-aria-global">
+            <th tabindex="-1" id="index-aria-global">
               any
-            </td>
+            </th>
             <td>
               ARIA <dfn>global states and properties</dfn> can be used on any
               HTML element.
@@ -3398,9 +3396,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-alert">
+            <th tabindex="-1" id="index-aria-alert">
               <a data-cite="wai-aria-1.1#alert">`alert`</a>
-            </td>
+            </th>
             <td>
               A type of live region with important, and usually
               time-sensitive, information. See related `alertdialog`
@@ -3420,9 +3418,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-alertdialog">
+            <th tabindex="-1" id="index-aria-alertdialog">
               <a data-cite="wai-aria-1.1#alertdialog">`alertdialog`</a>
-            </td>
+            </th>
             <td>
               A type of dialog that contains an alert message, where initial
               focus goes to an element within the dialog. See related
@@ -3449,9 +3447,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-application">
+            <th tabindex="-1" id="index-aria-application">
               <a data-cite="wai-aria-1.1#application">`application`</a>
-            </td>
+            </th>
             <td>
               A structure containing one or more focusable elements requiring
               user input, such as keyboard or gesture events, that do not
@@ -3478,9 +3476,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-article">
+            <th tabindex="-1" id="index-aria-article">
               <a data-cite="wai-aria-1.1#article">`article`</a>
-            </td>
+            </th>
             <td>
               A section of a page that consists of a composition that forms an
               independent part of a document, page, or site.
@@ -3501,9 +3499,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-banner">
+            <th tabindex="-1" id="index-aria-banner">
               <a data-cite="wai-aria-1.1#banner">`banner`</a>
-            </td>
+            </th>
             <td>
               A region that contains mostly site-oriented content, rather than
               page-specific content.
@@ -3525,9 +3523,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-button">
+            <th tabindex="-1" id="index-aria-button">
               <a data-cite="wai-aria-1.1#button">`button`</a>
-            </td>
+            </th>
             <td>
               An input that allows for user-triggered actions when clicked or
               pressed. See related `link`.
@@ -3555,9 +3553,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-checkbox">
+            <th tabindex="-1" id="index-aria-checkbox">
               <a data-cite="wai-aria-1.1#checkbox">`checkbox`</a>
-            </td>
+            </th>
             <td>
               A checkable input that has three possible values: true, false, or mixed.
             </td>
@@ -3577,9 +3575,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-cell">
+            <th tabindex="-1" id="index-aria-cell">
               <a data-cite="wai-aria-1.1#cell">`cell`</a>
-            </td>
+            </th>
             <td>
               A cell in a tabular container.
             </td>
@@ -3610,9 +3608,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-columnheader">
+            <th tabindex="-1" id="index-aria-columnheader">
               <a data-cite="wai-aria-1.1#columnheader">`columnheader`</a>
-            </td>
+            </th>
             <td>
               A cell containing header information for a column.
             </td>
@@ -3658,9 +3656,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-combobox">
+            <th tabindex="-1" id="index-aria-combobox">
               <a data-cite="wai-aria-1.1#combobox">`combobox`</a>
-            </td>
+            </th>
             <td>
               A presentation of a select; usually similar to a textbox where
               users can type ahead to select an option, or type to enter
@@ -3700,9 +3698,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-complementary">
+            <th tabindex="-1" id="index-aria-complementary">
               <a data-cite="wai-aria-1.1#complementary">`complementary`</a>
-            </td>
+            </th>
             <td>
               A supporting section of the document, designed to be
               complementary to the main content at a similar level in the DOM
@@ -3724,9 +3722,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-contentinfo">
+            <th tabindex="-1" id="index-aria-contentinfo">
               <a data-cite="wai-aria-1.1#contentinfo">`contentinfo`</a>
-            </td>
+            </th>
             <td>
               A large perceivable region that contains information about the
               parent document.
@@ -3749,9 +3747,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-definition">
+            <th tabindex="-1" id="index-aria-definition">
               <a data-cite="wai-aria-1.1#definition">`definition`</a>
-            </td>
+            </th>
             <td>
               A definition of a term or concept.
             </td>
@@ -3771,9 +3769,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-dialog">
+            <th tabindex="-1" id="index-aria-dialog">
               <a data-cite="wai-aria-1.1#dialog">`dialog`</a>
-            </td>
+            </th>
             <td>
               A dialog is an application window that is designed to interrupt
               the current processing of an application in order to prompt the
@@ -3800,9 +3798,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-directory">
+            <th tabindex="-1" id="index-aria-directory">
               <a data-cite="wai-aria-1.1#directory">`directory`</a>
-            </td>
+            </th>
             <td>
               A list of references to members of a group, such as a static
               table of contents.
@@ -3821,9 +3819,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-document">
+            <th tabindex="-1" id="index-aria-document">
              <a data-cite="wai-aria-1.1#document">`document`</a>
-            </td>
+            </th>
             <td>
               A region containing related information that is declared as
               document content, as opposed to a web application.
@@ -3844,9 +3842,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-feed">
+            <th tabindex="-1" id="index-aria-feed">
               <a data-cite="wai-aria-1.1#feed">`feed`</a>
-            </td>
+            </th>
             <td>
               A scrollable list of articles where scrolling may cause articles
               to be added to or removed from either end of the list.
@@ -3865,9 +3863,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-figure">
+            <th tabindex="-1" id="index-aria-figure">
               <a data-cite="wai-aria-1.1#figure">`figure`</a>
-            </td>
+            </th>
             <td>
               A perceivable section of content that typically contains a
               graphical document, images, code snippets, or example text.
@@ -3886,9 +3884,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-form">
+            <th tabindex="-1" id="index-aria-form">
               <a data-cite="wai-aria-1.1#form">`form`</a>
-            </td>
+            </th>
             <td>
               A landmark region that contains a collection of items and objects
               that, as a whole, combine to create a form. See related `search`.
@@ -3909,9 +3907,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-grid">
+            <th tabindex="-1" id="index-aria-grid">
               <a data-cite="wai-aria-1.1#grid">`grid`</a>
-            </td>
+            </th>
             <td>
               A grid is an interactive control which contains cells of tabular
               data arranged in rows and columns, like a table.
@@ -3957,9 +3955,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-gridcell">
+            <th tabindex="-1" id="index-aria-gridcell">
               <a data-cite="wai-aria-1.1#gridcell">`gridcell`</a>
-            </td>
+            </th>
             <td>
               A cell in a `grid` or `treegrid`.
             </td>
@@ -4007,9 +4005,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-group">
+            <th tabindex="-1" id="index-aria-group">
               <a data-cite="wai-aria-1.1#group">`group`</a>
-            </td>
+            </th>
             <td>
               A set of user interface objects which are not intended to be
               included in a page summary or table of contents by assistive technologies.
@@ -4035,9 +4033,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-heading">
+            <th tabindex="-1" id="index-aria-heading">
               <a data-cite="wai-aria-1.1#heading">`heading`</a>
-            </td>
+            </th>
             <td>
               A heading for a section of the page.
             </td>
@@ -4065,9 +4063,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-img">
+            <th tabindex="-1" id="index-aria-img">
               <a data-cite="wai-aria-1.1#img">`img`</a>
-            </td>
+            </th>
             <td>
               A container for a collection of elements that form an image.
             </td>
@@ -4087,9 +4085,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-link">
+            <th tabindex="-1" id="index-aria-link">
               <a data-cite="wai-aria-1.1#link">`link`</a>
-            </td>
+            </th>
             <td>
               An interactive reference to an internal or external resource
               that, when activated, causes the user agent to navigate to that
@@ -4114,9 +4112,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-list">
+            <th tabindex="-1" id="index-aria-list">
               <a data-cite="wai-aria-1.1#list">`list`</a>
-            </td>
+            </th>
             <td>
               A group of non-interactive list items. See related `listbox`.
             </td>
@@ -4136,9 +4134,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-listbox">
+            <th tabindex="-1" id="index-aria-listbox">
               <a data-cite="wai-aria-1.1#listbox">`listbox`</a>
-            </td>
+            </th>
             <td>
               A widget that allows the user to select one or more items from a
               list of choices. See related `combobox` and `list`.
@@ -4178,9 +4176,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-listitem">
+            <th tabindex="-1" id="index-aria-listitem">
               <a data-cite="wai-aria-1.1#listitem">`listitem`</a>
-            </td>
+            </th>
             <td>
               A single item in a `list` or `directory`.
             </td>
@@ -4211,9 +4209,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-log">
+            <th tabindex="-1" id="index-aria-log">
               <a data-cite="wai-aria-1.1#log">`log`</a>
-            </td>
+            </th>
             <td>
               A type of live region where new information is added in meaningful
               order and old information may disappear. See related `marquee`.
@@ -4234,9 +4232,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-main">
+            <th tabindex="-1" id="index-aria-main">
               <code><a data-cite="wai-aria-1.1#main">main</a></code>
-            </td>
+            </th>
             <td>
               The main content of a document.
             </td>
@@ -4257,9 +4255,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-marquee">
+            <th tabindex="-1" id="index-aria-marquee">
               <a data-cite="wai-aria-1.1#marquee">`marquee`</a>
-            </td>
+            </th>
             <td>
               A type of live region where non-essential information changes
               frequently. See related `log`.
@@ -4280,9 +4278,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-math">
+            <th tabindex="-1" id="index-aria-math">
               <a data-cite="wai-aria-1.1#math">`math`</a>
-            </td>
+            </th>
             <td>
               Content that represents a mathematical expression.
             </td>
@@ -4302,9 +4300,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-menu">
+            <th tabindex="-1" id="index-aria-menu">
               <a data-cite="wai-aria-1.1#menu">`menu`</a>
-            </td>
+            </th>
             <td>
               A type of widget that offers a list of choices to the user.
             </td>
@@ -4337,9 +4335,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-menubar">
+            <th tabindex="-1" id="index-aria-menubar">
               <a data-cite="wai-aria-1.1#menubar">`menubar`</a>
-            </td>
+            </th>
             <td>
               A presentation of menu that usually remains visible and is
               usually presented horizontally.
@@ -4373,9 +4371,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-menuitem">
+            <th tabindex="-1" id="index-aria-menuitem">
               <a data-cite="wai-aria-1.1#menuitem">`menuitem`</a>
-            </td>
+            </th>
             <td>
               An option in a group of choices contained by a `menu` or `menubar`.
             </td>
@@ -4403,9 +4401,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-menuitemcheckbox">
+            <th tabindex="-1" id="index-aria-menuitemcheckbox">
               <a data-cite="wai-aria-1.1#menuitemcheckbox">`menuitemcheckbox`</a>
-            </td>
+            </th>
             <td>
               A checkable menuitem that has three possible values: true, false,
               or mixed.
@@ -4434,9 +4432,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-menuitemradio">
+            <th tabindex="-1" id="index-aria-menuitemradio">
               <a data-cite="wai-aria-1.1#menuitemradio">`menuitemradio`</a>
-            </td>
+            </th>
             <td>
               A checkable `menuitem` in a group of `menuitemradio`
               roles, only one of which can be checked at a time.
@@ -4464,9 +4462,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-navigation">
+            <th tabindex="-1" id="index-aria-navigation">
               <a data-cite="wai-aria-1.1#navigation">`navigation`</a>
-            </td>
+            </th>
             <td>
               A collection of navigational elements (usually links) for
               navigating the document or related documents.
@@ -4488,9 +4486,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-none">
+            <th tabindex="-1" id="index-aria-none">
               <a data-cite="wai-aria-1.1#none">`none`</a>
-            </td>
+            </th>
             <td>
               An element whose implicit native role semantics will not be
               mapped to the accessibility
@@ -4510,9 +4508,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-note">
+            <th tabindex="-1" id="index-aria-note">
               <a data-cite="wai-aria-1.1#note">`note`</a>
-            </td>
+            </th>
             <td>
               A section whose content is parenthetic or ancillary to the main
               content of the resource.
@@ -4533,9 +4531,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-option">
+            <th tabindex="-1" id="index-aria-option">
               <a data-cite="wai-aria-1.1#option">`option`</a>
-            </td>
+            </th>
             <td>
               A selectable item in a select list.
             </td>
@@ -4569,9 +4567,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-presentation">
+            <th tabindex="-1" id="index-aria-presentation">
               <a data-cite="wai-aria-1.1#presentation">`presentation`</a>
-            </td>
+            </th>
             <td>
               An element whose implicit native role semantics will not be
               mapped to the accessibility API.
@@ -4588,9 +4586,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-progressbar">
+            <th tabindex="-1" id="index-aria-progressbar">
               <a data-cite="wai-aria-1.1#progressbar">`progressbar`</a>
-            </td>
+            </th>
             <td>
               An element that displays the progress status for tasks that take
               a long time.
@@ -4622,9 +4620,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-radio">
+            <th tabindex="-1" id="index-aria-radio">
               <a data-cite="wai-aria-1.1#radio">`radio`</a>
-            </td>
+            </th>
             <td>
               A checkable input in a group of radio roles, only one of which
               can be checked at a time.
@@ -4656,9 +4654,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-radiogroup">
+            <th tabindex="-1" id="index-aria-radiogroup">
               <a data-cite="wai-aria-1.1#radiogroup">`radiogroup`</a>
-            </td>
+            </th>
             <td>
               A group of radio buttons.
             </td>
@@ -4689,9 +4687,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-region">
+            <th tabindex="-1" id="index-aria-region">
               <a data-cite="wai-aria-1.1#region">`region`</a>
-            </td>
+            </th>
             <td>
               A large perceivable section of a web page or document, that the
               author feels is important enough to be included in a page summary
@@ -4714,9 +4712,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-row">
+            <th tabindex="-1" id="index-aria-row">
               <a data-cite="wai-aria-1.1#row">`row`</a>
-            </td>
+            </th>
             <td>
               <p>
                 A row of cells in a tabular container.
@@ -4765,9 +4763,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-rowgroup">
+            <th tabindex="-1" id="index-aria-rowgroup">
               <a data-cite="wai-aria-1.1#rowgroup">`rowgroup`</a>
-            </td>
+            </th>
             <td>
               A group containing one or more row elements in a grid.
             </td>
@@ -4785,9 +4783,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-rowheader">
+            <th tabindex="-1" id="index-aria-rowheader">
               <a data-cite="wai-aria-1.1#rowheader">`rowheader`</a>
-            </td>
+            </th>
             <td>
               A cell containing header information for a row in a grid.
             </td>
@@ -4830,9 +4828,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-scrollbar">
+            <th tabindex="-1" id="index-aria-scrollbar">
               <a data-cite="wai-aria-1.1#scrollbar">`scrollbar`</a>
-            </td>
+            </th>
             <td>
               A graphical object that controls the scrolling of content within
               a viewing area, regardless of whether the content is fully
@@ -4880,9 +4878,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-search">
+            <th tabindex="-1" id="index-aria-search">
               <a data-cite="wai-aria-1.1#search">`search`</a>
-            </td>
+            </th>
             <td>
               A landmark region that contains a collection of items and objects
               that, as a whole, combine to create a search facility. See
@@ -4904,9 +4902,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-searchbox">
+            <th tabindex="-1" id="index-aria-searchbox">
               <a data-cite="wai-aria-1.1#searchbox">`searchbox`</a>
-            </td>
+            </th>
             <td>
               A type of textbox intended for specifying search criteria.
             </td>
@@ -4946,9 +4944,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-separator">
+            <th tabindex="-1" id="index-aria-separator">
               <a data-cite="wai-aria-1.1#separator">`separator`</a>
-            </td>
+            </th>
             <td>
               A divider that separates and distinguishes sections of content or
               groups of menuitems.
@@ -4990,9 +4988,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-slider">
+            <th tabindex="-1" id="index-aria-slider">
               <a data-cite="wai-aria-1.1#slider">`slider`</a>
-            </td>
+            </th>
             <td>
               A user input where the user selects a value from within a given range.
             </td>
@@ -5027,9 +5025,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-spinbutton">
+            <th tabindex="-1" id="index-aria-spinbutton">
               <a data-cite="wai-aria-1.1#spinbutton">`spinbutton`</a>
-            </td>
+            </th>
             <td>
               A form of range that expects the user to select from among discrete choices.
             </td>
@@ -5072,9 +5070,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-status">
+            <th tabindex="-1" id="index-aria-status">
               <a data-cite="wai-aria-1.1#status">`status`</a>
-            </td>
+            </th>
             <td>
               A container whose content is advisory information for the user
               but is not important enough to justify an alert, often but not
@@ -5098,9 +5096,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-switch">
+            <th tabindex="-1" id="index-aria-switch">
               <a data-cite="wai-aria-1.1#switch">`switch`</a>
-            </td>
+            </th>
             <td>
               A type of checkbox that represents on/off values, as opposed to
               checked/unchecked values.
@@ -5123,9 +5121,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-tab">
+            <th tabindex="-1" id="index-aria-tab">
               <a data-cite="wai-aria-1.1#tab">`tab`</a>
-            </td>
+            </th>
             <td>
               A grouping label providing a mechanism for selecting the tab
               content that is to be rendered to the user.
@@ -5161,9 +5159,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-table">
+            <th tabindex="-1" id="index-aria-table">
               <a data-cite="wai-aria-1.1#table">`table`</a>
-            </td>
+            </th>
             <td>
               A section containing data arranged in rows and columns. The table
               role is intended for tabular containers which are not interactive.
@@ -5189,9 +5187,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-tablist">
+            <th tabindex="-1" id="index-aria-tablist">
               <a data-cite="wai-aria-1.1#tablist">`tablist`</a>
-            </td>
+            </th>
             <td>
               A list of `tab` elements, which are references to `tabpanel` elements.
             </td>
@@ -5222,9 +5220,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-tabpanel">
+            <th tabindex="-1" id="index-aria-tabpanel">
               <a data-cite="wai-aria-1.1#tabpanel">`tabpanel`</a>
-            </td>
+            </th>
             <td>
               A container for the resources associated with a `tab`,
               where each `tab` is contained in a `tablist`.
@@ -5245,9 +5243,9 @@
             </td>
           </tr>
           <tr>
-            <td id="index-aria-term" tabindex="-1">
+            <th id="index-aria-term" tabindex="-1">
               <a data-cite="wai-aria-1.1#term">`term`</a>
-            </td>
+            </th>
             <td>
               A word or phrase with a corresponding definition. See related
               <a href="#index-aria-definition">`definition`</a>.
@@ -5266,9 +5264,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-textbox">
+            <th tabindex="-1" id="index-aria-textbox">
               <a data-cite="wai-aria-1.1#textbox">`textbox`</a>
-            </td>
+            </th>
             <td>
               Input that allows free-form text as its value.
             </td>
@@ -5308,9 +5306,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-timer">
+            <th tabindex="-1" id="index-aria-timer">
               <a data-cite="wai-aria-1.1#timer">`timer`</a>
-            </td>
+            </th>
             <td>
               A type of live region containing a numerical counter which
               indicates an amount of elapsed time from a start point, or the
@@ -5332,9 +5330,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-toolbar">
+            <th tabindex="-1" id="index-aria-toolbar">
               <a data-cite="wai-aria-1.1#toolbar">`toolbar`</a>
-            </td>
+            </th>
             <td>
               A collection of commonly used function buttons represented in
               compact visual form.
@@ -5363,9 +5361,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-tooltip">
+            <th tabindex="-1" id="index-aria-tooltip">
               <a data-cite="wai-aria-1.1#tooltip">`tooltip`</a>
-            </td>
+            </th>
             <td>
               A contextual pop-up that displays a description for an element.
             </td>
@@ -5385,9 +5383,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-tree">
+            <th tabindex="-1" id="index-aria-tree">
               <code><a data-cite="wai-aria-1.1#tree">tree</a></code>
-            </td>
+            </th>
             <td>
               A type of list that may contain sub-level nested groups that can
               be collapsed and expanded.
@@ -5422,9 +5420,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-treegrid">
+            <th tabindex="-1" id="index-aria-treegrid">
               <a data-cite="wai-aria-1.1#treegrid">`treegrid`</a>
-            </td>
+            </th>
             <td>
               A grid whose rows can be expanded and collapsed in the same
               manner as for a tree.
@@ -5471,9 +5469,9 @@
             </td>
           </tr>
           <tr>
-            <td tabindex="-1" id="index-aria-treeitem">
+            <th tabindex="-1" id="index-aria-treeitem">
               <a data-cite="wai-aria-1.1#treeitem">`treeitem`</a>
-            </td>
+            </th>
             <td>
               An option item of a tree. This is an element within a tree that
               may be expanded or collapsed if it contains a sub-level group of treeitems.


### PR DESCRIPTION
- make sure each `<tr>` starts with a `<th>`
- a few stray bits of broken markup/unclosed elements

Closes https://github.com/w3c/html-aria/issues/268


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/269.html" title="Last updated on Feb 26, 2021, 11:17 PM UTC (e89d3d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/269/d382ab9...e89d3d0.html" title="Last updated on Feb 26, 2021, 11:17 PM UTC (e89d3d0)">Diff</a>