### PR TITLE
Correction: adds missing radio role allowance for img

### DIFF
--- a/index.html
+++ b/index.html
@@ -1185,6 +1185,9 @@
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-progressbar">`progressbar`</a>,
+                <span class="proposed correction">
+                  <a href="#index-aria-radio">`radio`</a>,
+                </span>
                 <a href="#index-aria-scrollbar">`scrollbar`</a>,
                 <a href="#index-aria-separator">`separator`</a>,
                 <a href="#index-aria-slider">`slider`</a>,

--- a/index.html
+++ b/index.html
@@ -4374,6 +4374,10 @@
 
       <ul>
         <li>
+          13-Dec-2021:
+          Allow `radio` role on <a href="#el-img">`img alt="some text"` element</a>.
+        </li>
+        <li>
           07-Dec-2021:
           Allow only `none` and `presentation` roles for <a href="#el-wbr">`wbr` element</a>. 
           Allow only `aria-hidden` global attribute for <a href="#el-br">`br`</a> and <a href="#el-wbr">`wbr`</a> elements.


### PR DESCRIPTION
closes #380.
As noted in #212, `role=radio` was meant to be allowed on an `img alt=foo`.  This corrects the mistake of that allowance not making it into the spec.

---

Need at least two checkers to accept this change before we can merge.

- [x] [html validator](https://github.com/validator/validator/pull/1276) (merged and will be in next release)
- [x] [ibm equal access accessibility checker](https://github.com/IBMa/equal-access/issues/392)
- [x] [axe-core](https://github.com/dequelabs/axe-core/pull/3320)
- [x] [arc toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/pull/48)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/381.html" title="Last updated on Dec 13, 2021, 5:33 PM UTC (de6ec0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/381/cfab4e1...de6ec0f.html" title="Last updated on Dec 13, 2021, 5:33 PM UTC (de6ec0f)">Diff</a>