### PR TITLE
replace “authors” with “developers”

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,12 +138,12 @@
           The following uses a `role=list` on an `ul` element. This is
           generally unnecessary, because the `ul` element is implicitly exposed
           as a `role=list`. However, some user agents suppress a list's
-          implicit ARIA semantics if list markers are removed. Authors can use
-          `role=list` to reinstate the role if necessary, though this practice
-          would generally not be recommended, otherwise.
+          implicit ARIA semantics if list markers are removed. Developers can
+          use `role=list` to reinstate the role if necessary, though this
+          practice would generally not be recommended, otherwise.
         </p>
         <pre class="HTML example" title="Redundant role on list">
-          &lt!-- Avoid doing this! -->    
+          &lt!-- Avoid doing this! -->
           &lt;ul role="list"&gt;...&lt;/ul&gt;
         </pre>
       </section>
@@ -186,7 +186,7 @@
         <dfn><strong>Any</strong> `role`</dfn> it indicates that any `role`
         value apart from the <a>implicit ARIA semantics</a> `role` value,
         MAY be used. If a cell in the third column includes the term
-        <dfn><strong>No `role`</strong></dfn> it indicates that authors
+        <dfn><strong>No `role`</strong></dfn> it indicates that developers
         MUST NOT overwrite the implicit ARIA semantics, or native semantics
         of the HTML element.
       </p>
@@ -424,12 +424,12 @@
               <a>autonomous custom element</a>
             </th>
             <td>
-              Role exposed from author defined <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">`ElementInternals`</a>.
+              Role exposed from developer defined <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">`ElementInternals`</a>.
               Otherwise <a>no corresponding role</a>.
             </td>
             <td>
               <p>
-                If no author defined role,<br><a><strong>Any</strong> `role`</a>
+                If no developer defined role,<br><a><strong>Any</strong> `role`</a>
               </p>
               <p>Otherwise only allowed roles for the role exposed by the custom element's `ElementInternals`.</p>
               <p>
@@ -1013,11 +1013,11 @@
               <a>form-associated custom element</a>
             </th>
             <td>
-              Role exposed from author defined <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">`ElementInternals`</a>.
+              Role exposed from developer defined <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#the-elementinternals-interface">`ElementInternals`</a>.
               Otherwise <a>no corresponding role</a>.
             </td>
             <td>
-              <p>If no author defined role,<br> Roles:
+              <p>If no developer defined role,<br> Roles:
                 <a href="#index-aria-application">`application`</a>,
                 <a href="#index-aria-button">`button`</a>,
                 <a href="#index-aria-checkbox">`checkbox`</a>,
@@ -1252,12 +1252,12 @@
             </td>
             <td>
               <p>
-                If no author-defined accessible name is provided by other
-                methods: <strong class="nosupport">No `role`</strong>, and
+                If no accessible name is provided via other <a data-cite=
+              "html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>: <strong class="nosupport">No `role`</strong>, and
                 <strong>no `aria-*` attributes</strong> except `aria-hidden="true"`.
               </p>
               <p>
-                Otherwise, if the `img` has an author defined accessible name, see <a href="#el-img">`img` with `alt="some text"`</a>.
+                Otherwise, if the `img` has an developer defined accessible name, see <a href="#el-img">`img` with `alt="some text"`</a>.
               </p>
             </td>
           </tr>
@@ -1305,7 +1305,7 @@
                 or <a href="#index-aria-switch">`switch`</a>.
               </p>
               <p>
-                Authors <a href="#att-checked">SHOULD NOT use the `aria-checked` attribute on `input type=checkbox` elements</a>.
+                Developers <a href="#att-checked">SHOULD NOT use the `aria-checked` attribute on `input type=checkbox` elements</a>.
               </p>
               <p>
                 Otherwise, any <a href="#index-aria-global">global `aria-*` attributes</a> and
@@ -1504,7 +1504,7 @@
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>
               </p>
               <p>
-                Authors <a href="#att-checked">SHOULD NOT use the
+                Developers <a href="#att-checked">SHOULD NOT use the
                 `aria-checked` attribute on `input type=radio` elements</a>.
               </p>
               <p>
@@ -1531,7 +1531,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or <a href="#att-min">`aria-valuemin`</a> attributes on `input type=range`.
+                Developers SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or <a href="#att-min">`aria-valuemin`</a> attributes on `input type=range`.
               </p>
               <p>
                 Otherwise, any <a href="#index-aria-global">global `aria-*` attributes</a> and any `aria-*` attributes applicable to the
@@ -1646,10 +1646,10 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-haspopup` attribute on the indicated `input`s with a `list` attribute.
+                Developers SHOULD NOT use the `aria-haspopup` attribute on the indicated `input`s with a `list` attribute.
               </p>
               <!-- <p>
-                Authors MUST NOT use the `aria-haspopup` attribute with a value other than `listbox` on the indicated `input`s with a `list` attribute.
+                Developers MUST NOT use the `aria-haspopup` attribute with a value other than `listbox` on the indicated `input`s with a `list` attribute.
               </p> -->
               <p>
                 Otherwise, any
@@ -2059,7 +2059,7 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-selected` attribute on the `option` element.
+                Developers SHOULD NOT use the `aria-selected` attribute on the `option` element.
               </p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
@@ -2362,7 +2362,7 @@
               <p>
                 Role: <a href="#index-aria-menu">`menu`</a>
               </p>
-              <p>Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.</p>
+              <p>Developers SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.</p>
               <p>
                 Otherwise, any <a href="#index-aria-global">global `aria-*` attributes</a> and
                 any other `aria-*` attributes applicable to the `combobox` or `menu` role.
@@ -2381,7 +2381,7 @@
               <p>
                 <strong class="nosupport">No `role`</strong>
               </p>
-              <p>Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.</p>
+              <p>Developers SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.</p>
               <p>
                 Otherwise, any <a href="#index-aria-global">global `aria-*` attributes</a> and
                 any other `aria-*` attributes applicable to the `listbox` role.
@@ -2874,7 +2874,7 @@
       </p>
       <div class="note">
         <p>
-          Authors are encouraged to make use of the following documents for
+          Developers are encouraged to make use of the following documents for
           guidance on using ARIA in HTML beyond that which is provided here:
         </p>
         <ul>
@@ -2921,7 +2921,7 @@
         Document conformance requirements for use of ARIA attributes with HTML attributes
       </h3>
       <p>
-        Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a `button` element, rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
+        Unless otherwise stated, developers MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, developers MAY use `aria-disabled=true` on a `button` element, rather than the `disabled` attribute. However, developers SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
         <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
         user agents MUST ignore WAI-ARIA attributes and use the host language
         (HTML) attribute with the same <a>implicit ARIA semantics</a>.
@@ -2933,7 +2933,7 @@
         Each language feature (element and attribute) in a cell in the first
         column implies the ARIA semantics (states, and properties) given in
         the cell in the second column of the same row. The third cell in each
-        row defines how authors can use the native HTML feature, along with
+        row defines how developers can use the native HTML feature, along with
         requirements for using the `aria-*` attributes that supply the same
         <a>implicit ARIA semantics</a>.
       </p>
@@ -2952,7 +2952,7 @@
               </p>
             </th>
             <th>
-              HTML feature and `aria-*` attribute author guidance
+              HTML feature and `aria-*` attribute developer guidance
             </th>
           </tr>
         </thead>
@@ -2971,10 +2971,10 @@
                 <a data-cite="html/input.html#attr-input-checked">allowed the `checked` attribute</a> in HTML.
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-checked` attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> of the element can be in opposition to the current value of the  <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` attribute</a>.
+                Developers SHOULD NOT use the `aria-checked` attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> of the element can be in opposition to the current value of the  <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` attribute</a>.
               </p>
               <p>
-                Authors MAY use the `aria-checked` attribute on any other element with a WAI-ARIA role which allows the  attribute.
+                Developers MAY use the `aria-checked` attribute on any other element with a WAI-ARIA role which allows the  attribute.
               </p>
             </td>
           </tr>
@@ -2991,13 +2991,13 @@
                 Use the `disabled` attribute on any element that is <a data-cite="html/form-control-infrastructure.html#attr-fe-disabled">allowed the `disabled` attribute</a> in HTML.
               </p>
               <p>
-                Authors MAY use the `aria-disabled` attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled` attribute</a>.
+                Developers MAY use the `aria-disabled` attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled` attribute</a>.
               </p>
               <p>
-                Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
+                Developers SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
               </p>
               <p>
-                Authors MUST NOT use `aria-disabled="false"` on any element which also has a `disabled` attribute.
+                Developers MUST NOT use `aria-disabled="false"` on any element which also has a `disabled` attribute.
               </p>
             </td>
           </tr>
@@ -3011,15 +3011,15 @@
             </td>
             <td>
               <p>
-                Authors MAY use the `aria-hidden` attribute on any HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a>, with the following exceptions:
+                Developers MAY use the `aria-hidden` attribute on any HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a>, with the following exceptions:
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-hidden="true"` attribute on any element which also has a `hidden` attribute.
+                Developers SHOULD NOT use the `aria-hidden="true"` attribute on any element which also has a `hidden` attribute.
               </p>
 
               <!-- this will be covered as part of issue 221 -->
               <!-- <p>
-                Authors MUST NOT use `aria-hidden="true"` on an element that can receive keyboard focus, or on an ancestor element to an element or elements which can receive keyboard focus.
+                Developers MUST NOT use `aria-hidden="true"` on an element that can receive keyboard focus, or on an ancestor element to an element or elements which can receive keyboard focus.
               </p>
               <p>
                 Any elements which can receive keyboard focus, interactive elements or otherwise, MUST have their ability to receive keyboard focus removed while the `aria-hidden="true"` attribute is present. For instance, by using `tabindex="-1"` on any focusable elements with `aria-hidden="true"`, or setting `tabindex="-1"` to focusable elements that are descendants of an `aria-hidden="true"` containing element.
@@ -3039,10 +3039,10 @@
                 `placeholder` attribute</a> in HTML.
               </p>
               <p>
-                Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
+                Developers MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
               </p>
               <p>
-                Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
+                Developers MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
               </p>
             </td>
           </tr>
@@ -3060,13 +3060,13 @@
                 <a data-cite="html/input.html#attr-input-max">allowed the `max` attribute</a> in HTML. It is NOT RECOMMENDED to use the <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax` attribute</a> on these elements.
               </p>
               <p>
-                Authors MAY use the `aria-valuemax` attribute on any other element with a WAI-ARIA role which allows the  attribute.
+                Developers MAY use the `aria-valuemax` attribute on any other element with a WAI-ARIA role which allows the  attribute.
               </p>
               <p>
-                Authors SHOULD NOT use `aria-valuemax` on any element which also has a `max` attribute, even if the values of each attribute match.
+                Developers SHOULD NOT use `aria-valuemax` on any element which also has a `max` attribute, even if the values of each attribute match.
               </p>
               <p>
-                Authors MUST NOT use `aria-valuemax` on any element which also has a `max` attribute, and the values of each attribute do not match.
+                Developers MUST NOT use `aria-valuemax` on any element which also has a `max` attribute, and the values of each attribute do not match.
               </p>
             </td>
           </tr>
@@ -3084,13 +3084,13 @@
                 <a data-cite="html/input.html#attr-input-min">allowed the `min` attribute</a> in HTML. It is NOT RECOMMENDED to use the <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin` attribute</a> on these elements.
               </p>
               <p>
-                Authors MAY use the `aria-valuemin` attribute on any other element with a WAI-ARIA role which allows the  attribute.
+                Developers MAY use the `aria-valuemin` attribute on any other element with a WAI-ARIA role which allows the  attribute.
               </p>
               <p>
-                Authors SHOULD NOT use `aria-valuemin` on any element which also has a `min` attribute, even if the values of each attribute match.
+                Developers SHOULD NOT use `aria-valuemin` on any element which also has a `min` attribute, even if the values of each attribute match.
               </p>
               <p>
-                Authors MUST NOT use `aria-valuemin` on any element which also has a `min` attribute, and the values of each attribute do not match.
+                Developers MUST NOT use `aria-valuemin` on any element which also has a `min` attribute, and the values of each attribute do not match.
               </p>
             </td>
           </tr>
@@ -3108,13 +3108,13 @@
                 <a data-cite="html/input.html#attr-input-readonly">allowed the `readonly` attribute</a> in HTML. It is NOT RECOMMENDED to use `aria-readonly` on these elements.
               </p>
               <p>
-                Authors MAY use the `aria-readonly` attribute on any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly` attribute</a>.
+                Developers MAY use the `aria-readonly` attribute on any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly` attribute</a>.
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.
+                Developers SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.
               </p>
               <p>
-                Authors MUST NOT use `aria-readonly="false"` on any element which also has a `readonly` attribute.
+                Developers MUST NOT use `aria-readonly="false"` on any element which also has a `readonly` attribute.
               </p>
             </td>
           </tr>
@@ -3138,7 +3138,7 @@
               `aria-readonly="false"`
             </td>
             <td>
-              Authors MUST NOT set `aria-readonly="true"` on an element that has `isContentEditable="true"`.
+              Developers MUST NOT set `aria-readonly="true"` on an element that has `isContentEditable="true"`.
             </td>
           </tr>
           <tr id="att-required" tabindex="-1">
@@ -3156,13 +3156,13 @@
                 `required` attribute</a> in HTML.
               </p>
               <p>
-                Authors MAY use the `aria-required` attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-required">`aria-required` attribute</a>.
+                Developers MAY use the `aria-required` attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-required">`aria-required` attribute</a>.
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-required="true"` on any element which also has a `required` attribute.
+                Developers SHOULD NOT use the `aria-required="true"` on any element which also has a `required` attribute.
               </p>
               <p>
-                Authors MUST NOT use `aria-required="false"` on any element which also has a `required` attribute.
+                Developers MUST NOT use `aria-required="false"` on any element which also has a `required` attribute.
               </p>
             </td>
           </tr>
@@ -3180,13 +3180,13 @@
                 <a data-cite="html/tables.html#attr-tdth-colspan">allowed the `colspan` attribute</a> in HTML.
               </p>
               <p>
-                Authors MAY use the `aria-colspan` attribute on any element that is allowed the `colspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan` attribute</a>.
+                Developers MAY use the `aria-colspan` attribute on any element that is allowed the `colspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan` attribute</a>.
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-colspan` attribute on any element which also has a `colspan` attribute.
+                Developers SHOULD NOT use the `aria-colspan` attribute on any element which also has a `colspan` attribute.
               </p>
               <p>
-                Authors MUST NOT use `aria-colspan` on any element which also has a `colspan` attribute, and the values of each attribute do not match.
+                Developers MUST NOT use `aria-colspan` on any element which also has a `colspan` attribute, and the values of each attribute do not match.
               </p>
             </td>
           </tr>
@@ -3204,13 +3204,13 @@
                 <a data-cite="html/tables.html#attr-tdth-rowspan">allowed the `rowspan` attribute</a> in HTML.
               </p>
               <p>
-                Authors MAY use the `aria-rowspan` attribute on any element that is allowed the `rowspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan` attribute</a>.
+                Developers MAY use the `aria-rowspan` attribute on any element that is allowed the `rowspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan` attribute</a>.
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-rowspan` attribute on any element which also has a `rowspan` attribute.
+                Developers SHOULD NOT use the `aria-rowspan` attribute on any element which also has a `rowspan` attribute.
               </p>
               <p>
-                Authors MUST NOT use `aria-rowspan` on any element which also has a `rowspan` attribute, and the values of each attribute do not match.
+                Developers MUST NOT use `aria-rowspan` on any element which also has a `rowspan` attribute, and the values of each attribute do not match.
               </p>
             </td>
           </tr>
@@ -3242,7 +3242,7 @@
         Case requirements for ARIA role, state and property attributes
       </h2>
       <p>
-        Authors MUST use <a data-cite=
+        Developers MUST use <a data-cite=
         "html/infrastructure.html#lowercase-ascii-letters">lowercase ASCII
         letters</a> for all `role` token values and any state or property
         attributes (`aria-*`) whose values are <a data-cite=


### PR DESCRIPTION
aside from a few instances where we are referencing where author = developer, or other docs that use ‘author’, this spec will otherwise use ‘developer(s)’ in place of ‘author(s)’

closes #271


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/286.html" title="Last updated on Mar 8, 2021, 1:09 PM UTC (dc69261)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/286/45ad2d5...dc69261.html" title="Last updated on Mar 8, 2021, 1:09 PM UTC (dc69261)">Diff</a>