### PR TITLE
Addition: adjust allowances for deprecated dpub roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1898,7 +1898,7 @@
                 </p>
                 <div class="note">
                   <p>The `doc-biblioentry` and `doc-endnote` roles are not valid children of an element with an implict or explicit role of `list`. 
-                    These roles are marked for deprecation in [[[dpug-aria-1.1]]].
+                    These roles are marked for deprecation in [[[dpub-aria-1.1]]].
                     Authors can use standard `li` elements without the need for these roles.</p>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -4378,8 +4378,12 @@
     <section class="informative">
       <h2>Change log</h2>
       <h3>Substantive changes since the last published Recommendation</h3>
-
       <ul>
+        <li>
+          06-Jan-2022:
+          Change allowances for `doc-biblioentry` and `doc-endnote` roles on the <a href="#el-li">`li` element</a>. 
+          These roles are deprecated in [[[dpub-aria-1.1]]].
+        </li>
         <li>
           13-Dec-2021:
           Allow `radio` role on <a href="#el-img">`img alt="some text"` element</a>.
@@ -4396,10 +4400,6 @@
         <li>
           16-Nov-2021:
           Allow `link` and `button` roles on <a href="#el-area-no-href">`area` without `href` element</a>.
-        </li>
-        <li>
-          02-Nov-2021:
-          Remove `doc-biblioentry` and `doc-endnote` from `li` element allowances. These roles are deprecated in [[[dpub-aria-1.1]]].
         </li>
         <li>
           26-Oct-2021:

--- a/index.html
+++ b/index.html
@@ -1752,11 +1752,6 @@
                 or <a href="#index-aria-treeitem">`treeitem`</a>
               </p>
               <p>
-                DPub Roles:
-                <a data-cite="dpub-aria-1.0#doc-biblioentry">`doc-biblioentry`</a>,
-                <a data-cite="dpub-aria-1.0#doc-endnote">`doc-endnote`</a>.
-              </p>
-              <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles.
               </p>
@@ -4167,7 +4162,7 @@
         A conformance checker MAY define their own terminology, and level or levels of
         severity, when surfacing document failures to conform to this specification.
       </p>
-</section>
+    </section>
     <section id="priv-sec" class="informative">
       <h2>
         Privacy and security considerations
@@ -4189,6 +4184,10 @@
       <h3>Substantive changes since the last published Recommendation</h3>
 
       <ol reversed>
+        <li>
+          02-Nov-2021:
+          Remove `doc-biblioentry` and `doc-endnote` from `li` element allowances. These roles are deprecated in [[[dpub-aria-1.1]]].
+        </li>
         <li>
           26-Oct-2021:
           Allow `aria-hidden` attribute on the `picture` element. 

--- a/index.html
+++ b/index.html
@@ -1762,6 +1762,16 @@
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles.
               </p>
+              <div class="addition proposal">
+                <p>Authors SHOULD NOT use the following DPub Roles:
+                  <a data-cite="dpub-aria-1.0#doc-biblioentry">`doc-biblioentry`</a>,
+                  <a data-cite="dpub-aria-1.0#doc-endnote">`doc-endnote`</a>.
+                </p>
+                <div class="note">
+                  <p>The `doc-biblioentry` and `doc-endnote` roles are not valid children of an element with an implict or explicit role of `list`. 
+                    Authors can use standard `li` elements without the need for these roles.</p>
+                </div>
+              </div>
             </td>
           </tr>
           <tr id="el-link" tabindex="-1">

--- a/index.html
+++ b/index.html
@@ -1769,6 +1769,7 @@
                 </p>
                 <div class="note">
                   <p>The `doc-biblioentry` and `doc-endnote` roles are not valid children of an element with an implict or explicit role of `list`. 
+                    These roles are marked for deprecation in [[[dpug-aria-1.1]]].
                     Authors can use standard `li` elements without the need for these roles.</p>
                 </div>
               </div>


### PR DESCRIPTION
closes #363

revises allowances for `li` element to specify dpub roles [`doc-biblioentry`](https://w3c.github.io/dpub-aria/#doc-biblioentry) and [`doc-endnote`](https://w3c.github.io/dpub-aria/#doc-endnote) to authors SHOULD NOT.  These roles are being deprecated in dpub ARIA 1.1. Authors should use standard list elements instead.

As there is a clear preference to use list/listitem elements, if possible conformance checkers should indicate to use such elements and flag errors, rather than warnings.

---

Need at least two checkers to accept this change before we can merge.

- [x] [html validator](https://github.com/validator/validator/pull/1262) (merged and will be in next release)
- [x] [ibm equal access accessibility checker](https://github.com/IBMa/equal-access/issues/540)
- [x] [axe-core](https://github.com/dequelabs/axe-core/issues/3253)
- [x] [arc toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/pull/45)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/369.html" title="Last updated on Dec 7, 2021, 2:54 PM UTC (a633849)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/369/9fb3173...a633849.html" title="Last updated on Dec 7, 2021, 2:54 PM UTC (a633849)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/369.html" title="Last updated on Jan 6, 2022, 12:51 PM UTC (c6b2bf3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/369/5578fa9...c6b2bf3.html" title="Last updated on Jan 6, 2022, 12:51 PM UTC (c6b2bf3)">Diff</a>