### PR TITLE
ARIA 1.2 updates to Allowed ARIA roles, states and properties table

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <section id="abstract">
       <p>
         This specification defines the authoring rules (author conformance
-        requirements) for the use of [[[wai-aria-1.1]]] and [[[dpub-aria-1.0]]]
+        requirements) for the use of [[[wai-aria-1.2]]] and [[[dpub-aria-1.0]]]
         attributes on [[HTML]] elements. This specification's primary objective is to define requirements for use 
         with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors 
         in their development of web content, including custom interfaces/widgets, that makes use of ARIA to
@@ -70,10 +70,10 @@
         Authors MAY use the ARIA `role` and `aria-*` attributes to change
         the exposed meaning (<a data-cite="html/dom.html#semantics-2">semantics</a>) of
         [=HTML elements=], in accordance with the requirements described in
-        [[wai-aria-1.1|WAI-ARIA]], except where these conflict with the
-        <dfn data-cite="wai-aria-1.1#host_general_conflict">strong native semantics</dfn>
+        [[wai-aria-1.2|WAI-ARIA]], except where these conflict with the
+        <dfn data-cite="wai-aria-1.2#host_general_conflict">strong native semantics</dfn>
         or are equal to the
-        <dfn data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</dfn>
+        <dfn data-cite="wai-aria-1.2#implicit_semantics">implicit ARIA semantics</dfn>
         of a given HTML element. The <a>implicit ARIA semantics</a> for
         HTML elements are defined in the
         [[html-aam-1.0|HTML Accessibility API Mappings]] specification.
@@ -2850,7 +2850,7 @@
         </h3>
         <p>
           Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a [^button^] element, rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
-          <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
+          <a data-cite="wai-aria-1.2#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
           user agents MUST ignore WAI-ARIA attributes and use the host language
           (HTML) attribute with the same <a>implicit ARIA semantics</a>.
         </p>
@@ -2898,7 +2898,7 @@
                   allowed the `checked` attribute in HTML.
                 </p>
                 <p>
-                  Authors SHOULD NOT use the `aria-checked` attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> of the element can be in opposition to the current value of the <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` attribute</a>.
+                  Authors SHOULD NOT use the `aria-checked` attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> of the element can be in opposition to the current value of the <a data-cite="wai-aria-1.2#aria-checked">`aria-checked` attribute</a>.
                 </p>
                 <p>
                   Authors MAY use the `aria-checked` attribute on any other element with a WAI-ARIA role which allows the  attribute.
@@ -2920,7 +2920,7 @@
                   Use the `disabled` attribute on any element that is allowed the `disabled` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the `aria-disabled` attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled` attribute</a>.
+                  Authors MAY use the `aria-disabled` attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled` attribute</a>.
                 </p>
                 <p>
                   Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
@@ -2967,7 +2967,7 @@
                   `placeholder` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
+                  Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder` attribute</a>.
                 </p>
                 <p>
                   Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
@@ -3034,7 +3034,7 @@
                   allowed the `readonly` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the `aria-readonly` attribute on any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly` attribute</a>.
+                  Authors MAY use the `aria-readonly` attribute on any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly` attribute</a>.
                 </p>
                 <p>
                   Authors SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.
@@ -3079,7 +3079,7 @@
                   that is allowed the `required` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the `aria-required` attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-required">`aria-required` attribute</a>.
+                  Authors MAY use the `aria-required` attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.2#aria-required">`aria-required` attribute</a>.
                 </p>
                 <p>
                   Authors SHOULD NOT use the `aria-required="true"` on any element which also has a `required` attribute.
@@ -3102,7 +3102,7 @@
                   allowed the `colspan` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the `aria-colspan` attribute on any element that is allowed the `colspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan` attribute</a>.
+                  Authors MAY use the `aria-colspan` attribute on any element that is allowed the `colspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.2#aria-colspan">`aria-colspan` attribute</a>.
                 </p>
                 <p>
                   Authors SHOULD NOT use the `aria-colspan` attribute on any element which also has a `colspan` attribute.
@@ -3126,7 +3126,7 @@
                   allowed the `rowspan` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the `aria-rowspan` attribute on any element that is allowed the `rowspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan` attribute</a>.
+                  Authors MAY use the `aria-rowspan` attribute on any element that is allowed the `rowspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.2#aria-rowspan">`aria-rowspan` attribute</a>.
                 </p>
                 <p>
                   Authors SHOULD NOT use the `aria-rowspan` attribute on any element which also has a `rowspan` attribute.
@@ -3169,7 +3169,7 @@
         "html/infrastructure.html#lowercase-ascii-letters">lowercase ASCII
         letters</a> for all `role` token values and any state or property
         attributes (`aria-*`) whose values are <a data-cite=
-        "wai-aria-1.1#propcharacteristic_value">defined as tokens</a>.
+        "wai-aria-1.2#propcharacteristic_value">defined as tokens</a>.
       </p>
       <aside class="example">
         <p>
@@ -3201,8 +3201,8 @@
         Properties</a> table provide an informative <em>(non-normative)</em>
         reference to the ARIA roles, states and properties permitted for use in
         HTML. All ARIA roles, states and properties are normatively defined in
-        the [[[wai-aria-1.1]]] specification. Links to ARIA roles, states and
-        properties in the table reference the normative [[[wai-aria-1.1]]] definitions.
+        the [[[wai-aria-1.2]]] specification. Links to ARIA roles, states and
+        properties in the table reference the normative [[[wai-aria-1.2]]] definitions.
       </p>
       <p>
         Column 4 of the <a href="#aria-table">ARIA Roles, States and
@@ -3470,13 +3470,13 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-pressed">`aria-pressed`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-pressed">`aria-pressed`</a></li>
               </ul>
             </td>
             <td>
@@ -3544,17 +3544,17 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -3592,35 +3592,35 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a></li>
                 <li>
                   <a data-cite="wai-aria-1.2#aria-colindextext">`aria-colindextext`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-colspan">`aria-colspan`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a></li>
                 <li>
                   <a data-cite="wai-aria-1.2#aria-rowindextext">`aria-rowindextext`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-rowspan">`aria-rowspan`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-sort">`aria-sort`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-sort">`aria-sort`</a></li>
               </ul>
             </td>
             <td>
@@ -3893,15 +3893,15 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-colcount">`aria-colcount`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a></li>
+                  <a data-cite="wai-aria-1.2#aria-rowcount">`aria-rowcount`</a></li>
               </ul>
             </td>
             <td>
@@ -3925,18 +3925,18 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-colspan">`aria-colspan`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-rowspan">`aria-rowspan`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a></li>
               </ul>
             </td>
             <td>
@@ -4037,9 +4037,9 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
               </ul>
             </td>
             <td>
@@ -4076,15 +4076,15 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4267,11 +4267,11 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4291,11 +4291,11 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4315,15 +4315,15 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4427,10 +4427,10 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4545,13 +4545,13 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4588,20 +4588,20 @@
             <td>
               <p>If child of `role=grid`, `rowgroup`, `table` or `treegrid`:</p>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a></li>
                 <li><a data-cite="wai-aria-1.2#aria-colindextext">`aria-colindextext`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a></li>
                 <li><a data-cite="wai-aria-1.2#aria-rowindextext">`aria-rowindextext`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a></li>
               </ul>
               <p>Only if child of `role=treegrid`:</p>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-level">`aria-level`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-level">`aria-level`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4636,24 +4636,24 @@
             <td>
               <p>If descendant of `role=grid`, `table` or `treegrid`:</p>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a></li>
                 <li><a data-cite="wai-aria-1.2#aria-colindextext">`aria-colindextext`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-colspan">`aria-colspan`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a></li>
                 <li><a data-cite="wai-aria-1.2#aria-rowindextext">`aria-rowindextext`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-sort">`aria-sort`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-rowspan">`aria-rowspan`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-sort">`aria-sort`</a></li>
               </ul>
               <p>Only if child of `role=grid` or `treegrid`:</p>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4669,17 +4669,17 @@
             </th>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-controls">`aria-controls`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-controls">`aria-controls`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a></li>
               </ul>
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a></li>
               </ul>
             </td>
             <td>
@@ -4720,16 +4720,16 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-multiline">`aria-multiline`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-autocomplete">`aria-autocomplete`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-multiline">`aria-multiline`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4749,11 +4749,11 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a> (if focusable)</li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a> (if focusable)</li>
-                <li><a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a> (if focusable)</li>
-                <li><a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a> (if focusable)</li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a> (if focusable)</li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a> (if focusable)</li>
+                <li><a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a> (if focusable)</li>
+                <li><a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a> (if focusable)</li>
               </ul>
             </td>
             <td>
@@ -4772,15 +4772,15 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a></li>
               </ul>
             </td>
             <td>
@@ -4799,16 +4799,16 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a></li>
               </ul>
             </td>
             <td>
@@ -4900,12 +4900,12 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4925,12 +4925,12 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4974,10 +4974,10 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
               </ul>
             </td>
             <td>
@@ -5030,16 +5030,16 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-multiline">`aria-multiline`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-autocomplete">`aria-autocomplete`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-multiline">`aria-multiline`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -5076,9 +5076,9 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
               </ul>
             </td>
             <td>
@@ -5114,13 +5114,13 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -5139,16 +5139,16 @@
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-colcount">`aria-colcount`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-rowcount">`aria-rowcount`</a></li>
               </ul>
             </td>
             <td>
@@ -5163,16 +5163,16 @@
               <a data-cite="wai-aria-1.2#treeitem">`treeitem`</a>
             </th>
             <td>
-              <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
+              <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
             </td>
             <td>
               <ul>
-                <li><a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-level">`aria-level`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
-                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-level">`aria-level`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -5197,7 +5197,7 @@
         authors MAY use on each [=HTML element=] in [[[#docconformance]]].
         Conformance checkers SHOULD flag instances where authors are explicitly providing 
         an element with a `role` which matches its
-        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a> as failures, 
+        <a data-cite="wai-aria-1.2#implicit_semantics">implicit ARIA semantics</a> as failures, 
         as it is NOT RECOMMENDED for authors to explicitly set these roles.
       </p>
       <p>
@@ -5210,7 +5210,7 @@
         Privacy and security considerations
       </h2>
       <p>
-        This specification does not define the features of [[wai-aria-1.1]], 
+        This specification does not define the features of [[wai-aria-1.2]], 
         [[dpub-aria-1.0]] or [[HTML]]. Rather it provides rules and guidance for conformance 
         checkers that claim support for checking ARIA in HTML, as well as providing guidance to authors.
       </p>

--- a/index.html
+++ b/index.html
@@ -4048,10 +4048,10 @@
               <a data-cite="wai-aria-1.2#heading">`heading`</a>
             </th>
             <td>
-              none
+              <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a> (required)
+              Global `aria-*` only
             </td>
             <td>
               [=Heading content=]
@@ -4304,10 +4304,10 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a>
                 </li>
                 <li>
                   <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
@@ -4335,12 +4335,11 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4360,12 +4359,11 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4385,12 +4383,15 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4439,7 +4440,7 @@
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4455,7 +4456,11 @@
             <td>
               none
             </td>
-            <td>&nbsp;
+            <td>
+              Global `aria-*` only, except prohibited `aria-label`, and `aria-labelledby`
+              <p class="note">
+                Use of global `aria-*` attributes on an element with `role=none` will negate the role, re-exposing the element's implicit ARIA role, if any.
+              </p>
             </td>
             <td>
               [=Flow content=]
@@ -4472,7 +4477,7 @@
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4486,22 +4491,14 @@
               <a data-cite="wai-aria-1.2#option">`option`</a>
             </th>
             <td>
-              none
+              <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4512,6 +4509,23 @@
               [=interactive content=] descendants.
             </td>
           </tr>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-paragraph">
+              <a data-cite="wai-aria-1.2#paragraph">`paragraph`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              Global `aria-*` only, except prohibited `aria-label`, and `aria-labelledby`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
           <tr>
             <th tabindex="-1" id="index-aria-presentation">
               <a data-cite="wai-aria-1.2#presentation">`presentation`</a>
@@ -4519,7 +4533,12 @@
             <td>
               none
             </td>
-            <td></td>
+            <td>
+              Global `aria-*` only, except prohibited `aria-label`, and `aria-labelledby`
+              <p class="note">
+                Use of global `aria-*` attributes on an element with `role=presentation` will negate the role, re-exposing the element's implicit ARIA role, if any.
+              </p>
+            </td>
             <td>
               [=Flow content=]
             </td>
@@ -4567,10 +4586,10 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
                   <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
@@ -4594,18 +4613,13 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4623,7 +4637,7 @@
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4640,39 +4654,22 @@
               none
             </td>
             <td>
-              <p>
-                If child of `role=grid`, `rowgroup`, `table` or `treegrid`:
-              </p>
+              <p>If child of `role=grid`, `rowgroup`, `table` or `treegrid`:</p>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a>
-                </li>
-                <li>
-                  <a title="aria-rowindex" data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-colindextext">`aria-colindextext`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-rowindextext">`aria-rowindextext`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
               </ul>
-              <p>
-                Also, if child of `role=treegrid`:
-              </p>
+              <p>Only if child of `role=treegrid`:</p>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-level">`aria-level`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -4689,7 +4686,7 @@
             <td>
               none
             </td>
-            <td></td>
+            <td>Global `aria-*` only</td>
             <td>
               none
             </td>
@@ -4705,31 +4702,26 @@
               none
             </td>
             <td>
+              <p>If descendant of `role=grid`, `table` or `treegrid`:</p>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-colspan">`aria-colspan`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-rowspan">`aria-rowspan`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-colindextext">`aria-colindextext`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a></li>
+                <li><a data-cite="wai-aria-1.2#aria-rowindextext">`aria-rowindextext`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-sort">`aria-sort`</a></li>
+              </ul>
+              <p>Only if child of `role=grid` or `treegrid`:</p>
+              <ul>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4745,31 +4737,17 @@
             </th>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-controls">`aria-controls`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-controls">`aria-controls`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a></li>
               </ul>
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a></li>
               </ul>
             </td>
             <td>
@@ -4792,7 +4770,7 @@
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4810,24 +4788,16 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-autocomplete">`aria-autocomplete`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-multiline">`aria-multiline`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-multiline">`aria-multiline`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4843,26 +4813,15 @@
               <a data-cite="wai-aria-1.2#separator">`separator`</a>
             </th>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a> (if focusable)
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a> (if focusable)
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a> (if focusable)
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a> (if focusable)
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a> (if focusable)
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a> (if focusable)</li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a> (if focusable)</li>
+                <li><a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a> (if focusable)</li>
+                <li><a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a> (if focusable)</li>
               </ul>
             </td>
             <td>
@@ -4877,26 +4836,19 @@
               <a data-cite="wai-aria-1.2#slider">`slider`</a>
             </th>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a>
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a>
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a></li>
               </ul>
             </td>
             <td>
@@ -4911,29 +4863,20 @@
               <a data-cite="wai-aria-1.2#spinbutton">`spinbutton`</a>
             </th>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a>
-                </li>
-              </ul>
+              none
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a></li>
               </ul>
             </td>
             <td>
@@ -4956,7 +4899,7 @@
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4965,6 +4908,57 @@
               [=Flow content=]
             </td>
           </tr>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-strong">
+              <a data-cite="wai-aria-1.2#strong">`strong`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              Global `aria-*` only, except prohibited `aria-label`, and `aria-labelledby`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-subscript">
+              <a data-cite="wai-aria-1.2#subscript">`subscript`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              Global `aria-*` only, except prohibited `aria-label`, and `aria-labelledby`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-superscript">
+              <a data-cite="wai-aria-1.2#superscript">`superscript`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              Global `aria-*` only, except prohibited `aria-label`, and `aria-labelledby`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
           <tr>
             <th tabindex="-1" id="index-aria-switch">
               <a data-cite="wai-aria-1.2#switch">`switch`</a>
@@ -4973,7 +4967,14 @@
               <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
+              <ul>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+              </ul>
             </td>
             <td>
               [=Interactive content=]
@@ -4992,18 +4993,12 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>
@@ -5047,18 +5042,10 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
               </ul>
             </td>
             <td>
@@ -5076,9 +5063,7 @@
               none
             </td>
             <td>
-              <p>
-                <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-              </p>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -5095,7 +5080,7 @@
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Phrasing content=]
@@ -5113,24 +5098,16 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-autocomplete">`aria-autocomplete`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-multiline">`aria-multiline`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-multiline">`aria-multiline`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -5149,7 +5126,7 @@
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -5167,15 +5144,9 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
               </ul>
             </td>
             <td>
@@ -5193,7 +5164,7 @@
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -5204,28 +5175,20 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-tree">
-              <code><a data-cite="wai-aria-1.2#tree">tree</a></code>
+              <a data-cite="wai-aria-1.2#tree">`tree`</a>
             </th>
             <td>
               none
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -5244,33 +5207,16 @@
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-colcount">`aria-colcount`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-rowcount">`aria-rowcount`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a></li>
               </ul>
             </td>
             <td>
@@ -5285,28 +5231,16 @@
               <a data-cite="wai-aria-1.2#treeitem">`treeitem`</a>
             </th>
             <td>
-              none
+              <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-level">`aria-level`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a></li>
               </ul>
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -3334,7 +3334,7 @@
         <tbody>
           <tr>
             <th tabindex="-1" id="index-aria-global">
-              any
+              any - allows global `aria-*` attributes
             </th>
             <td>
               none
@@ -3342,67 +3342,54 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-atomic">`aria-atomic`</a>
+                  <a data-cite="wai-aria-1.2#aria-atomic">`aria-atomic`</a>
+                </li>
+                <!-- <li>
+                  <a data-cite="wai-aria-1.2#aria-brailleroledescription">`aria-brailleroledescription`</a>
+                </li> -->
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-busy">`aria-busy`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-busy">`aria-busy`</a>
+                  <a data-cite="wai-aria-1.2#aria-controls">`aria-controls`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-controls">`aria-controls`</a>
+                  <a data-cite="wai-aria-1.2#aria-current">`aria-current`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-current">`aria-current`</a>
+                  <a data-cite="wai-aria-1.2#aria-describedby">`aria-describedby`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-describedby">`aria-describedby`</a>
+                  <a data-cite="wai-aria-1.2#aria-details">`aria-details`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-details">`aria-details`</a>
+                  <a data-cite="wai-aria-1.2#aria-dropeffect">`aria-dropeffect`</a> (Deprecated in ARIA 1.1)</li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-flowto">`aria-flowto`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a>
+                  <a data-cite="wai-aria-1.2#aria-grabbed">`aria-grabbed`</a> (Deprecated in ARIA 1.1)</li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-dropeffect">`aria-dropeffect`</a> (deprecated in ARIA 1.1)
+                  <a data-cite="wai-aria-1.2#aria-keyshortcuts">`aria-keyshortcuts`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a>
+                  <a data-cite="wai-aria-1.2#aria-label">`aria-label`</a> (Except where prohibited)</li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-labelledby">`aria-labelledby`</a> (Except where prohibited)</li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-live">`aria-live`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-flowto">`aria-flowto`</a>
+                  <a data-cite="wai-aria-1.2#aria-owns">`aria-owns`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-grabbed">`aria-grabbed`</a>  (deprecated in ARIA 1.1)
+                  <a data-cite="wai-aria-1.2#aria-relevant">`aria-relevant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-keyshortcuts">`aria-keyshortcuts`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-label">`aria-label`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-labelledby">`aria-labelledby`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-live">`aria-live`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-owns">`aria-owns`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-relevant">`aria-relevant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-roledescription">`aria-roledescription`</a>
+                  <a data-cite="wai-aria-1.2#aria-roledescription">`aria-roledescription`</a>
                 </li>
               </ul>
             </td>
@@ -3415,13 +3402,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-alert">
-              <a data-cite="wai-aria-1.1#alert">`alert`</a>
+              <a data-cite="wai-aria-1.2#alert">`alert`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3432,20 +3419,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-alertdialog">
-              <a data-cite="wai-aria-1.1#alertdialog">`alertdialog`</a>
+              <a data-cite="wai-aria-1.2#alertdialog">`alertdialog`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-modal">`aria-modal`</a>
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.2#aria-modal">`aria-modal`</a>
             </td>
             <td>
               [=Flow content=]
@@ -3456,7 +3436,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-application">
-              <a data-cite="wai-aria-1.1#application">`application`</a>
+              <a data-cite="wai-aria-1.2#application">`application`</a>
             </th>
             <td>
               none
@@ -3464,10 +3444,22 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a>
                 </li>
               </ul>
             </td>
@@ -3480,15 +3472,20 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-article">
-              <a data-cite="wai-aria-1.1#article">`article`</a>
+              <a data-cite="wai-aria-1.2#article">`article`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <p>
-                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-              </p>
+              <ul>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
+                </li>
+              </ul>
             </td>
             <td>
               [=Flow content=]
@@ -3499,13 +3496,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-banner">
-              <a data-cite="wai-aria-1.1#banner">`banner`</a>
+              <a data-cite="wai-aria-1.2#banner">`banner`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               Document region
@@ -3514,9 +3511,26 @@
               No <a>main</a>, <a>header</a> or <a>footer</a> element descendants.
             </td>
           </tr>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-blockquote">
+              <a data-cite="wai-aria-1.2#blockquote">`blockquote`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              Global `aria-*` only
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
           <tr>
             <th tabindex="-1" id="index-aria-button">
-              <a data-cite="wai-aria-1.1#button">`button`</a>
+              <a data-cite="wai-aria-1.2#button">`button`</a>
             </th>
             <td>
               none
@@ -3524,11 +3538,13 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-pressed">`aria-pressed`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-pressed">`aria-pressed`</a></li>
               </ul>
             </td>
             <td>
@@ -3537,17 +3553,77 @@
             <td>
               [=Phrasing content=], but there must be no
               [=interactive content=] descendant.
+            </td>
+          </tr>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-caption">
+              <a data-cite="wai-aria-1.2#caption">`caption`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              Global `aria-*` only, except prohibited `aria-label` and `aria-labelledby`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
+          <tr>
+            <th tabindex="-1" id="index-aria-cell">
+              <a data-cite="wai-aria-1.2#cell">`cell`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-colspan">`aria-colspan`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-rowspan">`aria-rowspan`</a>
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=]
             </td>
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-checkbox">
-              <a data-cite="wai-aria-1.1#checkbox">`checkbox`</a>
+              <a data-cite="wai-aria-1.2#checkbox">`checkbox`</a>
             </th>
             <td>
-              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
+              <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+              <ul>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+              </ul>
             </td>
             <td>
               [=Interactive content=]
@@ -3557,39 +3633,26 @@
               [=interactive content=] descendant.
             </td>
           </tr>
-          <tr>
-            <th tabindex="-1" id="index-aria-cell">
-              <a data-cite="wai-aria-1.1#cell">`cell`</a>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-code">
+              <a data-cite="wai-aria-1.2#code">`code`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a>
-                </li>
-              </ul>
+              Global `aria-*` only, except prohibited `aria-label` and `aria-labelledby`
             </td>
             <td>
-              [=Flow content=]
+              TODO
             </td>
             <td>
-              [=Flow content=]
+              TODO
             </td>
-          </tr>
+          </tr> -->
           <tr>
             <th tabindex="-1" id="index-aria-columnheader">
-              <a data-cite="wai-aria-1.1#columnheader">`columnheader`</a>
+              <a data-cite="wai-aria-1.2#columnheader">`columnheader`</a>
             </th>
             <td>
               none
@@ -3597,32 +3660,35 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-sort">`aria-sort`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
-                </li>
+                  <a data-cite="wai-aria-1.2#aria-colindextext">`aria-colindextext`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-rowindextext">`aria-rowindextext`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
+                <li>
+                  <a data-cite="wai-aria-1.1#aria-sort">`aria-sort`</a></li>
               </ul>
             </td>
             <td>
@@ -3634,31 +3700,43 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-combobox">
-              <a data-cite="wai-aria-1.1#combobox">`combobox`</a>
+              <a data-cite="wai-aria-1.2#combobox">`combobox`</a>
             </th>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-controls">`aria-controls`</a>
+                  <a data-cite="wai-aria-1.2#aria-controls">`aria-controls`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
+                  <a data-cite="wai-aria-1.2#aria-autocomplete">`aria-autocomplete`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-errormessage">`aria-errormessage`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-haspopup">`aria-haspopup`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-invalid">`aria-invalid`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
                 </li>
               </ul>
             </td>
@@ -3671,13 +3749,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-complementary">
-              <a data-cite="wai-aria-1.1#complementary">`complementary`</a>
+              <a data-cite="wai-aria-1.2#complementary">`complementary`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3688,13 +3766,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-contentinfo">
-              <a data-cite="wai-aria-1.1#contentinfo">`contentinfo`</a>
+              <a data-cite="wai-aria-1.2#contentinfo">`contentinfo`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3705,15 +3783,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-definition">
-              <a data-cite="wai-aria-1.1#definition">`definition`</a>
+              <a data-cite="wai-aria-1.2#definition">`definition`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <p>
-                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-              </p>
+              Global `aria-*` only
             </td>
             <td>
               [=Phrasing content=]
@@ -3722,22 +3798,32 @@
               [=Phrasing content=]
             </td>
           </tr>
-          <tr>
-            <th tabindex="-1" id="index-aria-dialog">
-              <a data-cite="wai-aria-1.1#dialog">`dialog`</a>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-deletion">
+              <a data-cite="wai-aria-1.2#deletion">`deletion`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-modal">`aria-modal`</a>
-                </li>
-              </ul>
+              Global `aria-*` only, except prohibited `aria-label` and `aria-labelledby`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
+          <tr>
+            <th tabindex="-1" id="index-aria-dialog">
+              <a data-cite="wai-aria-1.2#dialog">`dialog`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+                <a data-cite="wai-aria-1.2#aria-modal">`aria-modal`</a>
             </td>
             <td>
               [=Flow content=]
@@ -3748,13 +3834,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-directory">
-              <a data-cite="wai-aria-1.1#directory">`directory`</a>
+              <a data-cite="wai-aria-1.2#directory">`directory`</a> (Deprecated in ARIA 1.2)
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3765,13 +3851,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-document">
-              <a data-cite="wai-aria-1.1#document">`document`</a>
+              <a data-cite="wai-aria-1.2#document">`document`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3780,15 +3866,32 @@
               [=Flow content=]
             </td>
           </tr>
-          <tr>
-            <th tabindex="-1" id="index-aria-feed">
-              <a data-cite="wai-aria-1.1#feed">`feed`</a>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-emphasis">
+              <a data-cite="wai-aria-1.2#emphasis">`emphasis`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only, except prohibited `aria-label` and `aria-labelledby`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
+          <tr>
+            <th tabindex="-1" id="index-aria-feed">
+              <a data-cite="wai-aria-1.2#feed">`feed`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3799,13 +3902,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-figure">
-              <a data-cite="wai-aria-1.1#figure">`figure`</a>
+              <a data-cite="wai-aria-1.2#figure">`figure`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3816,13 +3919,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-form">
-              <a data-cite="wai-aria-1.1#form">`form`</a>
+              <a data-cite="wai-aria-1.2#form">`form`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3831,9 +3934,26 @@
               [=Flow content=]
             </td>
           </tr>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-generic">
+              <a data-cite="wai-aria-1.2#generic">`generic`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              Global `aria-*` only, except prohibited `aria-label`,  `aria-labelledby`, and `aria-roledescription`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
           <tr>
             <th tabindex="-1" id="index-aria-grid">
-              <a data-cite="wai-aria-1.1#grid">`grid`</a>
+              <a data-cite="wai-aria-1.2#grid">`grid`</a>
             </th>
             <td>
               none
@@ -3841,26 +3961,15 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a>
-                </li>
+                  <a data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a></li>
               </ul>
             </td>
             <td>
@@ -3877,37 +3986,25 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-gridcell">
-              <a data-cite="wai-aria-1.1#gridcell">`gridcell`</a>
+              <a data-cite="wai-aria-1.2#gridcell">`gridcell`</a>
             </th>
             <td>
               none
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a></li>
               </ul>
             </td>
             <td>
@@ -3924,7 +4021,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-group">
-              <a data-cite="wai-aria-1.1#group">`group`</a>
+              <a data-cite="wai-aria-1.2#group">`group`</a>
             </th>
             <td>
               none
@@ -3932,10 +4029,10 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a>
                 </li>
               </ul>
             </td>
@@ -3948,20 +4045,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-heading">
-              <a data-cite="wai-aria-1.1#heading">`heading`</a>
+              <a data-cite="wai-aria-1.2#heading">`heading`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-                </li>
-              </ul>
+              <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a> (required)
             </td>
             <td>
               [=Heading content=]
@@ -3974,13 +4064,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-img">
-              <a data-cite="wai-aria-1.1#img">`img`</a>
+              <a data-cite="wai-aria-1.2#img">`img`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -3989,15 +4079,36 @@
               [=Phrasing content=]
             </td>
           </tr>
-          <tr>
-            <th tabindex="-1" id="index-aria-link">
-              <a data-cite="wai-aria-1.1#link">`link`</a>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-insertion">
+              <a data-cite="wai-aria-1.2#insertion">`insertion`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only, except prohibited `aria-label`, and `aria-labelledby`
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
+          <tr>
+            <th tabindex="-1" id="index-aria-link">
+              <a data-cite="wai-aria-1.2#link">`link`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              <ul>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-haspopup">`aria-haspopup`</a></li>
+              </ul>
             </td>
             <td>
               [=Flow content=]
@@ -4009,13 +4120,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-list">
-              <a data-cite="wai-aria-1.1#list">`list`</a>
+              <a data-cite="wai-aria-1.2#list">`list`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4026,28 +4137,22 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-listbox">
-              <a data-cite="wai-aria-1.1#listbox">`listbox`</a>
+              <a data-cite="wai-aria-1.2#listbox">`listbox`</a>
             </th>
             <td>
               none
             </td>
             <td>
               <ul>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
-                </li>
+                <li><a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-errormessage">`aria-errormessage`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-invalid">`aria-invalid`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a></li>
+                <li><a data-cite="wai-aria-1.1#aria-required">`aria-required`</a></li>
               </ul>
             </td>
             <td>
@@ -4064,7 +4169,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-listitem">
-              <a data-cite="wai-aria-1.1#listitem">`listitem`</a>
+              <a data-cite="wai-aria-1.2#listitem">`listitem`</a>
             </th>
             <td>
               none
@@ -4072,16 +4177,13 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
+                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
-                </li>
-                <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
@@ -4094,13 +4196,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-log">
-              <a data-cite="wai-aria-1.1#log">`log`</a>
+              <a data-cite="wai-aria-1.2#log">`log`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4111,13 +4213,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-main">
-              <a data-cite="wai-aria-1.1#main">`main`</a>
+              <a data-cite="wai-aria-1.2#main">`main`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4128,13 +4230,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-marquee">
-              <a data-cite="wai-aria-1.1#marquee">`marquee`</a>
+              <a data-cite="wai-aria-1.2#marquee">`marquee`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4145,13 +4247,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-math">
-              <a data-cite="wai-aria-1.1#math">`math`</a>
+              <a data-cite="wai-aria-1.2#math">`math`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              Global `aria-*` only
             </td>
             <td>
               [=Flow content=]
@@ -4162,7 +4264,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-menu">
-              <a data-cite="wai-aria-1.1#menu">`menu`</a>
+              <a data-cite="wai-aria-1.2#menu">`menu`</a>
             </th>
             <td>
               none
@@ -4170,13 +4272,13 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -4189,12 +4291,12 @@
               </p>
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=], but only with allowed
             </td>
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-menubar">
-              <a data-cite="wai-aria-1.1#menubar">`menubar`</a>
+              <a data-cite="wai-aria-1.2#menubar">`menubar`</a>
             </th>
             <td>
               none
@@ -4202,13 +4304,13 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -4226,7 +4328,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-menuitem">
-              <a data-cite="wai-aria-1.1#menuitem">`menuitem`</a>
+              <a data-cite="wai-aria-1.2#menuitem">`menuitem`</a>
             </th>
             <td>
               none
@@ -4234,10 +4336,10 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
@@ -4251,18 +4353,18 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-menuitemcheckbox">
-              <a data-cite="wai-aria-1.1#menuitemcheckbox">`menuitemcheckbox`</a>
+              <a data-cite="wai-aria-1.2#menuitemcheckbox">`menuitemcheckbox`</a>
             </th>
             <td>
-              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
+              <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
@@ -4276,18 +4378,18 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-menuitemradio">
-              <a data-cite="wai-aria-1.1#menuitemradio">`menuitemradio`</a>
+              <a data-cite="wai-aria-1.2#menuitemradio">`menuitemradio`</a>
             </th>
             <td>
-              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
+              <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
@@ -4299,15 +4401,45 @@
               [=interactive content=] descendants.
             </td>
           </tr>
-          <tr>
-            <th tabindex="-1" id="index-aria-navigation">
-              <a data-cite="wai-aria-1.1#navigation">`navigation`</a>
+          <!-- <tr>
+            <th tabindex="-1" id="index-aria-meter">
+              <a data-cite="wai-aria-1.2#meter">`meter`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              <ul>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a>
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a> (required)
+                </li>
+                <li>
+                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a>
+                </li>
+              </ul>
+            </td>
+            <td>
+              TODO
+            </td>
+            <td>
+              TODO
+            </td>
+          </tr> -->
+          <tr>
+            <th tabindex="-1" id="index-aria-navigation">
+              <a data-cite="wai-aria-1.2#navigation">`navigation`</a>
+            </th>
+            <td>
+              none
+            </td>
+            <td>
+              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
               [=Flow content=]
@@ -4318,7 +4450,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-none">
-              <a data-cite="wai-aria-1.1#none">`none`</a>
+              <a data-cite="wai-aria-1.2#none">`none`</a>
             </th>
             <td>
               none
@@ -4334,13 +4466,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-note">
-              <a data-cite="wai-aria-1.1#note">`note`</a>
+              <a data-cite="wai-aria-1.2#note">`note`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
               [=Flow content=]
@@ -4351,7 +4483,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-option">
-              <a data-cite="wai-aria-1.1#option">`option`</a>
+              <a data-cite="wai-aria-1.2#option">`option`</a>
             </th>
             <td>
               none
@@ -4359,16 +4491,16 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
+                  <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
+                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
@@ -4382,7 +4514,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-presentation">
-              <a data-cite="wai-aria-1.1#presentation">`presentation`</a>
+              <a data-cite="wai-aria-1.2#presentation">`presentation`</a>
             </th>
             <td>
               none
@@ -4397,7 +4529,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-progressbar">
-              <a data-cite="wai-aria-1.1#progressbar">`progressbar`</a>
+              <a data-cite="wai-aria-1.2#progressbar">`progressbar`</a>
             </th>
             <td>
               none
@@ -4405,16 +4537,16 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a>
                 </li>
               </ul>
             </td>
@@ -4427,21 +4559,21 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-radio">
-              <a data-cite="wai-aria-1.1#radio">`radio`</a>
+              <a data-cite="wai-aria-1.2#radio">`radio`</a>
             </th>
             <td>
-              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
+              <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
+                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
@@ -4455,7 +4587,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-radiogroup">
-              <a data-cite="wai-aria-1.1#radiogroup">`radiogroup`</a>
+              <a data-cite="wai-aria-1.2#radiogroup">`radiogroup`</a>
             </th>
             <td>
               none
@@ -4463,16 +4595,16 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -4485,13 +4617,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-region">
-              <a data-cite="wai-aria-1.1#region">`region`</a>
+              <a data-cite="wai-aria-1.2#region">`region`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
               [=Flow content=]
@@ -4502,7 +4634,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-row">
-              <a data-cite="wai-aria-1.1#row">`row`</a>
+              <a data-cite="wai-aria-1.2#row">`row`</a>
             </th>
             <td>
               none
@@ -4513,16 +4645,16 @@
               </p>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
+                  <a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a>
                 </li>
                 <li>
-                  <a title="aria-rowindex" data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
+                  <a title="aria-rowindex" data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
+                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
               </ul>
               <p>
@@ -4530,16 +4662,16 @@
               </p>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
+                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
               </ul>
             </td>
@@ -4552,7 +4684,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-rowgroup">
-              <a data-cite="wai-aria-1.1#rowgroup">`rowgroup`</a>
+              <a data-cite="wai-aria-1.2#rowgroup">`rowgroup`</a>
             </th>
             <td>
               none
@@ -4567,7 +4699,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-rowheader">
-              <a data-cite="wai-aria-1.1#rowheader">`rowheader`</a>
+              <a data-cite="wai-aria-1.2#rowheader">`rowheader`</a>
             </th>
             <td>
               none
@@ -4575,28 +4707,28 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
+                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan`</a>
+                  <a data-cite="wai-aria-1.2#aria-colspan">`aria-colspan`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colindex">`aria-colindex`</a>
+                  <a data-cite="wai-aria-1.2#aria-colindex">`aria-colindex`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-rowindex">`aria-rowindex`</a>
+                  <a data-cite="wai-aria-1.2#aria-rowindex">`aria-rowindex`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan`</a>
+                  <a data-cite="wai-aria-1.2#aria-rowspan">`aria-rowspan`</a>
                 </li>
               </ul>
             </td>
@@ -4609,34 +4741,34 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-scrollbar">
-              <a data-cite="wai-aria-1.1#scrollbar">`scrollbar`</a>
+              <a data-cite="wai-aria-1.2#scrollbar">`scrollbar`</a>
             </th>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-controls">`aria-controls`</a>
+                  <a data-cite="wai-aria-1.2#aria-controls">`aria-controls`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a>
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a>
                 </li>
               </ul>
             </td>
@@ -4654,13 +4786,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-search">
-              <a data-cite="wai-aria-1.1#search">`search`</a>
+              <a data-cite="wai-aria-1.2#search">`search`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
               [=Flow content=]
@@ -4671,7 +4803,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-searchbox">
-              <a data-cite="wai-aria-1.1#searchbox">`searchbox`</a>
+              <a data-cite="wai-aria-1.2#searchbox">`searchbox`</a>
             </th>
             <td>
               none
@@ -4679,22 +4811,22 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a>
+                  <a data-cite="wai-aria-1.2#aria-autocomplete">`aria-autocomplete`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-multiline">`aria-multiline`</a>
+                  <a data-cite="wai-aria-1.2#aria-multiline">`aria-multiline`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder`</a>
+                  <a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
                 </li>
               </ul>
             </td>
@@ -4708,28 +4840,28 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-separator">
-              <a data-cite="wai-aria-1.1#separator">`separator`</a>
+              <a data-cite="wai-aria-1.2#separator">`separator`</a>
             </th>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a> (if focusable)
+                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a> (if focusable)
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a> (if focusable)
+                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a> (if focusable)
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a> (if focusable)
+                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a> (if focusable)
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a> (if focusable)
+                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a> (if focusable)
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -4742,28 +4874,28 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-slider">
-              <a data-cite="wai-aria-1.1#slider">`slider`</a>
+              <a data-cite="wai-aria-1.2#slider">`slider`</a>
             </th>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a>
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a>
                 </li>
               </ul>
             </td>
@@ -4776,31 +4908,31 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-spinbutton">
-              <a data-cite="wai-aria-1.1#spinbutton">`spinbutton`</a>
+              <a data-cite="wai-aria-1.2#spinbutton">`spinbutton`</a>
             </th>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemax">`aria-valuemax`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuemin">`aria-valuemin`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuemin">`aria-valuemin`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuenow">`aria-valuenow`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuenow">`aria-valuenow`</a>
                 </li>
               </ul>
             </td>
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-valuetext">`aria-valuetext`</a>
+                  <a data-cite="wai-aria-1.2#aria-valuetext">`aria-valuetext`</a>
                 </li>
               </ul>
             </td>
@@ -4818,13 +4950,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-status">
-              <a data-cite="wai-aria-1.1#status">`status`</a>
+              <a data-cite="wai-aria-1.2#status">`status`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
               [=Flow content=]
@@ -4835,13 +4967,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-switch">
-              <a data-cite="wai-aria-1.1#switch">`switch`</a>
+              <a data-cite="wai-aria-1.2#switch">`switch`</a>
             </th>
             <td>
-              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
+              <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+              <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
             </td>
             <td>
               [=Interactive content=]
@@ -4853,7 +4985,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-tab">
-              <a data-cite="wai-aria-1.1#tab">`tab`</a>
+              <a data-cite="wai-aria-1.2#tab">`tab`</a>
             </th>
             <td>
               none
@@ -4861,16 +4993,16 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
+                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
               </ul>
             </td>
@@ -4884,7 +5016,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-table">
-              <a data-cite="wai-aria-1.1#table">`table`</a>
+              <a data-cite="wai-aria-1.2#table">`table`</a>
             </th>
             <td>
               none
@@ -4892,10 +5024,10 @@
             <td>
               <ul>
                 <li>
-                  <a title="aria-colcount" data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a>
+                  <a title="aria-colcount" data-cite="wai-aria-1.2#aria-colcount">`aria-colcount`</a>
                 </li>
                 <li>
-                  <a title="aria-rowcount" data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a>
+                  <a title="aria-rowcount" data-cite="wai-aria-1.2#aria-rowcount">`aria-rowcount`</a>
                 </li>
               </ul>
             </td>
@@ -4908,7 +5040,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-tablist">
-              <a data-cite="wai-aria-1.1#tablist">`tablist`</a>
+              <a data-cite="wai-aria-1.2#tablist">`tablist`</a>
             </th>
             <td>
               none
@@ -4916,16 +5048,16 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
+                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
+                  <a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a>
                 </li>
               </ul>
             </td>
@@ -4938,14 +5070,14 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-tabpanel">
-              <a data-cite="wai-aria-1.1#tabpanel">`tabpanel`</a>
+              <a data-cite="wai-aria-1.2#tabpanel">`tabpanel`</a>
             </th>
             <td>
               none
             </td>
             <td>
               <p>
-                <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
               </p>
             </td>
             <td>
@@ -4957,13 +5089,13 @@
           </tr>
           <tr>
             <th id="index-aria-term" tabindex="-1">
-              <a data-cite="wai-aria-1.1#term">`term`</a>
+              <a data-cite="wai-aria-1.2#term">`term`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
               [=Phrasing content=]
@@ -4974,7 +5106,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-textbox">
-              <a data-cite="wai-aria-1.1#textbox">`textbox`</a>
+              <a data-cite="wai-aria-1.2#textbox">`textbox`</a>
             </th>
             <td>
               none
@@ -4982,22 +5114,22 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-autocomplete">`aria-autocomplete`</a>
+                  <a data-cite="wai-aria-1.2#aria-autocomplete">`aria-autocomplete`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-multiline">`aria-multiline`</a>
+                  <a data-cite="wai-aria-1.2#aria-multiline">`aria-multiline`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder`</a>
+                  <a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
                 </li>
               </ul>
             </td>
@@ -5011,13 +5143,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-timer">
-              <a data-cite="wai-aria-1.1#timer">`timer`</a>
+              <a data-cite="wai-aria-1.2#timer">`timer`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
               [=Flow content=]
@@ -5028,7 +5160,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-toolbar">
-              <a data-cite="wai-aria-1.1#toolbar">`toolbar`</a>
+              <a data-cite="wai-aria-1.2#toolbar">`toolbar`</a>
             </th>
             <td>
               none
@@ -5036,13 +5168,13 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -5055,13 +5187,13 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-tooltip">
-              <a data-cite="wai-aria-1.1#tooltip">`tooltip`</a>
+              <a data-cite="wai-aria-1.2#tooltip">`tooltip`</a>
             </th>
             <td>
               none
             </td>
             <td>
-              <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+              <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
               [=Flow content=]
@@ -5072,7 +5204,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-tree">
-              <code><a data-cite="wai-aria-1.1#tree">tree</a></code>
+              <code><a data-cite="wai-aria-1.2#tree">tree</a></code>
             </th>
             <td>
               none
@@ -5080,19 +5212,19 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
+                  <a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
               </ul>
             </td>
@@ -5105,7 +5237,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-treegrid">
-              <a data-cite="wai-aria-1.1#treegrid">`treegrid`</a>
+              <a data-cite="wai-aria-1.2#treegrid">`treegrid`</a>
             </th>
             <td>
               none
@@ -5113,31 +5245,31 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
+                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-multiselectable">`aria-multiselectable`</a>
+                  <a data-cite="wai-aria-1.2#aria-multiselectable">`aria-multiselectable`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+                  <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-activedescendant">`aria-activedescendant`</a>
+                  <a data-cite="wai-aria-1.2#aria-activedescendant">`aria-activedescendant`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-required">`aria-required`</a>
+                  <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-orientation">`aria-orientation`</a>
+                  <a data-cite="wai-aria-1.2#aria-orientation">`aria-orientation`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-colcount">`aria-colcount`</a>
+                  <a data-cite="wai-aria-1.2#aria-colcount">`aria-colcount`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-rowcount">`aria-rowcount`</a>
+                  <a data-cite="wai-aria-1.2#aria-rowcount">`aria-rowcount`</a>
                 </li>
               </ul>
             </td>
@@ -5150,7 +5282,7 @@
           </tr>
           <tr>
             <th tabindex="-1" id="index-aria-treeitem">
-              <a data-cite="wai-aria-1.1#treeitem">`treeitem`</a>
+              <a data-cite="wai-aria-1.2#treeitem">`treeitem`</a>
             </th>
             <td>
               none
@@ -5158,22 +5290,22 @@
             <td>
               <ul>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-level">`aria-level`</a>
+                  <a data-cite="wai-aria-1.2#aria-level">`aria-level`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-posinset">`aria-posinset`</a>
+                  <a data-cite="wai-aria-1.2#aria-posinset">`aria-posinset`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-setsize">`aria-setsize`</a>
+                  <a data-cite="wai-aria-1.2#aria-setsize">`aria-setsize`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
+                  <a data-cite="wai-aria-1.2#aria-expanded">`aria-expanded`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
+                  <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a>
                 </li>
                 <li>
-                  <a data-cite="wai-aria-1.1#aria-selected">`aria-selected`</a>
+                  <a data-cite="wai-aria-1.2#aria-selected">`aria-selected`</a>
                 </li>
               </ul>
             </td>


### PR DESCRIPTION
This PR replaces the closed #198 PR

Updates the informative cells of the Allowed ARIA roles, states and properties to reflect ARIA 1.2 allowances

closes #192 
closes #251


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/300.html" title="Last updated on May 13, 2021, 10:00 PM UTC (fadba54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/300/813397c...fadba54.html" title="Last updated on May 13, 2021, 10:00 PM UTC (fadba54)">Diff</a>