### PR TITLE
Remove case sensitive requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,6 @@
         MUST NOT overwrite the implicit ARIA semantics, or native semantics
         of the HTML element.
       </p>
-
       <p class="note" id="aria-usage-note">
         While setting an ARIA `role` and/or `aria-*` attribute that matches the
         <span>implicit ARIA semantics</span> is NOT RECOMMENDED, in some
@@ -198,7 +197,10 @@
         For instance, in user agents which lack exposing specific implicit
         ARIA semantics.
       </p>
-
+      <p>
+        When setting an ARIA `role` and/or `aria-*` attribute, it is RECOMMENDED
+        that the attribute's values be in [=ascii lowercase=] form.
+      </p>
       <table class="simple">
         <caption>
           Rules of ARIA attribute usage by HTML element

--- a/index.html
+++ b/index.html
@@ -198,8 +198,9 @@
         ARIA semantics.
       </p>
       <p>
-        When setting an ARIA `role` and/or `aria-*` attribute, it is RECOMMENDED
-        that the attribute's values be in [=ascii lowercase=] form.
+        The values of ARIA `role` and/or `aria-*` attribute are case insensitive.
+        However, when setting an ARIA `role` and/or `aria-*` attribute, it is 
+        RECOMMENDED that the attribute's values be in lowercase form.
       </p>
       <table class="simple">
         <caption>

--- a/index.html
+++ b/index.html
@@ -3238,39 +3238,6 @@
       </table>
     </section>
     <section>
-      <h2 id="case-sensitivity">
-        Case requirements for ARIA role, state and property attributes
-      </h2>
-      <p>
-        Developers MUST use <a data-cite=
-        "html/infrastructure.html#lowercase-ascii-letters">lowercase ASCII
-        letters</a> for all `role` token values and any state or property
-        attributes (`aria-*`) whose values are <a data-cite=
-        "wai-aria-1.1#propcharacteristic_value">defined as tokens</a>.
-      </p>
-      <aside class="example">
-        <p>
-          <strong>Correct (conforming) examples:</strong>
-        </p>
-        <pre>
-  &lt;div <mark>role="radiogroup"</mark>&gt;...&lt;/div&gt;
-
-  &lt;a href="home/" <mark>aria-current="page"</mark>&gt;home&lt;/a&gt;
-</pre>
-        <p>
-          <strong>Incorrect (non-conforming) examples:</strong>
-        </p>
-        <pre>
-&lt;!-- DO NOT DO THIS --&gt;
-&lt;div <mark>role="radioGroup"</mark>&gt;...&lt;/div&gt;
-
-&lt;div <mark>role="RADIOGROUP"</mark>&gt;...&lt;/div&gt;
-
-&lt;a href="home/" <mark>aria-current="Page"</mark>&gt;home&lt;/a&gt;
-</pre>
-      </aside>
-    </section>
-    <section>
       <h2>
         Allowed ARIA roles, states and properties
       </h2>


### PR DESCRIPTION
Closes #280

Safari and Chrome do the right thing. 

Firefox has a web compat bug  filed https://bugzilla.mozilla.org/show_bug.cgi?id=1407167


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/287.html" title="Last updated on Mar 10, 2021, 4:03 AM UTC (4c0a47d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/287/8385517...4c0a47d.html" title="Last updated on Mar 10, 2021, 4:03 AM UTC (4c0a47d)">Diff</a>