### PR TITLE
revise casing requirement from MUST to SHOULD for authors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
           &lt;!-- Avoid doing this! -->
           &lt;fieldset role="group"&gt;...&lt;/fieldset&gt;
           &lt;!-- or this! -->
-          &lt;main role="main">...&lt;/main>
+          &lt;main role="Main">...&lt;/main>
         </pre>
         <p>
           The following uses a `role=list` on an [^ul^] element. This is

--- a/index.html
+++ b/index.html
@@ -3159,7 +3159,7 @@
 
       <div class="note">
         <p>While all modern browsers allow for the use of upper or lowercase ASCII letters to specify the `role` or `aria-*` attribute state and property values, not all assistive technologies will correctly parse these values.</p>
-        <p>It is imperative that authors either use lowercase ASCII letters to specify the values of these attributes, or that they rigorously test with different browser and assistive technology combinations to ensure that their content will be correctly exposed to their users.</p>
+        <p>To reduce interoperability issues, author are encouraged to use [=ASCII lowercase=] for `aria-*` and `role` attribute values. Further, authors are encouraged to rigorously test with different browser and assistive technology combinations to ensure that their content will be correctly exposed to their users.</p>
       </div>
       <aside class="example">
         <p>

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
           &lt;button role="button"&gt;...&lt;/button&gt;
         </pre>
         <p>
-          Similarly, the following uses a `role=group` on a [^fieldset^] element, and a `role=main` on a [^main^] element.
+          Similarly, the following uses a `role=group` on a [^fieldset^] element, and a `role=Main` on a [^main^] element.
           This is unnecessary, because the `fieldset` element is implicitly
           exposed as a `role=group`, as is the `main` element implicity exposed as a `role=main`. Again, in practice this will likely not
           have any unforeseen side effects to users of assistive technology, so long as the declaration of the `role` value uses <a data-cite=

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     </script>
     <link rel="stylesheet" href="makeup.css">
   </head>
-  <body data-cite="HTML WAI-ARIA">
+  <body data-cite="HTML WAI-ARIA INFRA">
     <section id="abstract">
       <p>
         This specification defines the authoring rules (author conformance requirements) for the use
@@ -125,8 +125,8 @@
         <p>
           Similarly, the following uses a `role=group` on a [^fieldset^] element, and a `role=Main` on a [^main^] element.
           This is unnecessary, because the `fieldset` element is implicitly
-          exposed as a `role=group`, as is the `main` element implicity exposed as a `role=main`. Again, in practice this will likely not
-          have any unforeseen side effects to users of assistive technology, as long as the declaration of the `role` value uses [=ascii lowercase=]. Please see [[[#case-sensitivity]]] for more information.
+          exposed as a `role=group`, as is the `main` element implicitly exposed as a `role=main`. Again, in practice this will likely not
+          have any unforeseen side effects to users of assistive technology, as long as the declaration of the `role` value uses [=ASCII lowercase=]. Please see [[[#case-sensitivity]]] for more information.
         </p>
         <pre class="HTML example" title="Redundant role on fieldset and main">
           &lt;!-- Avoid doing this! -->
@@ -3149,14 +3149,18 @@
         Case requirements for ARIA role, state and property attributes
       </h2>
       <p>
-        Authors SHOULD use [=lowercase ASCII=] for all `role` token values and any state or property
-        attributes (`aria-*`) whose values are <a data-cite=
-        "wai-aria-1.1#propcharacteristic_value">defined as tokens</a>.
+        Authors SHOULD use [=ASCII lowercase=] for all `role` token values
+        and any state or property attributes (`aria-*`) whose values are
+        <a data-cite="wai-aria-1.1#propcharacteristic_value">defined as tokens</a>.
       </p>
 
       <div class="note">
-        <p>While all modern browsers allow for the use of upper or lowercase ASCII letters to specify the `role` or `aria-*` attribute state and property values, not all assistive technologies will correctly parse these values.</p>
-        <p>To reduce interoperability issues, author are encouraged to use [=ASCII lowercase=] for `aria-*` and `role` attribute values. Further, authors are encouraged to rigorously test with different browser and assistive technology combinations to ensure that their content will be correctly exposed to their users.</p>
+        <p>
+          While modern browsers treat the `role` or `aria-*` attribute values as [=ASCII case-insensitive=], not all assistive technologies will correctly parse these values.
+        </p>
+        <p>
+          To reduce interoperability issues, authors are strongly encouraged to use [=ASCII lowercase=] for `aria-*` and `role` attribute values. Further, authors are encouraged to rigorously test with different browser and assistive technology combinations to ensure that their content will be correctly exposed to their users.
+        </p>
       </div>
       <aside class="example">
         <p>

--- a/index.html
+++ b/index.html
@@ -126,8 +126,7 @@
           Similarly, the following uses a `role=group` on a [^fieldset^] element, and a `role=Main` on a [^main^] element.
           This is unnecessary, because the `fieldset` element is implicitly
           exposed as a `role=group`, as is the `main` element implicity exposed as a `role=main`. Again, in practice this will likely not
-          have any unforeseen side effects to users of assistive technology, so long as the declaration of the `role` value uses <a data-cite=
-        "html/infrastructure.html#lowercase-ascii-letters">lowercase ASCII letters</a>. Please see <a href="#case-sensitivity">Case requirements for ARIA role, state and property attributes</a> for more information.
+          have any unforeseen side effects to users of assistive technology, as long as the declaration of the `role` value uses [=ascii lowercase=]. Please see [[[#case-sensitivity]]] for more information.
         </p>
         <pre class="HTML example" title="Redundant role on fieldset and main">
           &lt;!-- Avoid doing this! -->

--- a/index.html
+++ b/index.html
@@ -123,14 +123,17 @@
           &lt;button role="button"&gt;...&lt;/button&gt;
         </pre>
         <p>
-          Similarly, the following uses a `role=group` on a [^fieldset^] element.
+          Similarly, the following uses a `role=group` on a [^fieldset^] element, and a `role=main` on a [^main^] element.
           This is unnecessary, because the `fieldset` element is implicitly
-          exposed as a `role=group`. Again, in practice this will likely not
-          have any unforeseen side effects.
+          exposed as a `role=group`, as is the `main` element implicity exposed as a `role=main`. Again, in practice this will likely not
+          have any unforeseen side effects to users of assistive technology, so long as the declaration of the `role` value uses <a data-cite=
+        "html/infrastructure.html#lowercase-ascii-letters">lowercase ASCII letters</a>. Please see <a href="#case-sensitivity">Case requirements for ARIA role, state and property attributes</a> for more information.
         </p>
-        <pre class="HTML example" title="Redundant role on fieldset">
+        <pre class="HTML example" title="Redundant role on fieldset and main">
           &lt;!-- Avoid doing this! -->
           &lt;fieldset role="group"&gt;...&lt;/fieldset&gt;
+          &lt;!-- or this! -->
+          &lt;main role="main">...&lt;/main>
         </pre>
         <p>
           The following uses a `role=list` on an [^ul^] element. This is
@@ -141,7 +144,7 @@
           practice would generally not be recommended, otherwise.
         </p>
         <pre class="HTML example" title="Redundant role on list">
-          &lt;!-- Avoid doing this! -->
+          &lt;!-- Generally avoid doing this! -->
           &lt;ul role="list"&gt;...&lt;/ul&gt;
         </pre>
       </section>
@@ -3142,39 +3145,45 @@
           </tbody>
         </table>
       </section>
-    </section>
-    <section>
+      <section>
       <h2 id="case-sensitivity">
         Case requirements for ARIA role, state and property attributes
       </h2>
       <p>
-        Authors MUST use <a data-cite=
+        Authors SHOULD use <a data-cite=
         "html/infrastructure.html#lowercase-ascii-letters">lowercase ASCII
         letters</a> for all `role` token values and any state or property
         attributes (`aria-*`) whose values are <a data-cite=
         "wai-aria-1.1#propcharacteristic_value">defined as tokens</a>.
       </p>
+
+      <div class="note">
+        <p>While all modern browsers allow for the use of upper or lowercase ASCII letters to specify the `role` or `aria-*` attribute state and property values, not all assistive technologies will correctly parse these values.</p>
+        <p>It is imperative that authors either use lowercase ASCII letters to specify the values of these attributes, or that they rigorously test with different browser and assistive technology combinations to ensure that their content will be correctly exposed to their users.</p>
+      </div>
       <aside class="example">
         <p>
           <strong>Correct (conforming) examples:</strong>
         </p>
         <pre>
-  &lt;div <mark>role="radiogroup"</mark>&gt;...&lt;/div&gt;
+  &lt;div <mark>role="main"</mark>&gt;...&lt;/div&gt;
 
   &lt;a href="home/" <mark>aria-current="page"</mark>&gt;home&lt;/a&gt;
         </pre>
         <p>
           <strong>Incorrect (non-conforming) examples:</strong>
         </p>
-        <pre>&lt;!-- DO NOT DO THIS --&gt;
-&lt;div <mark>role="radioGroup"</mark>&gt;...&lt;/div&gt;
+        <pre>&lt;!-- DO NOT DO THE FOLLOWING --&gt;
+&lt;div <mark>role="MAIN"</mark>&gt;...&lt;/div&gt;
 
-&lt;div <mark>role="RADIOGROUP"</mark>&gt;...&lt;/div&gt;
+&lt;div <mark>role="Main"</mark>&gt;...&lt;/div&gt;
 
 &lt;a href="home/" <mark>aria-current="Page"</mark>&gt;home&lt;/a&gt;
         </pre>
       </aside>
     </section>
+    </section>
+
     <section class="informative">
       <h2>
         Allowed descendants of ARIA roles

--- a/index.html
+++ b/index.html
@@ -3150,9 +3150,7 @@
         Case requirements for ARIA role, state and property attributes
       </h2>
       <p>
-        Authors SHOULD use <a data-cite=
-        "html/infrastructure.html#lowercase-ascii-letters">lowercase ASCII
-        letters</a> for all `role` token values and any state or property
+        Authors SHOULD use [=lowercase ASCII=] for all `role` token values and any state or property
         attributes (`aria-*`) whose values are <a data-cite=
         "wai-aria-1.1#propcharacteristic_value">defined as tokens</a>.
       </p>


### PR DESCRIPTION
provide note explaining why this is an issue which can be avoided by simply using lowercase.

add additional example/reference to casing requirement to examples of incorrect usage section.

make case requirements a sub-section of “document conformance requirements for use of aria attributes in html” rather than it’s own top-level section.

this PR is a middle ground between keeping the current requirement, and the change proposed in #287


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/333.html" title="Last updated on Jun 28, 2021, 3:35 PM UTC (f1b779a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/333/0c824f8...f1b779a.html" title="Last updated on Jun 28, 2021, 3:35 PM UTC (f1b779a)">Diff</a>