### PR TITLE
Editorial changes to structure/prose

### DIFF
--- a/index.html
+++ b/index.html
@@ -5197,11 +5197,10 @@
       </p>
       <p>
         A conforming document MUST NOT contain any elements with author defined `role` or `aria-*` attributes with values other than those
-        which have been indicated authors MAY use on each [=HTML element=] in [[[#docconformance]]].
-        Conformance checkers SHOULD surface failures of authors explicitly
-        defining a `role` on an element which matches its
-        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a>.
-        Authors are NOT RECOMMENDED to explicitly set these roles.
+        which, per this specification, authors MAY use on each [=HTML element=] in [[[#docconformance]]].
+        Conformance checkers SHOULD flag instances where authors are explicitly
+        providing an element with a `role` which matches its
+        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a> as failures, as it is NOT RECOMMENDED for authors to explicitly set these roles.
       </p>
       <p>
         A conformance checker MAY define their own terminology, and level or levels of severity, when surfacing document failures to conform to this specification.

--- a/index.html
+++ b/index.html
@@ -50,14 +50,13 @@
     </section>
     <section id="sotd">
       <p>
-        ARIA in HTML is a [[HTML]] specification module. Any HTML features,
+        ARIA in HTML is an [[HTML]] specification module. Any HTML features,
         conformance requirements, or terms that this specification module makes
         reference to, but does not explicitly define, are defined in the
         [[HTML|HTML specification]].
       </p>
       <p class="advisement" hidden>
-        This is a draft document and its contents are subject to change without
-        notice.
+        This is a draft document and its contents are subject to change without notice.
       </p>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -5118,8 +5118,8 @@
     </section>
     <section id="conformance">
       <p>
-        Conformance checkers that claim support for checking ARIA in HTML,
-        MUST implement checks for the document conformance requirements for use
+        Conformance checkers that claim support for checking ARIA in HTML documents
+        MUST implement checks for the conformance requirements for use
         of the ARIA `role` and `aria-*` attributes on [=HTML elements=] as
         defined in this specification.
       </p>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     </script>
     <link rel="stylesheet" href="makeup.css">
   </head>
-  <body data-cite="HTML">
+  <body data-cite="HTML WAI-ARIA">
     <section id="abstract">
       <p>
         This specification defines the authoring rules (author conformance
@@ -69,9 +69,9 @@
         the exposed meaning (<a data-cite="html/dom.html#semantics-2">semantics</a>) of
         [=HTML elements=], in accordance with the requirements described in
         [[wai-aria-1.1|WAI-ARIA]], except where these conflict with the
-        <dfn><a data-cite="wai-aria-1.1#host_general_conflict">strong native semantics</a></dfn>
+        <dfn data-cite="wai-aria-1.1#host_general_conflict">strong native semantics</dfn>
         or are equal to the
-        <dfn><a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a></dfn>
+        <dfn data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</dfn>
         of a given HTML element. The <a>implicit ARIA semantics</a> for
         HTML elements are defined in the
         <dfn>[[html-aam-1.0|HTML Accessibility API Mappings]]</dfn> specification.
@@ -968,7 +968,7 @@
             </th>
             <td>
               If the [^form^] element has an
-              <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>:
+              [=accessible name=]:
               <code>role=<a href="#index-aria-form">form</a></code>.
               Otherwise, <a>no corresponding role</a>.
             </td>

--- a/index.html
+++ b/index.html
@@ -5125,11 +5125,10 @@
       </p>
       <p>
         A conforming document MUST NOT contain any elements with author defined `role` or `aria-*` attributes with values other than those
-        which have been indicated authors MAY use on each [=HTML element=] in [[[#docconformance]]].
-        Conformance checkers SHOULD surface failures of authors explicitly
-        defining a `role` on an element which matches its
-        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a>.
-        Authors are NOT RECOMMENDED to explicitly set these roles.
+        which, per this specification, authors MAY use on each [=HTML element=] in [[[#docconformance]]].
+        Conformance checkers SHOULD flag instances where authors are explicitly
+        providing an element with a `role` which matches its
+        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a> as failures, as it is NOT RECOMMENDED for authors to explicitly set these roles.
       </p>
       <p>
         A conformance checker MAY define their own terminology, and level or levels of severity, when surfacing document failures to conform to this specification.

--- a/index.html
+++ b/index.html
@@ -5190,8 +5190,8 @@
     </section>
     <section id="conformance">
       <p>
-        Conformance checkers that claim support for checking ARIA in HTML,
-        MUST implement checks for the document conformance requirements for use
+        Conformance checkers that claim support for checking ARIA in HTML documents
+        MUST implement checks for the conformance requirements for use
         of the ARIA `role` and `aria-*` attributes on [=HTML elements=] as
         defined in this specification.
       </p>

--- a/index.html
+++ b/index.html
@@ -3408,10 +3408,10 @@
               </ul>
             </td>
             <td>
-              n/a
+              Not applicable
             </td>
             <td>
-              n/a
+              Not applicable
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
         <dfn data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</dfn>
         of a given HTML element. The <a>implicit ARIA semantics</a> for
         HTML elements are defined in the
-        <dfn>[[html-aam-1.0|HTML Accessibility API Mappings]]</dfn> specification.
+        [[html-aam-1.0|HTML Accessibility API Mappings]] specification.
       </p>
       <p>
         The constraints defined in this specification are intended to prevent

--- a/index.html
+++ b/index.html
@@ -2841,320 +2841,321 @@
 &lt;/figure&gt;
 </pre><!-- source: http://www.geocities.com/SoHo/7373/aquatic.htm#fish -->
       </aside>
+      <section>
+        <h3 id="docconformance-attr">
+          Requirements for use of ARIA attributes in place of equivalent HTML attributes
+        </h3>
+        <p>
+          Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a [^button^] element, rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
+          <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
+          user agents MUST ignore WAI-ARIA attributes and use the host language
+          (HTML) attribute with the same <a>implicit ARIA semantics</a>.
+        </p>
+        <p>
+          The following table represents HTML elements and their attributes which have `aria-*` attribute parity.
+        </p>
+        <p>
+          Each language feature (element and attribute) in a cell in the first
+          column implies the ARIA semantics (states, and properties) given in
+          the cell in the second column of the same row. The third cell in each
+          row defines how authors can use the native HTML feature, along with
+          requirements for using the `aria-*` attributes that supply the same
+          <a>implicit ARIA semantics</a>.
+        </p>
+        <table class="simple">
+          <caption>
+            Rules of ARIA attribute usage by HTML feature
+          </caption>
+          <thead>
+            <tr>
+              <th>
+                HTML feature
+              </th>
+              <th>
+                <p id="implicit-attr">
+                  Implicit ARIA semantics
+                </p>
+              </th>
+              <th>
+                HTML feature and `aria-*` attribute author guidance
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr id="att-checked" tabindex="-1">
+              <th>
+                Any element where the [^input/checked^] attribute is allowed
+              </th>
+              <td>
+                `aria-checked="true"`
+              </td>
+              <td>
+                <p>
+                  Use the `checked` attribute on any element that is
+                  allowed the `checked` attribute in HTML.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-checked` attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> of the element can be in opposition to the current value of the <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` attribute</a>.
+                </p>
+                <p>
+                  Authors MAY use the `aria-checked` attribute on any other element with a WAI-ARIA role which allows the  attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-disabled" tabindex="-1">
+              <th>
+                Any element where the [^input/disabled^]
+                attribute is allowed, including
+                `option` [^option/disabled^] and
+                `optgroup` [^optgroup/disabled^]
+              </th>
+              <td>
+                `aria-disabled="true"`
+              </td>
+              <td>
+                <p>
+                  Use the `disabled` attribute on any element that is allowed the `disabled` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-disabled` attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-disabled="false"` on any element which also has a `disabled` attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-hidden" tabindex="-1">
+              <th>
+                Any element with a [^html-global/hidden^] attribute
+              </th>
+              <td>
+                `aria-hidden="true"`
+              </td>
+              <td>
+                <p>
+                  Authors MAY use the `aria-hidden` attribute on any HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a>, with the following exception:
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-hidden="true"` attribute on any element which also has a `hidden` attribute.
+                </p>
 
-      <h3 id="docconformance-attr">
-        Document conformance requirements for use of ARIA attributes with HTML attributes
-      </h3>
-      <p>
-        Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a [^button^] element, rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
-        <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
-        user agents MUST ignore WAI-ARIA attributes and use the host language
-        (HTML) attribute with the same <a>implicit ARIA semantics</a>.
-      </p>
-      <p>
-        The following table represents HTML elements and their attributes which have `aria-*` attribute parity.
-      </p>
-      <p>
-        Each language feature (element and attribute) in a cell in the first
-        column implies the ARIA semantics (states, and properties) given in
-        the cell in the second column of the same row. The third cell in each
-        row defines how authors can use the native HTML feature, along with
-        requirements for using the `aria-*` attributes that supply the same
-        <a>implicit ARIA semantics</a>.
-      </p>
-      <table class="simple">
-        <caption>
-          Rules of ARIA attribute usage by HTML feature
-        </caption>
-        <thead>
-          <tr>
-            <th>
-              HTML feature
-            </th>
-            <th>
-              <p id="implicit-attr">
-                Implicit ARIA semantics
-              </p>
-            </th>
-            <th>
-              HTML feature and `aria-*` attribute author guidance
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr id="att-checked" tabindex="-1">
-            <th>
-              Any element where the [^input/checked^] attribute is allowed
-            </th>
-            <td>
-              `aria-checked="true"`
-            </td>
-            <td>
-              <p>
-                Use the `checked` attribute on any element that is
-                allowed the `checked` attribute in HTML.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-checked` attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> of the element can be in opposition to the current value of the <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` attribute</a>.
-              </p>
-              <p>
-                Authors MAY use the `aria-checked` attribute on any other element with a WAI-ARIA role which allows the  attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-disabled" tabindex="-1">
-            <th>
-              Any element where the [^input/disabled^]
-               attribute is allowed, including
-              `option` [^option/disabled^] and
-              `optgroup` [^optgroup/disabled^]
-            </th>
-            <td>
-              `aria-disabled="true"`
-            </td>
-            <td>
-              <p>
-                Use the `disabled` attribute on any element that is allowed the `disabled` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-disabled` attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-disabled="false"` on any element which also has a `disabled` attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-hidden" tabindex="-1">
-            <th>
-              Any element with a [^html-global/hidden^] attribute
-            </th>
-            <td>
-              `aria-hidden="true"`
-            </td>
-            <td>
-              <p>
-                Authors MAY use the `aria-hidden` attribute on any HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a>, with the following exception:
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-hidden="true"` attribute on any element which also has a `hidden` attribute.
-              </p>
-
-              <!-- this will be covered as part of issue 221 -->
-              <!-- <p>
-                Authors MUST NOT use `aria-hidden="true"` on an element that can receive keyboard focus, or on an ancestor element to an element or elements which can receive keyboard focus.
-              </p>
-              <p>
-                Any elements which can receive keyboard focus, interactive elements or otherwise, MUST have their ability to receive keyboard focus removed while the `aria-hidden="true"` attribute is present. For instance, by using `tabindex="-1"` on any focusable elements with `aria-hidden="true"`, or setting `tabindex="-1"` to focusable elements that are descendants of an `aria-hidden="true"` containing element.
-              </p> -->
-            </td>
-          </tr>
-          <tr id="att-placeholder" tabindex="-1">
-            <th>
-              Any element where the [^input/placeholder^] attribute is allowed
-            </th>
-            <td>
-              `aria-placeholder="..."`
-            </td>
-            <td>
-              <p>
-                Use the `placeholder` attribute on any element that is allowed the
-                `placeholder` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
-              </p>
-              <p>
-                Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-max" tabindex="-1">
-            <th>
-              Any element where the `max` attribute is allowed: `meter` [^meter/max^], `progress` [^progress/max^], and `input` [^input/max^]
-            </th>
-            <td>
-              `aria-valuemax="..."`
-            </td>
-            <td>
-              <p>
-                Use the `max` attribute on any element that is
-                allowed the `max` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-valuemax` attribute on any other element with a WAI-ARIA role which allows the attribute.
-              </p>
-              <p>
-                Authors SHOULD NOT use `aria-valuemax` on any element which allows the `max` attribute. Use the `max` attribute instead.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-valuemax` on any element which also has a `max` attribute, even if the values of each attribute match.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-min" tabindex="-1">
-            <th>
-              Any element where the `min` attribute is allowed: `meter` [^meter/min^] and `input` [^input/min^]
-            </th>
-            <td>
-              `aria-valuemin="..."`
-            </td>
-            <td>
-              <p>
-                Use the `min` attribute on any element that is
-                allowed the `min` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-valuemin` attribute on any other element with a WAI-ARIA role which allows the attribute.
-              </p>
-              <p>
-                Authors SHOULD NOT use `aria-valuemin` on any element which allows the `min` attribute. Use the `min` attribute instead.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-valuemin` on any element which also has a `min` attribute, even if the values of each attribute match.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-readonly" tabindex="-1">
-            <th>
-              Any element which allows the `readonly` attribute:
-              `input` [^input/readonly^], `textarea` [^textarea/readonly^] and <a>form-associated custom element</a> which allows the [^face/readonly^]
-            </th>
-            <td>
-              `aria-readonly="true"`
-            </td>
-            <td>
-              <p>
-                Use the `readonly` attribute on any element that is
-                allowed the `readonly` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-readonly` attribute on any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-readonly="false"` on any element which also has a `readonly` attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-contenteditable" tabindex="-1">
-            <th>
-              <p>
-                Element with [^html-global/contenteditable^]`=true`
-                or
-                element without `contenteditable` attribute whose closest
-                ancestor with a `contenteditable` attribute has
-                `contenteditable="true"`.
-              </p>
-              <p class="note">
-                This is equivalent to the <a data-cite=
-                "html/interaction.html#dom-iscontenteditable">`isContentEditable`</a>
-                IDL attribute.
-              </p>
-            </th>
-            <td>
-              `aria-readonly="false"`
-            </td>
-            <td>
-              Authors MUST NOT set `aria-readonly="true"` on an element that has `isContentEditable="true"`.
-            </td>
-          </tr>
-          <tr id="att-required" tabindex="-1">
-            <th>
-              Any element where the `required` attribute is allowed: `input` [^input/required^], `textarea` [^textarea/required^], and `select` [^select/required^]
-            </th>
-            <td>
-              `aria-required="true"`
-            </td>
-            <td>
-              <p>
-                Use the `required` attribute on any element
-                that is allowed the `required` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-required` attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-required">`aria-required` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-required="true"` on any element which also has a `required` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-required="false"` on any element which also has a `required` attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-colspan" tabindex="-1">
-            <th>
-              Any element where the [^th/colspan^] attribute is allowed: `td` and `th`
-            </th>
-            <td>
-              `aria-colspan="..."`
-            </td>
-            <td>
-              <p>
-                Use the `colspan` attribute on any element that is
-                allowed the `colspan` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-colspan` attribute on any element that is allowed the `colspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-colspan` attribute on any element which also has a `colspan` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-colspan` on any element which also has a `colspan` attribute, and the values of each attribute do not match.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-rowspan" tabindex="-1">
-            <th>
-              Any element where the [^th/rowspan^] attribute is allowed:
-              `td` and `th`
-            </th>
-            <td>
-              `aria-rowspan="..."`
-            </td>
-            <td>
-              <p>
-                Use the `rowspan` attribute on any element that is
-                allowed the `rowspan` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-rowspan` attribute on any element that is allowed the `rowspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-rowspan` attribute on any element which also has a `rowspan` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-rowspan` on any element which also has a `rowspan` attribute, and the values of each attribute do not match.
-              </p>
-            </td>
-          </tr>
+                <!-- this will be covered as part of issue 221 -->
+                <!-- <p>
+                  Authors MUST NOT use `aria-hidden="true"` on an element that can receive keyboard focus, or on an ancestor element to an element or elements which can receive keyboard focus.
+                </p>
+                <p>
+                  Any elements which can receive keyboard focus, interactive elements or otherwise, MUST have their ability to receive keyboard focus removed while the `aria-hidden="true"` attribute is present. For instance, by using `tabindex="-1"` on any focusable elements with `aria-hidden="true"`, or setting `tabindex="-1"` to focusable elements that are descendants of an `aria-hidden="true"` containing element.
+                </p> -->
+              </td>
+            </tr>
+            <tr id="att-placeholder" tabindex="-1">
+              <th>
+                Any element where the [^input/placeholder^] attribute is allowed
+              </th>
+              <td>
+                `aria-placeholder="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `placeholder` attribute on any element that is allowed the
+                  `placeholder` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
+                </p>
+                <p>
+                  Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-max" tabindex="-1">
+              <th>
+                Any element where the `max` attribute is allowed: `meter` [^meter/max^], `progress` [^progress/max^], and `input` [^input/max^]
+              </th>
+              <td>
+                `aria-valuemax="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `max` attribute on any element that is
+                  allowed the `max` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-valuemax` attribute on any other element with a WAI-ARIA role which allows the attribute.
+                </p>
+                <p>
+                  Authors SHOULD NOT use `aria-valuemax` on any element which allows the `max` attribute. Use the `max` attribute instead.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-valuemax` on any element which also has a `max` attribute, even if the values of each attribute match.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-min" tabindex="-1">
+              <th>
+                Any element where the `min` attribute is allowed: `meter` [^meter/min^] and `input` [^input/min^]
+              </th>
+              <td>
+                `aria-valuemin="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `min` attribute on any element that is
+                  allowed the `min` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-valuemin` attribute on any other element with a WAI-ARIA role which allows the attribute.
+                </p>
+                <p>
+                  Authors SHOULD NOT use `aria-valuemin` on any element which allows the `min` attribute. Use the `min` attribute instead.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-valuemin` on any element which also has a `min` attribute, even if the values of each attribute match.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-readonly" tabindex="-1">
+              <th>
+                Any element which allows the `readonly` attribute:
+                `input` [^input/readonly^], `textarea` [^textarea/readonly^] and <a>form-associated custom element</a> which allows the [^face/readonly^]
+              </th>
+              <td>
+                `aria-readonly="true"`
+              </td>
+              <td>
+                <p>
+                  Use the `readonly` attribute on any element that is
+                  allowed the `readonly` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-readonly` attribute on any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-readonly="false"` on any element which also has a `readonly` attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-contenteditable" tabindex="-1">
+              <th>
+                <p>
+                  Element with [^html-global/contenteditable^]`=true`
+                  or
+                  element without `contenteditable` attribute whose closest
+                  ancestor with a `contenteditable` attribute has
+                  `contenteditable="true"`.
+                </p>
+                <p class="note">
+                  This is equivalent to the <a data-cite=
+                  "html/interaction.html#dom-iscontenteditable">`isContentEditable`</a>
+                  IDL attribute.
+                </p>
+              </th>
+              <td>
+                `aria-readonly="false"`
+              </td>
+              <td>
+                Authors MUST NOT set `aria-readonly="true"` on an element that has `isContentEditable="true"`.
+              </td>
+            </tr>
+            <tr id="att-required" tabindex="-1">
+              <th>
+                Any element where the `required` attribute is allowed: `input` [^input/required^], `textarea` [^textarea/required^], and `select` [^select/required^]
+              </th>
+              <td>
+                `aria-required="true"`
+              </td>
+              <td>
+                <p>
+                  Use the `required` attribute on any element
+                  that is allowed the `required` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-required` attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-required">`aria-required` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-required="true"` on any element which also has a `required` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-required="false"` on any element which also has a `required` attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-colspan" tabindex="-1">
+              <th>
+                Any element where the [^th/colspan^] attribute is allowed: `td` and `th`
+              </th>
+              <td>
+                `aria-colspan="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `colspan` attribute on any element that is
+                  allowed the `colspan` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-colspan` attribute on any element that is allowed the `colspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-colspan` attribute on any element which also has a `colspan` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-colspan` on any element which also has a `colspan` attribute, and the values of each attribute do not match.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-rowspan" tabindex="-1">
+              <th>
+                Any element where the [^th/rowspan^] attribute is allowed:
+                `td` and `th`
+              </th>
+              <td>
+                `aria-rowspan="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `rowspan` attribute on any element that is
+                  allowed the `rowspan` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-rowspan` attribute on any element that is allowed the `rowspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-rowspan` attribute on any element which also has a `rowspan` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-rowspan` on any element which also has a `rowspan` attribute, and the values of each attribute do not match.
+                </p>
+              </td>
+            </tr>
 
 
-          <tr id="IDL-ValidityState" tabindex="-1">
-            <th>
-              Element that is a <a data-cite=
-              "html/form-control-infrastructure.html#candidate-for-constraint-validation">candidate for
-              constraint validation</a> but that does not <a data-cite=
-              "html/form-control-infrastructure.html#concept-fv-valid">satisfy its
-              constraints</a>
-            </th>
-            <td>
-              `aria-invalid="true"`
-            </td>
-            <td>
-              <p>
-                The `aria-invalid` attribute MAY be used on any
-                HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a> except for a <a data-cite="html/forms.html#category-submit">submittable element</a> that does not satisfy its <a data-cite="html/form-control-infrastructure.html#constraints">validation constraints</a>.
-              </p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            <tr id="IDL-ValidityState" tabindex="-1">
+              <th>
+                Element that is a <a data-cite=
+                "html/form-control-infrastructure.html#candidate-for-constraint-validation">candidate for
+                constraint validation</a> but that does not <a data-cite=
+                "html/form-control-infrastructure.html#concept-fv-valid">satisfy its
+                constraints</a>
+              </th>
+              <td>
+                `aria-invalid="true"`
+              </td>
+              <td>
+                <p>
+                  The `aria-invalid` attribute MAY be used on any
+                  HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a> except for a <a data-cite="html/forms.html#category-submit">submittable element</a> that does not satisfy its <a data-cite="html/form-control-infrastructure.html#constraints">validation constraints</a>.
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </section>
     <section>
       <h2 id="case-sensitivity">

--- a/index.html
+++ b/index.html
@@ -3336,10 +3336,10 @@
               </ul>
             </td>
             <td>
-              n/a
+              Not applicable
             </td>
             <td>
-              n/a
+              Not applicable
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
       <p>
         This specification defines the authoring rules (author conformance
         requirements) for the use of [[[wai-aria-1.1]]] and [[[dpub-aria-1.0]]]
-        attributes on [[HTML| HTML]] elements. This specification's primary objective is to define these requirements for use with Conformance Checking tools, where the intended recipients of such checking tools are authors (web developers). These requirements will aid authors in their development of custom web interfaces that do not entirely rely on the features of the host language [[HTML]].
+        attributes on [[HTML| HTML]] elements. This specification's primary objective is to define requirements for use with Conformance Checking tools used by authors (web developers). These requirements will aid authors in their development of custom web interfaces that do not entirely rely on the features of the host language [[HTML]].
       </p>
     </section>
     <section id="sotd">

--- a/index.html
+++ b/index.html
@@ -968,7 +968,7 @@
             </th>
             <td>
               If the [^form^] element has an
-              [=accessible name=]:
+              <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>:
               <code>role=<a href="#index-aria-form">form</a></code>.
               Otherwise, <a>no corresponding role</a>.
             </td>

--- a/index.html
+++ b/index.html
@@ -9,16 +9,16 @@
       editors: [
         {
           name: "Steve Faulkner",
-          url: "https://www.paciellogroup.com",
-          company: "The Paciello Group",
-          companyURL: "https://www.paciellogroup.com",
+          url: "https://www.tpgi.com",
+          company: "TPGi",
+          companyURL: "https://www.tpgi.com",
           w3cid: "35007"
         },
         {
           name: "Scott O'Hara",
-          url: "https://www.paciellogroup.com",
-          company: "The Paciello Group",
-          companyURL: "https://www.paciellogroup.com",
+          url: "https://www.tpgi.com",
+          company: "TPGi",
+          companyURL: "https://www.tpgi.com",
           w3cid: "103856"
         },
         { name: "Patrick H. Lauke",
@@ -45,7 +45,10 @@
       <p>
         This specification defines the authoring rules (author conformance
         requirements) for the use of [[[wai-aria-1.1]]] and [[[dpub-aria-1.0]]]
-        attributes on [[HTML]] elements. This specification's primary objective is to define requirements for use with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors in their development of web content, including custom interfaces/widgets, that makes use of ARIA to complement or extend the features of the host language [[HTML]].
+        attributes on [[HTML]] elements. This specification's primary objective is to define requirements for use 
+        with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors 
+        in their development of web content, including custom interfaces/widgets, that makes use of ARIA to complement 
+        or extend the features of the host language [[HTML]].
       </p>
     </section>
     <section id="sotd">
@@ -5191,19 +5194,21 @@
     <section id="conformance">
       <p>
         Conformance checkers that claim support for checking ARIA in HTML documents
-        MUST implement checks for the conformance requirements for use
-        of the ARIA `role` and `aria-*` attributes on [=HTML elements=] as
-        defined in this specification.
+        MUST implement checks for the conformance requirements for use of the ARIA `role` 
+        and `aria-*` attributes on [=HTML elements=] as defined in this specification.
       </p>
       <p>
-        A conforming document MUST NOT contain any elements with author defined `role` or `aria-*` attributes with values other than those
-        which, per this specification, authors MAY use on each [=HTML element=] in [[[#docconformance]]].
-        Conformance checkers SHOULD flag instances where authors are explicitly
-        providing an element with a `role` which matches its
-        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a> as failures, as it is NOT RECOMMENDED for authors to explicitly set these roles.
+        A conforming document MUST NOT contain any elements with author defined `role` 
+        or `aria-*` attributes with values other than those which, per this specification, 
+        authors MAY use on each [=HTML element=] in [[[#docconformance]]].
+        Conformance checkers SHOULD flag instances where authors are explicitly providing 
+        an element with a `role` which matches its
+        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a> as failures, 
+        as it is NOT RECOMMENDED for authors to explicitly set these roles.
       </p>
       <p>
-        A conformance checker MAY define their own terminology, and level or levels of severity, when surfacing document failures to conform to this specification.
+        A conformance checker MAY define their own terminology, and level or levels of 
+        severity, when surfacing document failures to conform to this specification.
       </p>
     </section>
     <section id="priv-sec">
@@ -5211,10 +5216,13 @@
         Privacy and security considerations
       </h2>
       <p>
-        This specification does not define the features of [[wai-aria-1.1]], [[dpub-aria-1.0]] or [[HTML]]. Rather it provides rules and guidance for conformance checkers that claim support for checking ARIA in HTML, as well as providing guidance to authors.
+        This specification does not define the features of [[wai-aria-1.1]], 
+        [[dpub-aria-1.0]] or [[HTML]]. Rather it provides rules and guidance for conformance 
+        checkers that claim support for checking ARIA in HTML, as well as providing guidance to authors.
       </p>
       <p>
-        Therefore, there are no known privacy or security impacts of this specification, as it defines no new features to introduce potential concern.
+        Therefore, there are no known privacy or security impacts of this specification, 
+        as it defines no new features to introduce potential concern.
       </p>
     </section>
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -9,16 +9,16 @@
       editors: [
         {
           name: "Steve Faulkner",
-          url: "https://www.paciellogroup.com",
-          company: "The Paciello Group",
-          companyURL: "https://www.paciellogroup.com",
+          url: "https://www.tpgi.com",
+          company: "TPGi",
+          companyURL: "https://www.tpgi.com",
           w3cid: "35007"
         },
         {
           name: "Scott O'Hara",
-          url: "https://www.paciellogroup.com",
-          company: "The Paciello Group",
-          companyURL: "https://www.paciellogroup.com",
+          url: "https://www.tpgi.com",
+          company: "TPGi",
+          companyURL: "https://www.tpgi.com",
           w3cid: "103856"
         },
         { name: "Patrick H. Lauke",
@@ -45,7 +45,10 @@
       <p>
         This specification defines the authoring rules (author conformance
         requirements) for the use of [[[wai-aria-1.1]]] and [[[dpub-aria-1.0]]]
-        attributes on [[HTML]] elements. This specification's primary objective is to define requirements for use with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors in their development of web content, including custom interfaces/widgets, that makes use of ARIA to complement or extend the features of the host language [[HTML]].
+        attributes on [[HTML]] elements. This specification's primary objective is to define requirements for use 
+        with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors 
+        in their development of web content, including custom interfaces/widgets, that makes use of ARIA to complement 
+        or extend the features of the host language [[HTML]].
       </p>
     </section>
     <section id="sotd">
@@ -5119,19 +5122,21 @@
     <section id="conformance">
       <p>
         Conformance checkers that claim support for checking ARIA in HTML documents
-        MUST implement checks for the conformance requirements for use
-        of the ARIA `role` and `aria-*` attributes on [=HTML elements=] as
-        defined in this specification.
+        MUST implement checks for the conformance requirements for use of the ARIA `role` 
+        and `aria-*` attributes on [=HTML elements=] as defined in this specification.
       </p>
       <p>
-        A conforming document MUST NOT contain any elements with author defined `role` or `aria-*` attributes with values other than those
-        which, per this specification, authors MAY use on each [=HTML element=] in [[[#docconformance]]].
-        Conformance checkers SHOULD flag instances where authors are explicitly
-        providing an element with a `role` which matches its
-        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a> as failures, as it is NOT RECOMMENDED for authors to explicitly set these roles.
+        A conforming document MUST NOT contain any elements with author defined `role` 
+        or `aria-*` attributes with values other than those which, per this specification, 
+        authors MAY use on each [=HTML element=] in [[[#docconformance]]].
+        Conformance checkers SHOULD flag instances where authors are explicitly providing 
+        an element with a `role` which matches its
+        <a data-cite="wai-aria-1.1#implicit_semantics">implicit ARIA semantics</a> as failures, 
+        as it is NOT RECOMMENDED for authors to explicitly set these roles.
       </p>
       <p>
-        A conformance checker MAY define their own terminology, and level or levels of severity, when surfacing document failures to conform to this specification.
+        A conformance checker MAY define their own terminology, and level or levels of 
+        severity, when surfacing document failures to conform to this specification.
       </p>
     </section>
     <section id="priv-sec" class="informative">
@@ -5139,10 +5144,13 @@
         Privacy and security considerations
       </h2>
       <p>
-        This specification does not define the features of [[wai-aria-1.1]], [[dpub-aria-1.0]] or [[HTML]]. Rather it provides rules and guidance for conformance checkers that claim support for checking ARIA in HTML, as well as providing guidance to authors.
+        This specification does not define the features of [[wai-aria-1.1]], 
+        [[dpub-aria-1.0]] or [[HTML]]. Rather it provides rules and guidance for conformance 
+        checkers that claim support for checking ARIA in HTML, as well as providing guidance to authors.
       </p>
       <p>
-        Therefore, there are no known privacy or security impacts of this specification, as it defines no new features to introduce potential concern.
+        Therefore, there are no known privacy or security impacts of this specification, 
+        as it defines no new features to introduce potential concern.
       </p>
     </section>
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
         requirements) for the use of [[[wai-aria-1.1]]] and [[[dpub-aria-1.0]]]
         attributes on [[HTML]] elements. This specification's primary objective is to define requirements for use 
         with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors 
-        in their development of web content, including custom interfaces/widgets, that makes use of ARIA to complement 
-        or extend the features of the host language [[HTML]].
+        in their development of web content, including custom interfaces/widgets, that makes use of ARIA to
+        complement or extend the features of the host language [[HTML]].
       </p>
     </section>
     <section id="sotd">

--- a/index.html
+++ b/index.html
@@ -2913,320 +2913,321 @@
 &lt;/figure&gt;
 </pre><!-- source: http://www.geocities.com/SoHo/7373/aquatic.htm#fish -->
       </aside>
+      <section>
+        <h3 id="docconformance-attr">
+          Requirements for use of ARIA attributes in place of equivalent HTML attributes
+        </h3>
+        <p>
+          Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a [^button^] element, rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
+          <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
+          user agents MUST ignore WAI-ARIA attributes and use the host language
+          (HTML) attribute with the same <a>implicit ARIA semantics</a>.
+        </p>
+        <p>
+          The following table represents HTML elements and their attributes which have `aria-*` attribute parity.
+        </p>
+        <p>
+          Each language feature (element and attribute) in a cell in the first
+          column implies the ARIA semantics (states, and properties) given in
+          the cell in the second column of the same row. The third cell in each
+          row defines how authors can use the native HTML feature, along with
+          requirements for using the `aria-*` attributes that supply the same
+          <a>implicit ARIA semantics</a>.
+        </p>
+        <table class="simple">
+          <caption>
+            Rules of ARIA attribute usage by HTML feature
+          </caption>
+          <thead>
+            <tr>
+              <th>
+                HTML feature
+              </th>
+              <th>
+                <p id="implicit-attr">
+                  Implicit ARIA semantics
+                </p>
+              </th>
+              <th>
+                HTML feature and `aria-*` attribute author guidance
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr id="att-checked" tabindex="-1">
+              <th>
+                Any element where the [^input/checked^] attribute is allowed
+              </th>
+              <td>
+                `aria-checked="true"`
+              </td>
+              <td>
+                <p>
+                  Use the `checked` attribute on any element that is
+                  allowed the `checked` attribute in HTML.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-checked` attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> of the element can be in opposition to the current value of the <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` attribute</a>.
+                </p>
+                <p>
+                  Authors MAY use the `aria-checked` attribute on any other element with a WAI-ARIA role which allows the  attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-disabled" tabindex="-1">
+              <th>
+                Any element where the [^input/disabled^]
+                attribute is allowed, including
+                `option` [^option/disabled^] and
+                `optgroup` [^optgroup/disabled^]
+              </th>
+              <td>
+                `aria-disabled="true"`
+              </td>
+              <td>
+                <p>
+                  Use the `disabled` attribute on any element that is allowed the `disabled` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-disabled` attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-disabled="false"` on any element which also has a `disabled` attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-hidden" tabindex="-1">
+              <th>
+                Any element with a [^html-global/hidden^] attribute
+              </th>
+              <td>
+                `aria-hidden="true"`
+              </td>
+              <td>
+                <p>
+                  Authors MAY use the `aria-hidden` attribute on any HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a>, with the following exception:
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-hidden="true"` attribute on any element which also has a `hidden` attribute.
+                </p>
 
-      <h3 id="docconformance-attr">
-        Document conformance requirements for use of ARIA attributes with HTML attributes
-      </h3>
-      <p>
-        Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY use `aria-disabled=true` on a [^button^] element, rather than the `disabled` attribute. However, authors SHOULD NOT use both the native HTML attribute and the `aria-*` attribute together, and MUST NOT use the these features together when their values are in opposition to each other. As stated in
-        <a data-cite="wai-aria-1.1#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
-        user agents MUST ignore WAI-ARIA attributes and use the host language
-        (HTML) attribute with the same <a>implicit ARIA semantics</a>.
-      </p>
-      <p>
-        The following table represents HTML elements and their attributes which have `aria-*` attribute parity.
-      </p>
-      <p>
-        Each language feature (element and attribute) in a cell in the first
-        column implies the ARIA semantics (states, and properties) given in
-        the cell in the second column of the same row. The third cell in each
-        row defines how authors can use the native HTML feature, along with
-        requirements for using the `aria-*` attributes that supply the same
-        <a>implicit ARIA semantics</a>.
-      </p>
-      <table class="simple">
-        <caption>
-          Rules of ARIA attribute usage by HTML feature
-        </caption>
-        <thead>
-          <tr>
-            <th>
-              HTML feature
-            </th>
-            <th>
-              <p id="implicit-attr">
-                Implicit ARIA semantics
-              </p>
-            </th>
-            <th>
-              HTML feature and `aria-*` attribute author guidance
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr id="att-checked" tabindex="-1">
-            <th>
-              Any element where the [^input/checked^] attribute is allowed
-            </th>
-            <td>
-              `aria-checked="true"`
-            </td>
-            <td>
-              <p>
-                Use the `checked` attribute on any element that is
-                allowed the `checked` attribute in HTML.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-checked` attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a> of the element can be in opposition to the current value of the <a data-cite="wai-aria-1.1#aria-checked">`aria-checked` attribute</a>.
-              </p>
-              <p>
-                Authors MAY use the `aria-checked` attribute on any other element with a WAI-ARIA role which allows the  attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-disabled" tabindex="-1">
-            <th>
-              Any element where the [^input/disabled^]
-               attribute is allowed, including
-              `option` [^option/disabled^] and
-              `optgroup` [^optgroup/disabled^]
-            </th>
-            <td>
-              `aria-disabled="true"`
-            </td>
-            <td>
-              <p>
-                Use the `disabled` attribute on any element that is allowed the `disabled` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-disabled` attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-disabled">`aria-disabled` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-disabled="false"` on any element which also has a `disabled` attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-hidden" tabindex="-1">
-            <th>
-              Any element with a [^html-global/hidden^] attribute
-            </th>
-            <td>
-              `aria-hidden="true"`
-            </td>
-            <td>
-              <p>
-                Authors MAY use the `aria-hidden` attribute on any HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a>, with the following exception:
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-hidden="true"` attribute on any element which also has a `hidden` attribute.
-              </p>
-
-              <!-- this will be covered as part of issue 221 -->
-              <!-- <p>
-                Authors MUST NOT use `aria-hidden="true"` on an element that can receive keyboard focus, or on an ancestor element to an element or elements which can receive keyboard focus.
-              </p>
-              <p>
-                Any elements which can receive keyboard focus, interactive elements or otherwise, MUST have their ability to receive keyboard focus removed while the `aria-hidden="true"` attribute is present. For instance, by using `tabindex="-1"` on any focusable elements with `aria-hidden="true"`, or setting `tabindex="-1"` to focusable elements that are descendants of an `aria-hidden="true"` containing element.
-              </p> -->
-            </td>
-          </tr>
-          <tr id="att-placeholder" tabindex="-1">
-            <th>
-              Any element where the [^input/placeholder^] attribute is allowed
-            </th>
-            <td>
-              `aria-placeholder="..."`
-            </td>
-            <td>
-              <p>
-                Use the `placeholder` attribute on any element that is allowed the
-                `placeholder` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
-              </p>
-              <p>
-                Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-max" tabindex="-1">
-            <th>
-              Any element where the `max` attribute is allowed: `meter` [^meter/max^], `progress` [^progress/max^], and `input` [^input/max^]
-            </th>
-            <td>
-              `aria-valuemax="..."`
-            </td>
-            <td>
-              <p>
-                Use the `max` attribute on any element that is
-                allowed the `max` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-valuemax` attribute on any other element with a WAI-ARIA role which allows the attribute.
-              </p>
-              <p>
-                Authors SHOULD NOT use `aria-valuemax` on any element which allows the `max` attribute. Use the `max` attribute instead.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-valuemax` on any element which also has a `max` attribute, even if the values of each attribute match.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-min" tabindex="-1">
-            <th>
-              Any element where the `min` attribute is allowed: `meter` [^meter/min^] and `input` [^input/min^]
-            </th>
-            <td>
-              `aria-valuemin="..."`
-            </td>
-            <td>
-              <p>
-                Use the `min` attribute on any element that is
-                allowed the `min` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-valuemin` attribute on any other element with a WAI-ARIA role which allows the attribute.
-              </p>
-              <p>
-                Authors SHOULD NOT use `aria-valuemin` on any element which allows the `min` attribute. Use the `min` attribute instead.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-valuemin` on any element which also has a `min` attribute, even if the values of each attribute match.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-readonly" tabindex="-1">
-            <th>
-              Any element which allows the `readonly` attribute:
-              `input` [^input/readonly^], `textarea` [^textarea/readonly^] and <a>form-associated custom element</a> which allows the [^face/readonly^]
-            </th>
-            <td>
-              `aria-readonly="true"`
-            </td>
-            <td>
-              <p>
-                Use the `readonly` attribute on any element that is
-                allowed the `readonly` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-readonly` attribute on any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-readonly="false"` on any element which also has a `readonly` attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-contenteditable" tabindex="-1">
-            <th>
-              <p>
-                Element with [^html-global/contenteditable^]`=true`
-                or
-                element without `contenteditable` attribute whose closest
-                ancestor with a `contenteditable` attribute has
-                `contenteditable="true"`.
-              </p>
-              <p class="note">
-                This is equivalent to the <a data-cite=
-                "html/interaction.html#dom-iscontenteditable">`isContentEditable`</a>
-                IDL attribute.
-              </p>
-            </th>
-            <td>
-              `aria-readonly="false"`
-            </td>
-            <td>
-              Authors MUST NOT set `aria-readonly="true"` on an element that has `isContentEditable="true"`.
-            </td>
-          </tr>
-          <tr id="att-required" tabindex="-1">
-            <th>
-              Any element where the `required` attribute is allowed: `input` [^input/required^], `textarea` [^textarea/required^], and `select` [^select/required^]
-            </th>
-            <td>
-              `aria-required="true"`
-            </td>
-            <td>
-              <p>
-                Use the `required` attribute on any element
-                that is allowed the `required` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-required` attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-required">`aria-required` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-required="true"` on any element which also has a `required` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-required="false"` on any element which also has a `required` attribute.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-colspan" tabindex="-1">
-            <th>
-              Any element where the [^th/colspan^] attribute is allowed: `td` and `th`
-            </th>
-            <td>
-              `aria-colspan="..."`
-            </td>
-            <td>
-              <p>
-                Use the `colspan` attribute on any element that is
-                allowed the `colspan` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-colspan` attribute on any element that is allowed the `colspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-colspan` attribute on any element which also has a `colspan` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-colspan` on any element which also has a `colspan` attribute, and the values of each attribute do not match.
-              </p>
-            </td>
-          </tr>
-          <tr id="att-rowspan" tabindex="-1">
-            <th>
-              Any element where the [^th/rowspan^] attribute is allowed:
-              `td` and `th`
-            </th>
-            <td>
-              `aria-rowspan="..."`
-            </td>
-            <td>
-              <p>
-                Use the `rowspan` attribute on any element that is
-                allowed the `rowspan` attribute in HTML.
-              </p>
-              <p>
-                Authors MAY use the `aria-rowspan` attribute on any element that is allowed the `rowspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan` attribute</a>.
-              </p>
-              <p>
-                Authors SHOULD NOT use the `aria-rowspan` attribute on any element which also has a `rowspan` attribute.
-              </p>
-              <p>
-                Authors MUST NOT use `aria-rowspan` on any element which also has a `rowspan` attribute, and the values of each attribute do not match.
-              </p>
-            </td>
-          </tr>
+                <!-- this will be covered as part of issue 221 -->
+                <!-- <p>
+                  Authors MUST NOT use `aria-hidden="true"` on an element that can receive keyboard focus, or on an ancestor element to an element or elements which can receive keyboard focus.
+                </p>
+                <p>
+                  Any elements which can receive keyboard focus, interactive elements or otherwise, MUST have their ability to receive keyboard focus removed while the `aria-hidden="true"` attribute is present. For instance, by using `tabindex="-1"` on any focusable elements with `aria-hidden="true"`, or setting `tabindex="-1"` to focusable elements that are descendants of an `aria-hidden="true"` containing element.
+                </p> -->
+              </td>
+            </tr>
+            <tr id="att-placeholder" tabindex="-1">
+              <th>
+                Any element where the [^input/placeholder^] attribute is allowed
+              </th>
+              <td>
+                `aria-placeholder="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `placeholder` attribute on any element that is allowed the
+                  `placeholder` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-placeholder` attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-placeholder">`aria-placeholder` attribute</a>.
+                </p>
+                <p>
+                  Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-max" tabindex="-1">
+              <th>
+                Any element where the `max` attribute is allowed: `meter` [^meter/max^], `progress` [^progress/max^], and `input` [^input/max^]
+              </th>
+              <td>
+                `aria-valuemax="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `max` attribute on any element that is
+                  allowed the `max` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-valuemax` attribute on any other element with a WAI-ARIA role which allows the attribute.
+                </p>
+                <p>
+                  Authors SHOULD NOT use `aria-valuemax` on any element which allows the `max` attribute. Use the `max` attribute instead.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-valuemax` on any element which also has a `max` attribute, even if the values of each attribute match.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-min" tabindex="-1">
+              <th>
+                Any element where the `min` attribute is allowed: `meter` [^meter/min^] and `input` [^input/min^]
+              </th>
+              <td>
+                `aria-valuemin="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `min` attribute on any element that is
+                  allowed the `min` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-valuemin` attribute on any other element with a WAI-ARIA role which allows the attribute.
+                </p>
+                <p>
+                  Authors SHOULD NOT use `aria-valuemin` on any element which allows the `min` attribute. Use the `min` attribute instead.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-valuemin` on any element which also has a `min` attribute, even if the values of each attribute match.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-readonly" tabindex="-1">
+              <th>
+                Any element which allows the `readonly` attribute:
+                `input` [^input/readonly^], `textarea` [^textarea/readonly^] and <a>form-associated custom element</a> which allows the [^face/readonly^]
+              </th>
+              <td>
+                `aria-readonly="true"`
+              </td>
+              <td>
+                <p>
+                  Use the `readonly` attribute on any element that is
+                  allowed the `readonly` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-readonly` attribute on any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-readonly="false"` on any element which also has a `readonly` attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-contenteditable" tabindex="-1">
+              <th>
+                <p>
+                  Element with [^html-global/contenteditable^]`=true`
+                  or
+                  element without `contenteditable` attribute whose closest
+                  ancestor with a `contenteditable` attribute has
+                  `contenteditable="true"`.
+                </p>
+                <p class="note">
+                  This is equivalent to the <a data-cite=
+                  "html/interaction.html#dom-iscontenteditable">`isContentEditable`</a>
+                  IDL attribute.
+                </p>
+              </th>
+              <td>
+                `aria-readonly="false"`
+              </td>
+              <td>
+                Authors MUST NOT set `aria-readonly="true"` on an element that has `isContentEditable="true"`.
+              </td>
+            </tr>
+            <tr id="att-required" tabindex="-1">
+              <th>
+                Any element where the `required` attribute is allowed: `input` [^input/required^], `textarea` [^textarea/required^], and `select` [^select/required^]
+              </th>
+              <td>
+                `aria-required="true"`
+              </td>
+              <td>
+                <p>
+                  Use the `required` attribute on any element
+                  that is allowed the `required` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-required` attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-required">`aria-required` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-required="true"` on any element which also has a `required` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-required="false"` on any element which also has a `required` attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-colspan" tabindex="-1">
+              <th>
+                Any element where the [^th/colspan^] attribute is allowed: `td` and `th`
+              </th>
+              <td>
+                `aria-colspan="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `colspan` attribute on any element that is
+                  allowed the `colspan` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-colspan` attribute on any element that is allowed the `colspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-colspan">`aria-colspan` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-colspan` attribute on any element which also has a `colspan` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-colspan` on any element which also has a `colspan` attribute, and the values of each attribute do not match.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-rowspan" tabindex="-1">
+              <th>
+                Any element where the [^th/rowspan^] attribute is allowed:
+                `td` and `th`
+              </th>
+              <td>
+                `aria-rowspan="..."`
+              </td>
+              <td>
+                <p>
+                  Use the `rowspan` attribute on any element that is
+                  allowed the `rowspan` attribute in HTML.
+                </p>
+                <p>
+                  Authors MAY use the `aria-rowspan` attribute on any element that is allowed the `rowspan` attribute in HTML, or any element with a WAI-ARIA role which allows the <a data-cite="wai-aria-1.1#aria-rowspan">`aria-rowspan` attribute</a>.
+                </p>
+                <p>
+                  Authors SHOULD NOT use the `aria-rowspan` attribute on any element which also has a `rowspan` attribute.
+                </p>
+                <p>
+                  Authors MUST NOT use `aria-rowspan` on any element which also has a `rowspan` attribute, and the values of each attribute do not match.
+                </p>
+              </td>
+            </tr>
 
 
-          <tr id="IDL-ValidityState" tabindex="-1">
-            <th>
-              Element that is a <a data-cite=
-              "html/form-control-infrastructure.html#candidate-for-constraint-validation">candidate for
-              constraint validation</a> but that does not <a data-cite=
-              "html/form-control-infrastructure.html#concept-fv-valid">satisfy its
-              constraints</a>
-            </th>
-            <td>
-              `aria-invalid="true"`
-            </td>
-            <td>
-              <p>
-                The `aria-invalid` attribute MAY be used on any
-                HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a> except for a <a data-cite="html/forms.html#category-submit">submittable element</a> that does not satisfy its <a data-cite="html/form-control-infrastructure.html#constraints">validation constraints</a>.
-              </p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            <tr id="IDL-ValidityState" tabindex="-1">
+              <th>
+                Element that is a <a data-cite=
+                "html/form-control-infrastructure.html#candidate-for-constraint-validation">candidate for
+                constraint validation</a> but that does not <a data-cite=
+                "html/form-control-infrastructure.html#concept-fv-valid">satisfy its
+                constraints</a>
+              </th>
+              <td>
+                `aria-invalid="true"`
+              </td>
+              <td>
+                <p>
+                  The `aria-invalid` attribute MAY be used on any
+                  HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a> except for a <a data-cite="html/forms.html#category-submit">submittable element</a> that does not satisfy its <a data-cite="html/form-control-infrastructure.html#constraints">validation constraints</a>.
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </section>
     <section>
       <h2 id="case-sensitivity">

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
       <p>
         This specification defines the authoring rules (author conformance
         requirements) for the use of [[[wai-aria-1.1]]] and [[[dpub-aria-1.0]]]
-        attributes on [[HTML| HTML]] elements. This specification's primary objective is to define requirements for use with conformance checking tools used by authors (web developers). These requirements will aid authors in their development of web content (including custom interfaces/widgets) that makes use of ARIA to complement or extend the features of the host language [[HTML]].
+        attributes on [[HTML]] elements. This specification's primary objective is to define requirements for use with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors in their development of web content, including custom interfaces/widgets, that makes use of ARIA to complement or extend the features of the host language [[HTML]].
       </p>
     </section>
     <section id="sotd">

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
       <p>
         This specification defines the authoring rules (author conformance
         requirements) for the use of [[[wai-aria-1.1]]] and [[[dpub-aria-1.0]]]
-        attributes on [[HTML| HTML]] elements. This specification's primary objective is to define requirements for use with Conformance Checking tools used by authors (web developers). These requirements will aid authors in their development of custom web interfaces that do not entirely rely on the features of the host language [[HTML]].
+        attributes on [[HTML| HTML]] elements. This specification's primary objective is to define requirements for use with conformance checking tools used by authors (web developers). These requirements will aid authors in their development of web content (including custom interfaces/widgets) that makes use of ARIA to complement or extend the features of the host language [[HTML]].
       </p>
     </section>
     <section id="sotd">


### PR DESCRIPTION
Related to https://github.com/w3c/html-aria/issues/297

- Small wording/grammatical tweaks
- Rename the "Document conformance requirements for use of ARIA attributes with HTML attributes" to "Requirements for use of ARIA attributes in place of equivalent HTML attributes" and make it a proper sub-`<section>` (so it appears in the TOC and gets numbered)
- Reword some of the abstract and conformance prose


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/306.html" title="Last updated on Apr 28, 2021, 7:21 AM UTC (8e417e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/306/1c0ae3b...8e417e8.html" title="Last updated on Apr 28, 2021, 7:21 AM UTC (8e417e8)">Diff</a>