### PR TITLE
update allowance column

### DIFF
--- a/index.html
+++ b/index.html
@@ -3228,7 +3228,7 @@
       
       <p>
         Additionally, there are certain roles which [[[wai-aria-1.1]]] has specified specific requirements for 
-        their allowed descendants. These have been identified in Column 4 as noting to "Refer to the 'Required Owned Elements'" for
+        their allowed descendants. These have been identified in Column 5 as noting to "Refer to the 'Required Owned Elements'" for
         those particular roles.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -3180,7 +3180,7 @@
         </pre>
       </aside>
     </section>
-    <section>
+    <section class="informative">
       <h2>
         Allowed ARIA roles, states and properties
       </h2>
@@ -3197,16 +3197,15 @@
         Properties</a> table defines extensions to the <a data-cite=
         "html/dom.html#kinds-of-content">Kinds of content</a> (defined in the
         [[HTML]] specification) categories each `role` has when it is used on a
-        HTML element. Column 5 defines what HTML elements can be descendants of
+        HTML element. Column 5 indicates what HTML elements can be descendants of
         an element with a particular <a href="#implicit">implicit</a> or
         explicit `role` value.
       </p>
       <p>
         For example, a [^button^] element has an implicit `role=button`.
-        A `button` element allows [=phrasing content=] as descendants and
-        does not allow [=interactive content=] or descendants with a
-        `tabindex` attribute.  Therefore, any elements specified with a
-        `role=button` also MUST NOT allow any interactive content descendants,
+        In HTML a `button` element allows [=phrasing content=] as descendants and does not allow [=interactive content=] 
+        or descendants with a `tabindex` attribute.  Therefore, any elements specified with a `role=button` would follow 
+        the same descendant restrictions, and not allow any interactive content descendants,
         elements with a `tabindex` specified or any elements with role values
         that are in the interactive content category (identified in Column 4).
       </p>
@@ -3226,6 +3225,12 @@
 &lt;/div&gt;
         </pre>
       </div>
+      
+      <p>
+        Additionally, there are certain roles which [[[wai-aria-1.1]]] has specified specific requirements for 
+        their allowed descendants. These have been identified in Column 4 as noting to "Refer to the 'Required Owned Elements'" for
+        those particular roles.
+      </p>
 
       <table id="aria-table" class="simple">
         <caption>
@@ -3829,7 +3834,7 @@
               </ul>
             </td>
             <td>
-              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#grid">ARIA `grid`</a> role.
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#grid">`grid`</a> role.
             </td>
           </tr>
           <tr>
@@ -3990,7 +3995,7 @@
               [=Flow content=]
             </td>
             <td>
-              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#list">ARIA `list`</a> role.
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#list">`list`</a> role.
             </td>
           </tr>
           <tr>
@@ -4027,7 +4032,7 @@
               </ul>
             </td>
             <td>
-              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#listbox">ARIA `listbox`</a> role.
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#listbox">`listbox`</a> role.
             </td>
           </tr>
           <tr>
@@ -4155,7 +4160,7 @@
               </ul>
             </td>
             <td>
-              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#menu">ARIA `menu`</a> role.
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#menu">`menu`</a> role.
             </td>
           </tr>
           <tr>
@@ -4185,7 +4190,7 @@
               </ul>
             </td>
             <td>
-              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#menubar">ARIA `menubar`</a> role.
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#menubar">`menubar`</a> role.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -3267,7 +3267,7 @@
               Kind of content
             </th>
             <th>
-              Descendant restrictions
+              Descendant allowances
             </th>
           </tr>
         </thead>
@@ -3367,7 +3367,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3431,10 +3431,14 @@
               </p>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Sectioning content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              No <a>main</a> element descendants.
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3448,10 +3452,13 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              Document region
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              No <a>main</a>, <a>header</a> or <a>footer</a> element descendants.
+              [=Flow content=] but with no <a>main</a>, <a>header</a>, or <a>footer</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3472,29 +3479,16 @@
               </ul>
             </td>
             <td>
-              [=Interactive content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
               [=Phrasing content=], but there must be no
-              [=interactive content=] descendant.
-            </td>
-          </tr>
-          <tr>
-            <th tabindex="-1" id="index-aria-checkbox">
-              <a data-cite="wai-aria-1.1#checkbox">`checkbox`</a>
-            </th>
-            <td>
-              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
-            </td>
-            <td>
-              <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
-            </td>
-            <td>
-              [=Interactive content=]
-            </td>
-            <td>
-              [=Phrasing content=], but there must be no
-              [=interactive content=] descendant.
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -3521,10 +3515,32 @@
               </ul>
             </td>
             <td>
-              [=Flow content=]
+              N/A
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-checkbox">
+              <a data-cite="wai-aria-1.1#checkbox">`checkbox`</a>
+            </th>
+            <td>
+              <a data-cite="wai-aria-1.1#aria-checked">`aria-checked`</a>
+            </td>
+            <td>
+              <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
+            </td>
+            <td>
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=], but there must be no
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -3566,10 +3582,10 @@
               </ul>
             </td>
             <td>
-              [=Flow content=]
+              N/A
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a>, <a>header</a>, or <a>footer</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3603,10 +3619,15 @@
               </ul>
             </td>
             <td>
-              [=Interactive content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3620,10 +3641,14 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Sectioning content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=], but with no <a>main</a> element descendants.
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3637,10 +3662,13 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=], but with no <a>main</a>, <a>header</a> or <a>footer</a> element descendants.
+              [=Flow content=] but with no <a>main</a>, <a>header</a>, or <a>footer</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3656,7 +3684,11 @@
               </p>
             </td>
             <td>
-              [=Phrasing content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
               [=Phrasing content=]
@@ -3700,7 +3732,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3734,7 +3766,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3748,10 +3780,13 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3765,10 +3800,13 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=], but with no [^form^] element descendants.
             </td>
           </tr>
           <tr>
@@ -3804,15 +3842,14 @@
               </ul>
             </td>
             <td>
-              <p>
-                [=Flow content=]
-              </p>
-              <p>
-                [=Interactive content=]
-              </p>
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Interactive content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#grid">ARIA `grid`</a> role.
             </td>
           </tr>
           <tr>
@@ -3851,15 +3888,10 @@
               </ul>
             </td>
             <td>
-              <p>
-                [=Flow content=]
-              </p>
-              <p>
-                [=Interactive content=]
-              </p>
+              [=Interactive content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -3880,7 +3912,10 @@
               </ul>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
               [=Flow content=]
@@ -3904,12 +3939,17 @@
               </ul>
             </td>
             <td>
-              [=Heading content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Heading content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=], but with no [=Heading content=],
-              [=Sectioning content=], or
-              <a data-cite="html/sections.html#sectioning-root">Sectioning roots</a>.
+              [=Flow content=] but with no <a>main</a> element,
+              [=heading content=],
+              [=sectioning content=],
+              or <a data-cite="html/sections.html#sectioning-root">sectioning roots</a> descendants.
             </td>
           </tr>
           <tr>
@@ -3923,10 +3963,15 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Embedded content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Phrasing content=]
+              [=Phrasing content=], but with no [=interactive content=] descendants.
             </td>
           </tr>
           <tr>
@@ -3940,11 +3985,15 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=], but with no [=interactive content=] or
-              <a>a</a> element descendants.
+              [=Flow content=], there must be no [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -3961,7 +4010,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#list">ARIA `list`</a> role.
             </td>
           </tr>
           <tr>
@@ -3991,15 +4040,14 @@
               </ul>
             </td>
             <td>
-              <p>
-                [=Flow content=]
-              </p>
-              <p>
-                [=Interactive content=]
-              </p>
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Interactive content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#listbox">ARIA `listbox`</a> role.
             </td>
           </tr>
           <tr>
@@ -4026,10 +4074,10 @@
               </ul>
             </td>
             <td>
-              [=Flow content=]
+              N/A
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4046,7 +4094,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=], but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4080,7 +4128,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=], but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4121,15 +4169,13 @@
               </ul>
             </td>
             <td>
-              <p>
-                [=Flow content=]
-              </p>
-              <p>
-                [=Interactive content=]
-              </p>
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Interactive content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#menu">ARIA `menu`</a> role.
             </td>
           </tr>
           <tr>
@@ -4153,15 +4199,13 @@
               </ul>
             </td>
             <td>
-              <p>
-                [=Flow content=]
-              </p>
-              <p>
-                [=Interactive content=]
-              </p>
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Interactive content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the <a data-cite="wai-aria-1.1#menubar">ARIA `menubar`</a> role.
             </td>
           </tr>
           <tr>
@@ -4185,8 +4229,8 @@
               [=Interactive content=]
             </td>
             <td>
-              [=Flow content=], but with no
-              [=interactive content=] descendants.
+              [=Phrasing content=], but with no
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -4211,7 +4255,7 @@
             </td>
             <td>
               [=Phrasing content=], but with no
-              [=interactive content=] descendants.
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -4236,7 +4280,7 @@
             </td>
             <td>
               [=Phrasing content=], but with no
-              [=interactive content=] descendants.
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -4250,7 +4294,11 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Sectioning content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
               [=Flow content=], but with no <a>main</a> element descendants.
@@ -4266,10 +4314,10 @@
             <td>&nbsp;
             </td>
             <td>
-              [=Flow content=]
+              N/A
             </td>
             <td>
-              [=Flow content=]
+              <a data-cite="html/dom.html#transparent-content-models">Transparent</a>
             </td>
           </tr>
           <tr>
@@ -4286,7 +4334,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=], but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4317,7 +4365,7 @@
             </td>
             <td>
               [=Phrasing content=], but with no
-              [=interactive content=] descendants.
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -4329,10 +4377,10 @@
             </td>
             <td></td>
             <td>
-              [=Flow content=]
+              N/A
             </td>
             <td>
-              [=Flow content=]
+              <a data-cite="html/dom.html#transparent-content-models">Transparent</a>
             </td>
           </tr>
           <tr>
@@ -4359,10 +4407,13 @@
               </ul>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+              </ul>
             </td>
             <td>
-              [=Phrasing content=]
+              [=Phrasing content=], but with no <a>progress</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4386,11 +4437,15 @@
               </ul>
             </td>
             <td>
-              [=Interactive content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+              </ul>
             </td>
             <td>
               [=Phrasing content=], but with no
-              [=interactive content=] descendants.
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -4417,7 +4472,10 @@
               </ul>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
               [=Flow content=]
@@ -4434,10 +4492,14 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Sectioning content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=], but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4484,10 +4546,10 @@
               </ul>
             </td>
             <td>
-              none
+              N/A
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#row">`row`</a> role.
             </td>
           </tr>
           <tr>
@@ -4499,10 +4561,10 @@
             </td>
             <td></td>
             <td>
-              none
+              N/A
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#rowgroup">`rowgroup`</a> role.
             </td>
           </tr>
           <tr>
@@ -4541,10 +4603,10 @@
               </ul>
             </td>
             <td>
-              none
+              N/A
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4581,12 +4643,7 @@
               </ul>
             </td>
             <td>
-              <p>
-                [=Flow content=]
-              </p>
-              <p>
-                [=Interactive content=]
-              </p>
+              [=Interactive content=]
             </td>
             <td>
               [=Phrasing content=]
@@ -4603,10 +4660,13 @@
               <a data-cite="wai-aria-1.1#aria-expanded">`aria-expanded`</a>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4639,11 +4699,14 @@
               </ul>
             </td>
             <td>
-              [=Interactive content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=], but with no
-              [=interactive content=] descendants.
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4708,7 +4771,11 @@
               </ul>
             </td>
             <td>
-              [=Interactive content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+              </ul>
             </td>
             <td>
               [=Phrasing content=]
@@ -4745,15 +4812,14 @@
               </ul>
             </td>
             <td>
-              <p>
-                [=Flow content=]
-              </p>
-              <p>
-                [=Interactive content=]
-              </p>
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4770,7 +4836,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4784,11 +4850,15 @@
               <a data-cite="wai-aria-1.1#aria-readonly">`aria-readonly`</a>
             </td>
             <td>
-              [=Interactive content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Phrasing content=]</li>
+                <li>[=Interactive content=]</li>
+              </ul>
             </td>
             <td>
               [=Phrasing content=], but with no
-              [=interactive content=] descendants.
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -4815,11 +4885,11 @@
               </ul>
             </td>
             <td>
-              [=interactive content=]
+              [=Interactive content=]
             </td>
             <td>
               [=Phrasing content=], but with no
-              [=interactive content=] descendants.
+              [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
             </td>
           </tr>
           <tr>
@@ -4840,10 +4910,13 @@
               </ul>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#table">`table`</a> role.
             </td>
           </tr>
           <tr>
@@ -4870,10 +4943,13 @@
               </ul>
             </td>
             <td>
-              [=Flow content=]
+              <ul>
+                <li>[=Flow content=]</li>
+                <li>[=Palpable content=]</li>
+              </ul>
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.1#tablist">`tablist`</a> role.
             </td>
           </tr>
           <tr>
@@ -4945,8 +5021,7 @@
               [=Interactive content=]
             </td>
             <td>
-              [=Flow content=], but with no
-              [=interactive content=] descendants.
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4963,7 +5038,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -4990,7 +5065,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Flow content=] but with no <a>main</a> element descendants.
             </td>
           </tr>
           <tr>
@@ -5007,7 +5082,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Phrasing content=]
             </td>
           </tr>
           <tr>
@@ -5040,7 +5115,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the ARIA <code><a data-cite="wai-aria-1.1#tree">tree</a></code> role.
             </td>
           </tr>
           <tr>
@@ -5085,7 +5160,7 @@
               [=Flow content=]
             </td>
             <td>
-              [=Flow content=]
+              Refer to the "Required Owned Elements" as defined for the ARIA <code><a data-cite="wai-aria-1.1#treegrid">treegrid</a></code> role.
             </td>
           </tr>
           <tr>
@@ -5121,7 +5196,7 @@
               [=Interactive content=]
             </td>
             <td>
-              [=Flow content=]
+              [=Phrasing content=]
             </td>
           </tr>
         </tbody>
@@ -5170,6 +5245,10 @@
       </p>
 
       <ol reversed="">
+        <li>
+          13-May-2021:
+          <a>Update allowed descendants for ARIA roles</a>, where specific children / descendants are necessary - link to ARIA specification.
+        </li>
         <li>
           07-Mar-2021:
           <a href="https://github.com/w3c/html-aria/commit/daca00dc304f5c3944ed0a0ae4d3b6f9d60039bc">Update allowed roles for `nav` element</a>.

--- a/index.html
+++ b/index.html
@@ -5247,7 +5247,7 @@
       <ol reversed="">
         <li>
           13-May-2021:
-          <a>Update allowed descendants for ARIA roles</a>, where specific children / descendants are necessary - link to ARIA specification.
+          <a href="https://github.com/w3c/html-aria/pull/322">Update allowed descendants for ARIA roles</a>, where specific children / descendants are necessary - link to ARIA specification.
         </li>
         <li>
           07-Mar-2021:


### PR DESCRIPTION
update role descendant allowances.
update “kind of content” column to reflect HTML kind of content categories for elements with implicit matching roles.  These do not always have a 1-to-1 match as there are variants in what ARIA might allow vs the native HTML element.  Additionally, content model categories like sectioning root, or labelable elements, etc. were purposefully left off as the ARIA roles do not automatically come with the features associated with these categories.

closes #54


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/322.html" title="Last updated on May 15, 2021, 3:19 PM UTC (7d4dbe4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/322/6bb33bd...7d4dbe4.html" title="Last updated on May 15, 2021, 3:19 PM UTC (7d4dbe4)">Diff</a>