### PR TITLE
chore: remove more data-cite= usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -2868,7 +2868,7 @@
         represented in roles, states and properties not provided by ARIA, and
         exposed to users of assistive technology via accessibility APIs. It is
         therefore recommended that developers add a `role` attribute to a
-        semantically neutral element such as a `div` or `span`, rather than
+        semantically neutral element such as a [^div^] or [^span^], rather than
         overriding the semantics of the listed elements.
       </p>
       <div class="note">
@@ -2881,8 +2881,8 @@
           add accessibility information to HTML elements using the Accessible
           Rich Internet Applications specification (ARIA 1.1).
           </li>
-          <li>[[[wai-aria-practices-1.2]]] - An author's guide to understanding
-          and implementing Accessible Rich Internet Applications.
+          <li>[[[wai-aria-practices-1.2]]] - A developer's guide to
+            understanding and implementing Accessible Rich Internet Applications.
           </li>
         </ul>
       </div>
@@ -2920,7 +2920,7 @@
         Document conformance requirements for use of ARIA attributes with HTML attributes
       </h3>
       <p>
-        Unless otherwise stated, developers MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, developers MAY use `aria-disabled=true` on a `button` element, rather than the `disabled` attribute. However, developers SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
+        Unless otherwise stated, developers MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, developers MAY use `aria-disabled=true` on a [^button^] element, rather than the `disabled` attribute. However, developers SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
         <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
         user agents MUST ignore WAI-ARIA attributes and use the host language
         (HTML) attribute with the same <a>implicit ARIA semantics</a>.
@@ -3045,7 +3045,7 @@
           </tr>
           <tr id="att-max" tabindex="-1">
             <th>
-              Any element where the `max` attribute is allowed: `meter` [^meter/max^], `progress` [^progress/max^], and `input` [^input/max^]. 
+              Any element where the `max` attribute is allowed: `meter` [^meter/max^], `progress` [^progress/max^], and `input` [^input/max^].
             </th>
             <td>
               `aria-valuemax="..."`
@@ -3296,15 +3296,15 @@
 &lt;!-- conformance checkers will report an error --&gt;
 
 <mark>&lt;button&gt;</mark>
-&lt;div <mark>role="button"</mark>&gt;...&lt;/div&gt;
+  &lt;div <mark>role="button"</mark>&gt;...&lt;/div&gt;
 &lt;/button&gt;
 
 &lt;div <mark>role="button"</mark>&gt;
-&lt;button&gt;...&lt;/button&gt;
+  &lt;button&gt;...&lt;/button&gt;
 &lt;/div&gt;
 
 &lt;div <mark>role="link"</mark>&gt;
-&lt;textarea&gt;...&lt;/textarea&gt;
+  &lt;textarea&gt;...&lt;/textarea&gt;
 &lt;/div&gt;
 </pre>
       </div>

--- a/index.html
+++ b/index.html
@@ -91,8 +91,8 @@
         unnecessary and can potentially lead to unintended consequences.
       </p>
       <aside class="example">
-        The following uses a `role=heading` on a `button` element. This is not
-        allowed, because the `button` element has default characteristics that
+        The following uses a `role=heading` on a [^button^] element. This is not
+        allowed, because the [^button^] element has default characteristics that
         conflict with the heading role.
         <pre class="HTML">
           &lt;button role="heading"&gt;search&lt;/button&gt;
@@ -100,7 +100,7 @@
       </aside>
 
       <aside class="example">
-        The following uses a `role=button` on a `button` element. This is
+        The following uses a `role=button` on a [^button^] element. This is
         unnecessary, as "button" is already exposed as the implicit role for
         the element. In practice this redundancy will likely not have any
         unforeseen side effects, other than unnecessarily making the markup
@@ -156,7 +156,7 @@
         The following table provides normative per-element document-conformance
         requirements for the use of ARIA markup in HTML documents and describes
         the <a>implicit ARIA semantics</a> that apply to
-        <a data-cite="html/dom.html#elements">HTML elements</a> as defined in [[html-aam-1.0|HTML AAM]].
+        [=HTML elements=] as defined in [[html-aam-1.0|HTML AAM]].
       </p>
       <p>
         Each language feature (element) in a cell in the first column implies
@@ -204,7 +204,7 @@
           <tr id="el-a" tabindex="-1">
             <th>
               [^a^] with
-              <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
+              [^a/href^]
             </th>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
@@ -242,7 +242,7 @@
           </tr>
           <tr id="el-a-no-href" tabindex="-1">
             <th>
-              [^a^] without <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
+              [^a^] without [^a/href^]
             </th>
             <td>
               <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn">No corresponding role</a>
@@ -296,7 +296,7 @@
           </tr>
           <tr id="el-area" tabindex="-1">
             <th>
-              [^area^] with <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
+              [^area^] with [^area/href^]
             </th>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
@@ -314,7 +314,7 @@
           </tr>
           <tr id="el-area-no-href" tabindex="-1">
             <th>
-              [^area^] without <a data-cite="html/links.html#attr-hyperlink-href">`href`</a>
+              [^area^] without [^area/href^]
             </th>
             <td><a>No corresponding role</a></td>
             <td>
@@ -1214,7 +1214,7 @@
           <tr id="el-img-empty-alt" tabindex="-1">
             <th>
               [^img^] with
-              <code><a data-cite="html/embedded-content.html#attr-img-alt">alt</a>=""</code>
+              [^img/alt^]`=""`
             </th>
             <td>
               <a>No corresponding role</a>
@@ -1226,7 +1226,7 @@
           </tr>
           <tr id="el-img-no-alt" tabindex="-1">
             <th>
-              [^img^] without <code><a data-cite="html/images.html#unknown-images">alt</a></code> attribute
+              [^img^] without [^img/alt^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-img">img</a></code>
@@ -1293,9 +1293,9 @@
                 any `aria-*` attributes applicable to the allowed roles and
                 implied role (if any).
               </p>
-              <p>
-                <strong>Note:</strong> the HTML
-                <a data-cite="html/input.html#attr-input-checked">`checked`</a>
+              <p class="note">
+                The HTML
+                [^input/checked^]
                 attribute can be used instead of the `aria-checked`
                 attribute for `menuitemcheckbox`, `option` or `switch`
                 when used on `type=checkbox`.
@@ -1355,8 +1355,7 @@
           <tr id="el-input-email" tabindex="-1">
             <th>
               <a data-cite="html/input.html#e-mail-state-(type=email)">`input type=email`</a>
-              with no
-              <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
+              with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-checkbox">textbox</a></code>
@@ -1540,7 +1539,7 @@
           <tr id="el-input-search" tabindex="-1">
             <th>
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=search`</a>,
-              with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
+              with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-searchbox">searchbox</a></code>
@@ -1574,7 +1573,7 @@
           </tr>
           <tr id="el-input-tel" tabindex="-1">
             <th>
-              <a data-cite="html/input.html#telephone-state-(type=tel)">`input type=tel`</a>, with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
+              <a data-cite="html/input.html#telephone-state-(type=tel)">`input type=tel`</a>, with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -1592,7 +1591,7 @@
           <tr id="el-input-text" tabindex="-1">
             <th>
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>
-              or with a missing or invalid `type`, with no <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
+              or with a missing or invalid `type`, with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -1617,7 +1616,7 @@
               <a data-cite="html/input.html#telephone-state-(type=tel)">`tel`</a>,
               <a data-cite="html/input.html#url-state-(type=url)">`url`</a>,
               <a data-cite="html/input.html#e-mail-state-(type=email)">`email`</a>,
-              or with a missing or invalid `type`, <strong>with a <a data-cite="html/input.html#attr-input-list">`list`</a> attribute</strong>
+              or with a missing or invalid `type`, <strong>with a [^input/list^] attribute</strong>
             </th>
             <td>
               <code>role=<a href="#index-aria-combobox">combobox</a></code>
@@ -1659,7 +1658,7 @@
             <th>
               <a data-cite="html/input.html#url-state-(type=url)">`input type=url`</a>
               with no
-              <a data-cite="html/input.html#attr-input-list">`list`</a> attribute
+              [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -2902,7 +2901,7 @@
         Document conformance requirements for use of ARIA attributes with HTML attributes
       </h3>
       <p>
-        Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a `button` element, rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
+        Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a [^button^] element, rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
         <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
         user agents MUST ignore WAI-ARIA attributes and use the host language
         (HTML) attribute with the same <a>implicit ARIA semantics</a>.
@@ -2940,8 +2939,7 @@
         <tbody>
           <tr id="att-checked" tabindex="-1">
             <th>
-              Any element where the <a data-cite="html/input.html#attr-input-checked">`checked`</a>
-              attribute is allowed
+              Any element where the [^input/checked^] attribute is allowed
             </th>
             <td>
               `aria-checked="true"`
@@ -2984,8 +2982,7 @@
           </tr>
           <tr id="att-hidden" tabindex="-1">
             <th>
-              Any element with a <a data-cite="html/interaction.html#the-hidden-attribute">`hidden`</a>
-              attribute
+              Any element with a [^html-global/hidden^] attribute
             </th>
             <td>
               `aria-hidden="true"`
@@ -3029,8 +3026,7 @@
           </tr>
           <tr id="att-max" tabindex="-1">
             <th>
-              Any element where the <a data-cite="html/input.html#attr-input-max">`max`</a>
-              attribute is allowed
+              Any element where the `max` attribute is allowed: `meter` [^meter/max^], `progress` [^progress/max^], and `input` [^input/max^]. 
             </th>
             <td>
               `aria-valuemax="..."`
@@ -3038,7 +3034,7 @@
             <td>
               <p>
                 Use the `max` attribute on any element that is
-                <a data-cite="html/input.html#attr-input-max">allowed the `max` attribute</a> in HTML. It is NOT RECOMMENDED to use the <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax` attribute</a> on these elements.
+                allowed the `max` attribute in HTML. It is NOT RECOMMENDED to use the <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax` attribute</a> on these elements.
               </p>
               <p>
                 Authors MAY use the `aria-valuemax` attribute on any other element with a WAI-ARIA role which allows the  attribute.
@@ -3053,8 +3049,7 @@
           </tr>
           <tr id="att-min" tabindex="-1">
             <th>
-              Any element where the <a data-cite="html/input.html#attr-input-min">`min`</a>
-              attribute is allowed
+              Any element where the `min` attribute is allowed: `meter` [^meter/min^] and `input` [^input/min^]
             </th>
             <td>
               `aria-valuemin="..."`
@@ -3062,7 +3057,7 @@
             <td>
               <p>
                 Use the `min` attribute on any element that is
-                <a data-cite="html/input.html#attr-input-min">allowed the `min` attribute</a> in HTML. It is NOT RECOMMENDED to use the <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin` attribute</a> on these elements.
+                allowed the `min` attribute in HTML. It is NOT RECOMMENDED to use the <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin` attribute</a> on these elements.
               </p>
               <p>
                 Authors MAY use the `aria-valuemin` attribute on any other element with a WAI-ARIA role which allows the  attribute.
@@ -3077,8 +3072,8 @@
           </tr>
           <tr id="att-readonly" tabindex="-1">
             <th>
-              Any element where the <a data-cite="html/input.html#attr-input-readonly">`readonly`</a>
-              attribute is allowed
+              Any element where the `readonly`
+              attribute is allowed: [^face/readonly^],
             </th>
             <td>
               `aria-readonly="true"`
@@ -3173,8 +3168,7 @@
           </tr>
           <tr id="att-rowspan" tabindex="-1">
             <th>
-              Any element where the <a data-cite="html/tables.html#attr-tdth-rowspan">`rowspan`</a>
-              attribute is allowed
+              `td` [^td/rowspan^] and `th` [^th/rowspan^]
             </th>
             <td>
               `aria-rowspan="..."`
@@ -3273,9 +3267,8 @@
         explicit `role` value.
       </p>
       <p>
-        For example, a `button` element has an implicit
-        `role=button`. A `button` element allows <a data-cite="html/dom.html#phrasing-content">phrasing content</a> as descendants and does not allow <a data-cite=
-        "html/dom.html#interactive-content-2">interactive content</a> or descendants with a `tabindex` attribute.  Therefore, any elements specified with a `role=button` also MUST NOT allow any interactive content descendants, elements with a `tabindex` specified or any elements with role values that are in the interactive content category (identified in
+        For example, a [^button^] element has an implicit
+        `role=button`. A [^button^] element allows [=phrasing content=] as descendants and does not allow [=interactive content=] or descendants with a `tabindex` attribute.  Therefore, any elements specified with a `role=button` also MUST NOT allow any interactive content descendants, elements with a `tabindex` specified or any elements with role values that are in the interactive content category (identified in
         Column 3).
       </p>
       <div class="example" id="bad-descendants">
@@ -3426,10 +3419,10 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3455,10 +3448,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3484,10 +3477,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3507,7 +3500,7 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
               No <a>main</a> element descendants.
@@ -3533,7 +3526,7 @@
             <td>
               no <a>main</a> element descendants, or <a>header</a>,
               <a>footer</a> elements that are not descendants of
-              <a data-cite="html/dom.html#sectioning-content-2">sectioning content</a>
+              [=sectioning content=]
               which is a descendant of the <a>header</a>.
             </td>
           </tr>
@@ -3559,10 +3552,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-               <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>,
+               [=Phrasing content=],
               but there must be no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a> descendant.
             </td>
@@ -3581,12 +3574,11 @@
               <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-               <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>,
-              but there must be no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a> descendant.
+               [=Phrasing content=],
+              but there must be no [=interactive content=] descendant.
             </td>
           </tr>
           <tr>
@@ -3616,10 +3608,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3664,10 +3656,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3706,10 +3698,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3729,10 +3721,10 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+              [=Flow content=], but
               with no <a>main</a> element descendants.
             </td>
           </tr>
@@ -3751,13 +3743,12 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+              [=Flow content=], but
               with no <a>main</a> element descendants, or <a>header</a>,
-              <a>footer</a> elements that are not descendants of <a data-cite=
-              "html/dom.html#sectioning-content-2">sectioning content</a> which
+              <a>footer</a> elements that are not descendants of [=sectioning content=] which
               is a descendant of the <a>header</a>.
             </td>
           </tr>
@@ -3777,10 +3768,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+              [=Phrasing content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+              [=Phrasing content=]
             </td>
           </tr>
           <tr>
@@ -3806,10 +3797,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3827,10 +3818,10 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3850,10 +3841,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3871,10 +3862,10 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3892,10 +3883,10 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3915,10 +3906,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -3959,14 +3950,14 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+                [=Interactive content=]
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4009,14 +4000,14 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+                [=Interactive content=]
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4041,10 +4032,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4071,9 +4062,9 @@
               <a data-cite="html/dom.html#heading-content">Heading content</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+              [=Flow content=], but
               with no <a data-cite="html/dom.html#heading-content">Heading content</a>,
-              <a data-cite="html/dom.html#sectioning-content-2">Sectioning content</a>,
+              [=Sectioning content=],
               <a data-cite="html/sections.html#sectioning-root">Sectioning roots</a>.
             </td>
           </tr>
@@ -4093,10 +4084,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+              [=Phrasing content=]
             </td>
           </tr>
           <tr>
@@ -4117,10 +4108,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+              [=Flow content=], but
               with no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a> or
               <a>a</a> element descendants.
@@ -4142,10 +4133,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4180,14 +4171,14 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+                [=Interactive content=]
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4217,10 +4208,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4240,10 +4231,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4262,10 +4253,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+              [=Flow content=], but
               with no <a>main</a> element descendants
             </td>
           </tr>
@@ -4286,10 +4277,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4308,10 +4299,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4339,14 +4330,14 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+                [=Interactive content=]
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4375,14 +4366,14 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+                [=Interactive content=]
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4406,10 +4397,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-               <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+               [=Flow content=], but
               with no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a>
               descendants.
@@ -4437,10 +4428,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-               <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>, but
+               [=Phrasing content=], but
               with no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a>
               descendants.
@@ -4468,9 +4459,9 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
-            <td> <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>, but
+            <td> [=Phrasing content=], but
               with no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a>
               descendants.
@@ -4493,10 +4484,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+              [=Flow content=], but
               with no <a>main</a> element descendants
             </td>
           </tr>
@@ -4516,10 +4507,10 @@
             <td>&nbsp;
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4539,10 +4530,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4572,10 +4563,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>, but
+              [=Phrasing content=], but
               with no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a>
               descendants.
@@ -4594,10 +4585,10 @@
             </td>
             <td></td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4628,10 +4619,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+              [=Phrasing content=]
             </td>
           </tr>
           <tr>
@@ -4659,10 +4650,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-             <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>, but
+             [=Phrasing content=], but
               with no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a>
               descendants.
@@ -4695,10 +4686,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4720,10 +4711,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4774,7 +4765,7 @@
               none
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4794,7 +4785,7 @@
               none
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4839,7 +4830,7 @@
               none
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4882,14 +4873,14 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+                [=Interactive content=]
               </p>
             </td>
             <td>
-             <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+             [=Phrasing content=]
             </td>
           </tr>
           <tr>
@@ -4909,11 +4900,11 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -4949,10 +4940,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+              [=Flow content=], but
               with no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a>
               descendants.
@@ -4995,11 +4986,11 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a> (if focusable)
+                [=Interactive content=] (if focusable)
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+              [=Phrasing content=]
             </td>
           </tr>
           <tr>
@@ -5033,10 +5024,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+              [=Phrasing content=]
             </td>
           </tr>
           <tr>
@@ -5074,14 +5065,14 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+                [=Interactive content=]
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5103,11 +5094,11 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#flow-content">Flow content</a>
+                [=Flow content=]
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5126,11 +5117,11 @@
             </td>
             <td>
               <p>
-                <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+                [=Interactive content=]
               </p>
             </td>
             <td>
-             <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>, but
+             [=Phrasing content=], but
               with no <a data-cite="html/dom.html#interactive-content-2">interactive content</a>
               descendants.
             </td>
@@ -5167,7 +5158,7 @@
             </td>
             <td>
 
-             <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>, but
+             [=Phrasing content=], but
               with no <a data-cite="html/dom.html#interactive-content-2">interactive content</a>
               descendants.
 
@@ -5195,10 +5186,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5228,10 +5219,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5251,10 +5242,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5272,10 +5263,10 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded` (state)</a>
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+              [=Phrasing content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#phrasing-content">Phrasing content</a>
+              [=Phrasing content=]
             </td>
           </tr>
           <tr>
@@ -5311,10 +5302,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>, but
+              [=Flow content=], but
               with no <a data-cite=
               "html/dom.html#interactive-content-2">interactive content</a>
               descendants.
@@ -5338,10 +5329,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5369,10 +5360,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5391,10 +5382,10 @@
               </p>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5428,10 +5419,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5477,10 +5468,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
@@ -5517,10 +5508,10 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#interactive-content">Interactive content</a>
+              [=Interactive content=]
             </td>
             <td>
-              <a data-cite="html/dom.html#flow-content">Flow content</a>
+              [=Flow content=]
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
       </h2>
       <p>
         Developers MAY use the ARIA `role` and `aria-*` attributes on
-        <a data-cite="html/dom.html#elements">HTML elements</a>, in accordance
+        [=HTML elements=], in accordance
         with the requirements described in [[wai-aria-1.1|WAI-ARIA]], except
         where these conflict with the
         <dfn><a data-cite="wai-aria-1.1#host_general_conflict">strong native semantics</a></dfn>
@@ -1194,9 +1194,7 @@
           </tr>
           <tr id="el-img" tabindex="-1">
             <th>
-              [^img^] with
-              <code><a data-cite=
-              "html/embedded-content.html#attr-img-alt">alt</a>="some text"</code>
+              [^img^] with [^img/alt^]`="some text"`
             </th>
             <td>
               <code>role=<a href="#index-aria-img">img</a></code>
@@ -3541,8 +3539,7 @@
             </td>
             <td>
                [=Phrasing content=],
-              but there must be no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a> descendant.
+              but there must be no [=interactive content=] descendant.
             </td>
           </tr>
           <tr>
@@ -3978,11 +3975,11 @@
               </ul>
             </td>
             <td>
-              <a data-cite="html/dom.html#heading-content">Heading content</a>
+              [=Heading content=]
             </td>
             <td>
               [=Flow content=], but
-              with no <a data-cite="html/dom.html#heading-content">Heading content</a>,
+              with no [=Heading content=],
               [=Sectioning content=],
               <a data-cite="html/sections.html#sectioning-root">Sectioning roots</a>.
             </td>
@@ -4023,8 +4020,7 @@
             </td>
             <td>
               [=Flow content=], but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a> or
+              with no [=interactive content=] or
               <a>a</a> element descendants.
             </td>
           </tr>
@@ -4278,8 +4274,7 @@
             </td>
             <td>
                [=Flow content=], but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
             </td>
           </tr>
@@ -4305,8 +4300,7 @@
             </td>
             <td>
                [=Phrasing content=], but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
             </td>
           </tr>
@@ -4331,8 +4325,7 @@
               [=Interactive content=]
             </td>
             <td> [=Phrasing content=], but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
             </td>
           </tr>
@@ -4419,8 +4412,7 @@
             </td>
             <td>
               [=Phrasing content=], but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
             </td>
           </tr>
@@ -4494,8 +4486,7 @@
             </td>
             <td>
              [=Phrasing content=], but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
             </td>
           </tr>
@@ -4751,8 +4742,7 @@
             </td>
             <td>
               [=Flow content=], but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
             </td>
           </tr>
@@ -4910,7 +4900,7 @@
             </td>
             <td>
              [=Phrasing content=], but
-              with no <a data-cite="html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
             </td>
           </tr>
@@ -4938,12 +4928,12 @@
               </ul>
             </td>
             <td>
-             <a data-cite="html/dom.html#interactive-content-2">interactive content</a>
+             [=interactive content=]
             </td>
             <td>
 
              [=Phrasing content=], but
-              with no <a data-cite="html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
 
             </td>
@@ -5072,8 +5062,7 @@
             </td>
             <td>
               [=Flow content=], but
-              with no <a data-cite=
-              "html/dom.html#interactive-content-2">interactive content</a>
+              with no [=interactive content=]
               descendants.
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -64,15 +64,15 @@
         Developer requirements for use of ARIA in HTML
       </h2>
       <p>
-        Developers MAY use the ARIA `role` and `aria-*` attributes on
-        [=HTML elements=], in accordance
-        with the requirements described in [[wai-aria-1.1|WAI-ARIA]], except
-        where these conflict with the
+        Developers MAY use the ARIA `role` and `aria-*` attributes to change
+        the exposed meaning (<a data-cite="html/dom.html#semantics-2">semantics</a>) of
+        [=HTML elements=], in accordance with the requirements described in
+        [[wai-aria-1.1|WAI-ARIA]], except where these conflict with the
         <dfn><a data-cite="wai-aria-1.1#host_general_conflict">strong native semantics</a></dfn>
         or are equal to the
         <dfn><a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a></dfn>
-        of a given HTML element. The <a>implicit ARIA semantics</a> for an
-        HTML element are defined in the
+        of a given HTML element. The <a>implicit ARIA semantics</a> for
+        HTML elements are defined in the
         <dfn>[[html-aam-1.0|HTML Accessibility API Mappings]]</dfn> specification.
       </p>
       <p>
@@ -1242,7 +1242,7 @@
           </tr>
           <tr id="el-img-no-alt" tabindex="-1">
             <th>
-              [^img^] without [^img/alt^] attribute
+              [^img^] <a data-cite="html/images.html#unknown-images">without an `alt` attribute</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-img">img</a></code>
@@ -3088,8 +3088,7 @@
           </tr>
           <tr id="att-readonly" tabindex="-1">
             <th>
-              Any element where the `readonly`
-              attribute is allowed: [^face/readonly^],
+              Any [^input^] element which allows the [^input/readonly^] attribute, or <a>form-associated custom element</a> which allows the [^face/readonly^] attribute.
             </th>
             <td>
               `aria-readonly="true"`
@@ -3284,10 +3283,10 @@
       </p>
       <p>
         For example, a [^button^] element has an implicit
-        `role=button`. A `button` element allows [=phrasing content=] as descendants and does not allow 
-        [=interactive content=] or descendants with a `tabindex` attribute.  Therefore, any elements 
-        specified with a `role=button` also MUST NOT allow any interactive content descendants, elements 
-        with a `tabindex` specified or any elements with role values that are in the interactive content 
+        `role=button`. A `button` element allows [=phrasing content=] as descendants and does not allow
+        [=interactive content=] or descendants with a `tabindex` attribute.  Therefore, any elements
+        specified with a `role=button` also MUST NOT allow any interactive content descendants, elements
+        with a `tabindex` specified or any elements with role values that are in the interactive content
         category (identified in Column 3).
       </p>
       <div class="example" id="bad-descendants">


### PR DESCRIPTION
Drops more use of `data-cite=` ... ideally, there should not be any data-cite= used, specially for HTML things. 

Fixed up a few more linking issues to HTML spec. 

Note: this is blocked on https://github.com/whatwg/html/pull/6464


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/285.html" title="Last updated on Mar 13, 2021, 5:49 PM UTC (9f0030c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/285/72cc9b4...9f0030c.html" title="Last updated on Mar 13, 2021, 5:49 PM UTC (9f0030c)">Diff</a>