### PR TITLE
Remove aria-invalid from the ARIA attributes in place of HTML equivalents table

### DIFF
--- a/index.html
+++ b/index.html
@@ -3144,26 +3144,6 @@
                 </p>
               </td>
             </tr>
-
-
-            <tr id="IDL-ValidityState" tabindex="-1">
-              <th>
-                Element that is a <a data-cite=
-                "html/form-control-infrastructure.html#candidate-for-constraint-validation">candidate for
-                constraint validation</a> but that does not <a data-cite=
-                "html/form-control-infrastructure.html#concept-fv-valid">satisfy its
-                constraints</a>
-              </th>
-              <td>
-                `aria-invalid="true"`
-              </td>
-              <td>
-                <p>
-                  The `aria-invalid` attribute MAY be used on any
-                  HTML element that allows <a href="#index-aria-global">global `aria-*` attributes</a> except for a <a data-cite="html/forms.html#category-submit">submittable element</a> that does not satisfy its <a data-cite="html/form-control-infrastructure.html#constraints">validation constraints</a>.
-                </p>
-              </td>
-            </tr>
           </tbody>
         </table>
       </section>

--- a/results/implementation-results.html
+++ b/results/implementation-results.html
@@ -3739,27 +3739,7 @@
         <td><strong class=yes>yes</strong><br> - <a href="https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/15">issue 15</a></td>
         <td>partial implementation: <br>passes test 1 (of 3)<br>- <a href="https://github.com/IBMa/equal-access/issues/354">issue 354</a></td>
       </tr>
-      <tr id="IDL-ValidityState" tabindex="-1">
-        <th>
-          Element that is a candidate for
-          constraint validation but that does not satisfy its
-          constraints
-        </th>
-        <td>
-          <code>aria-invalid="true"</code>
-        </td>
-        <td>
-          <p>
-            The <code>aria-invalid</code> attribute <em class="rfc2119">MAY</em> be used on any
-            HTML element that allows global <code>aria-*</code> attributes except for a submittable element that does not satisfy its validation constraints.
-          </p>
-        </td>
-        <td class="missing">???</td>
-        <td class="missing">???</td><!-- validator -->
-        <td class="missing">???</td><!-- arc -->
-        <td class="missing">???</td>
-      </tr>
-    </tbody>
+     </tbody>
   </table>
 </body>
 </html>


### PR DESCRIPTION
Discussed with Scott today, and we agreed:

* there is no equivalent HTML attribute that serves the same purpose - it touches on HTML element DOM *properties* (so it doesn't belong in the table that compared ARIA attributes vs equivalent HTML attributes in the first place)
* testing this would require validators to do dynamic checking of the DOM and the element *properties*. while a contrived static test case can be made, it would only be an artificial test


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/321.html" title="Last updated on May 13, 2021, 5:30 PM UTC (31a7310)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/321/04a33b7...31a7310.html" title="Last updated on May 13, 2021, 5:30 PM UTC (31a7310)">Diff</a>