### PR TITLE
Remove confusion in h1 to h6 implied mapping wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -1022,7 +1022,7 @@
             </th>
             <td>
               <code>role=<a href="#index-aria-heading">heading</a></code>,
-              with the `aria-level` = positive integer.
+              `aria-level` = the number in the element's tag name.
             </td>
             <td>
               <p>


### PR DESCRIPTION
- resolves #308


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aria/pull/309.html" title="Last updated on Apr 28, 2021, 7:28 AM UTC (86f04e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/309/b65efa2...carmacleod:86f04e2.html" title="Last updated on Apr 28, 2021, 7:28 AM UTC (86f04e2)">Diff</a>