### PR TITLE
Editorial: make th implied wording consistent with the style of td

### DIFF
--- a/index.html
+++ b/index.html
@@ -2639,14 +2639,14 @@
             </th>
             <td>
               <p>
-                If the ancestor `table` element is exposed as a `role=table`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a> according to
-                <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
+                <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a> if the ancestor
+                `table` element is exposed as a `role=table`.
               </p>
               <p>
-                If the ancestor `table` element is exposed as a `role=grid` or `treegrid`: <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a> according to
-                <a data-cite="html-aam-1.0#html-element-role-mappings">HTML AAM</a>.
+                <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a> if the ancestor
+                `table` element is exposed as a `role=grid` or `treegrid`.
              </p>
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -2666,7 +2666,7 @@
               [^tr^]
             </th>
             <td>
-              <a href="#index-aria-row">`role=row`</a>
+              <code>role=<a href="#index-aria-row">row</a></code>
             </td>
             <td>
               <p>

--- a/results/implementation-results.html
+++ b/results/implementation-results.html
@@ -3122,15 +3122,15 @@
         </th>
         <td>
           <p>
-            If the ancestor <code>table</code> element is exposed as a <code>role=table</code>: <code>role=columnheader</code>,
-            <code>rowheader</code> or <code>cell</code> according to
-            HTML AAM.
-          </p>
-          <p>
-            If the ancestor <code>table</code> element is exposed as a <code>role=grid</code> or <code>treegrid</code>: <code>role=columnheader</code>,
-            <code>rowheader</code> or <code>gridcell</code> according to
-            HTML AAM.
-          </p>
+                <code>role=columnheader</code>,
+            <code>rowheader</code> or <code>cell</code> if the ancestor
+            <code>table</code> element is exposed as a <code>role=table</code>.
+              </p>
+              <p>
+                <code>role=columnheader</code>,
+                <code>rowheader</code> or <code>gridcell</code> if the ancestor
+                <code>table</code> element is exposed as a <code>role=grid</code> or <code>treegrid</code>.
+             </p>
         </td>
         <td>
           <p>


### PR DESCRIPTION
Make th implied role wording consistent with the wording style of td implied role (and others)
- role first, then condition
- remove unnecessary mention of html-aam

Also - nit - make tr role=row implied role have same visual style as others


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carmacleod/html-aria/pull/313.html" title="Last updated on May 5, 2021, 12:10 PM UTC (eab3b86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/313/4c8832a...carmacleod:eab3b86.html" title="Last updated on May 5, 2021, 12:10 PM UTC (eab3b86)">Diff</a>