### PR TITLE
Correction: revise wbr and br element allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,7 +539,7 @@
                 <a href="#index-aria-presentation">`presentation`</a>
                 or <a href="#index-aria-none">`none`</a>.
               </p>
-              <p>
+              <p class="proposed addition">
                 Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `br` element.
                 Otherwise, no other allowed `aria-*` attributes.
               </p>
@@ -2788,15 +2788,17 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <p>
-                Roles:
-                <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>.
-              </p>
-              <p>
-                Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `wbr` element.
-                Otherwise, no other allowed `aria-*` attributes.
-              </p>
+              <div class="proposed correction">
+                <p>
+                  Roles:
+                  <a href="#index-aria-presentation">`presentation`</a>
+                  or <a href="#index-aria-none">`none`</a>.
+                </p>
+                <p>
+                  Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `wbr` element.
+                  Otherwise, no other allowed `aria-*` attributes.
+                </p>
+              </div>
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -540,8 +540,8 @@
                 or <a href="#index-aria-none">`none`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `br` element.
+                Otherwise, no other allowed `aria-*` attributes.
               </p>
             </td>
           </tr>
@@ -2783,11 +2783,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                Roles:
+                <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `wbr` element.
+                Otherwise, no other allowed `aria-*` attributes.
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -2972,7 +2972,7 @@
                 <p>
                   Roles:
                   <a href="#index-aria-presentation">`presentation`</a>
-                  or <a href="#index-aria-none">`none`</a>.
+                  or <a href="#index-aria-none">`none`</a>
                 </p>
                 <p>
                   Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `wbr` element.

--- a/index.html
+++ b/index.html
@@ -4371,6 +4371,11 @@
 
       <ul>
         <li>
+          07-Dec-2021:
+          Allow only `none` and `presentation` roles for <a href="#el-wbr">`wbr` element</a>. 
+          Allow only `aria-hidden` global attribute for <a href="#el-br">`br`</a> and <a href="#el-wbr">`wbr`</a> elements.
+        </li>
+        <li>
           02-Dec-2021:
           Allow `group` role on <a href="#el-section">`section` element</a>.
         </li>


### PR DESCRIPTION
closes #332

Revise the allowances for the `br` element - only allow `aria-hidden` attribute, rather than all global attributes.

Revise allowances for `wbr` to match `br`.  Neither of these elements allow for styling from authors, nor do they allow for child content (or content from CSS - again no styling).  So allowing for any roles/attributes beyond presentation or for hiding would not be a wise idea.

Need at least two checkers to accept this change before we can merge.

[html validator](https://github.com/validator/validator/issues/1241) 
- [x] role update
- [x] allowed attributes update

[ibm equal access accessibility checker](https://github.com/IBMa/equal-access/issues/507)
- [x] role update
- [x] allowed attributes update

[axe-core](https://github.com/dequelabs/axe-core/issues/3177)
- [x] role update
- [ ] allowed attributes update

[arc toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/42)
- [x] role update
- [x] allowed attributes update

html validator and axe issues are still open in regards to limiting allowed `aria-*` attributes on these elements to `aria-hidden` alone.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/353.html" title="Last updated on Dec 8, 2021, 1:04 AM UTC (e1dd099)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/353/3ef70c1...e1dd099.html" title="Last updated on Dec 8, 2021, 1:04 AM UTC (e1dd099)">Diff</a>