### PR TITLE
Addition: allow aria-hidden on picture element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1205,7 +1205,7 @@
             </td>
             <td>
               <strong class="nosupport">No `role` or `aria-*` attributes</strong>
-              except `aria-hidden="true"`.
+              except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
             </td>
           </tr>
           <tr id="el-img-no-alt" tabindex="-1">
@@ -2072,7 +2072,7 @@
             <td>
               <p><strong class="nosupport">no `role`</strong></p>
               <p>
-                Authors MAY specify the `aria-hidden` attribute on the `picture` element.
+                Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `picture` element.
                 Otherwise, no other allowed `aria-*` attributes.
               </p>
             </td>

--- a/index.html
+++ b/index.html
@@ -2070,10 +2070,10 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <p><strong class="nosupport">no `role`</p>
+              <p><strong class="nosupport">no `role`</strong></p>
               <p>
                 Authors MAY specify the `aria-hidden` attribute on the `picture` element.
-                Otherwise, no other allowed `aria-*` attributes</strong>.
+                Otherwise, no other allowed `aria-*` attributes.
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -2070,7 +2070,11 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p><strong class="nosupport">no `role`</p>
+              <p>
+                Authors MAY specify the `aria-hidden` attribute on the `picture` element.
+                Otherwise, no other allowed `aria-*` attributes</strong>.
+              </p>
             </td>
           </tr>
           <tr id="el-pre" tabindex="-1">

--- a/index.html
+++ b/index.html
@@ -2071,10 +2071,12 @@
             </td>
             <td>
               <p><strong class="nosupport">no `role`</strong></p>
+              <div class="addition.proposed">
               <p>
                 Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `picture` element.
                 Otherwise, no other allowed `aria-*` attributes.
               </p>
+              </div>
             </td>
           </tr>
           <tr id="el-pre" tabindex="-1">


### PR DESCRIPTION
Revise the allowances for the `picture` element to allow for the `aria-hidden` attribute.

Need at least two checkers to accept this change before we can merge.

Closes #346

- [x]  [html validator](https://github.com/validator/validator/issues/1239)
- [x] [ibm equal access accessibility checker](https://github.com/IBMa/equal-access/issues/503)
- [x] axe-core (already allows this)
- [x] [arc toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/41)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/352.html" title="Last updated on Oct 26, 2021, 3:36 PM UTC (5f0ff4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/352/d1f3a82...5f0ff4d.html" title="Last updated on Oct 26, 2021, 3:36 PM UTC (5f0ff4d)">Diff</a>