### PR TITLE
make descendant allowance wording consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -3216,11 +3216,9 @@
         </pre>
       </div>
 
-  <p>
-        Additionally, there are certain roles which [[[wai-aria-1.1]]] has specified specific requirements for
-        their allowed descendants. These have been identified in column 3 by indicating to "Refer to the 'Required Owned Elements'" for
-        those particular roles.
-  </p>
+    <p>
+      Additionally, there are certain roles which [[[wai-aria-1.1]]] has specified specific requirements for their allowed descendants. These have been identified in column 3 (Descendant allowances) by indicating to "Refer to the 'Required Owned Elements'" for those particular roles.
+    </p>
 
     <table id="aria-table" class="simple">
       <caption>
@@ -3315,7 +3313,7 @@
             </ul>
           </td>
           <td>
-            [=Phrasing content=], but there must be no
+            [=Phrasing content=], but but with no
             [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
           </td>
         </tr>
@@ -3342,7 +3340,7 @@
             </ul>
           </td>
           <td>
-            [=Phrasing content=], but there must be no
+            [=Phrasing content=], but but with no
             [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
           </td>
         </tr>
@@ -3576,7 +3574,7 @@
             </ul>
           </td>
           <td>
-            [=Flow content=], there must be no [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
+            [=Flow content=], but with no [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
remove instances of 'must' from non-normative section and made wording consistent with other roles with nesting restrictions


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/330.html" title="Last updated on Jun 24, 2021, 11:07 AM UTC (d4fa58b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/330/01b544c...d4fa58b.html" title="Last updated on Jun 24, 2021, 11:07 AM UTC (d4fa58b)">Diff</a>