### PR TITLE
revise custom element guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1026,9 +1026,9 @@
                 <a href="#index-aria-progressbar">`progressbar`</a>,
                 <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
+                <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-searchbox">`searchbox`</a>,
                 <a href="#index-aria-slider">`slider`</a>,
-                <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-spinbutton">`spinbutton`</a>,
                 <a href="#index-aria-switch">`switch`</a>
                 or <a href="#index-aria-textbox">`textbox`</a>.

--- a/index.html
+++ b/index.html
@@ -428,10 +428,10 @@
               Otherwise <a>no corresponding role</a>.
             </td>
             <td>
+              <p>If role defined by `ElementInternals`, <strong class="nosupport">no `role`</strong>.</p>
               <p>
-                If no developer defined role,<br><a><strong>Any</strong> `role`</a>
+                Otherwise, <a><strong>any</strong> `role`</a>
               </p>
-              <p>Otherwise only allowed roles for the role exposed by the custom element's `ElementInternals`.</p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and
@@ -1017,23 +1017,22 @@
               Otherwise <a>no corresponding role</a>.
             </td>
             <td>
-              <p>If no developer defined role,<br> Roles:
-                <a href="#index-aria-application">`application`</a>,
+              <p>If role defined by `ElementInternals`, <strong class="nosupport">no `role`</strong>.</p>
+              <p>Otherwise, form-related roles:
                 <a href="#index-aria-button">`button`</a>,
                 <a href="#index-aria-checkbox">`checkbox`</a>,
                 <a href="#index-aria-combobox">`combobox`</a>,
-                <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-listbox">`listbox`</a>,
                 <a href="#index-aria-progressbar">`progressbar`</a>,
+                <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
-                <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-searchbox">`searchbox`</a>,
                 <a href="#index-aria-slider">`slider`</a>,
+                <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-spinbutton">`spinbutton`</a>,
                 <a href="#index-aria-switch">`switch`</a>
                 or <a href="#index-aria-textbox">`textbox`</a>.
               </p>
-              <p>Otherwise only allowed roles for the role exposed by the custom element's `ElementInternals`.</p>
               <p>
                 <a href="#index-aria-global">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles and

--- a/results/implementation-results.html
+++ b/results/implementation-results.html
@@ -291,12 +291,13 @@
         Otherwise no corresponding role.
       </td>
       <td>
+        <p>If role defined by <code>ElementInternals</code>,
+          <strong class="nosupport">no <code>role</code></strong>.</p>
         <p>
-          If no author defined role,<br><strong>Any</strong> <code>role</code>
+          Otherwise, <strong>any</strong> <code>role</code><
         </p>
-        <p>Otherwise only allowed roles for the role exposed by the custom element's <code>ElementInternals</code>.</p>
         <p>
-          Global <code>aria-*</code> attributes and
+          <a href="#index-aria-global">Global <code>aria-*</code> attributes</a> and
           any <code>aria-*</code> attributes applicable to the allowed roles and
           implied role (if any).
         </p>
@@ -1026,8 +1027,9 @@
         Otherwise no corresponding role.
       </td>
       <td>
-        <p>If no author defined role,<br> Roles:
-          <code>application</code>,
+        <p>If role defined by <code>ElementInternals</code>,
+          <strong class="nosupport">no <code>role</code></strong>.</p>
+        <p>Otherwise, form-related roles:
           <code>button</code>,
           <code>checkbox</code>,
           <code>combobox</code>,
@@ -1042,7 +1044,6 @@
           <code>switch</code>
           or <code>textbox</code>.
         </p>
-        <p>Otherwise only allowed roles for the role exposed by the custom element's <code>ElementInternals</code>.</p>
         <p>
           Global <code>aria-*</code> attributes and
           any <code>aria-*</code> attributes applicable to the allowed roles and


### PR DESCRIPTION
if defining roles via elementInternals, then authors should not overwrite those roles with the role attribute.

if no role was defined via elementInternals, then any role can be valid for a custom element, but a form associated custom element should only allow form-related roles.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/290.html" title="Last updated on Mar 13, 2021, 5:26 PM UTC (b763f3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/290/8467845...b763f3c.html" title="Last updated on Mar 13, 2021, 5:26 PM UTC (b763f3c)">Diff</a>