### PR TITLE
chore: source cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -955,11 +955,11 @@
                 <a href="#index-aria-document">`document`</a>,
                 <a href="#index-aria-img">`img`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>
+                or <a href="#index-aria-none">`none`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1275,11 +1275,11 @@
                 <a href="#index-aria-document">`document`</a>,
                 <a href="#index-aria-img">`img`</a>,
                 <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
+                any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1377,14 +1377,12 @@
               </p>
             </td>
           </tr>
-          <tr id="el-input-checkbox" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-checkbox" tabindex="-1">
               <a data-cite="html/input.html#checkbox-state-(type=checkbox)">`input type=checkbox`</a>
             </th>
             <td>
-              <p>
-                <code>role=<a href="#index-aria-checkbox">checkbox</a></code>
-              </p>
+              <code>role=<a href="#index-aria-checkbox">checkbox</a></code>
             </td>
             <td>
               <p>
@@ -1392,7 +1390,7 @@
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                 <a href="#index-aria-option">`option`</a>
                 or <a href="#index-aria-switch">`switch`</a>;
-                <a href="#index-aria-button">`button` if used with `aria-pressed`</a>.
+                <a href="#index-aria-button">`button` if used with `aria-pressed`</a>
               </p>
               <p>
                 Authors <a href="#att-checked">SHOULD NOT use the `aria-checked` attribute on `input type=checkbox` elements</a>.
@@ -1408,8 +1406,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-input-color" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-color" tabindex="-1">
               <a data-cite="html/input.html#color-state-(type=color)">`input type=color`</a>
             </th>
             <td>
@@ -1420,12 +1418,12 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-input-date" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-date" tabindex="-1">
               <a data-cite="html/input.html#date-state-(type=date)">`input type=date`</a>
             </th>
             <td>
@@ -1441,8 +1439,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-input-datetime-local" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-datetime-local" tabindex="-1">
               <a data-cite="html/input.html#local-date-and-time-state-(type=datetime-local)">`input type=datetime-local`</a>
             </th>
             <td>
@@ -1458,8 +1456,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-input-email" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-email" tabindex="-1">
               <a data-cite="html/input.html#e-mail-state-(type=email)">`input type=email`</a>
               with no [^input/list^] attribute
             </th>
@@ -1471,13 +1469,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-file" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-file" tabindex="-1">
               <a data-cite="html/input.html#file-upload-state-(type=file)">`input type=file`</a>
             </th>
             <td>
@@ -1488,23 +1486,25 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-input-hidden" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-hidden" tabindex="-1">
               <a data-cite="html/input.html#hidden-state-(type=hidden)">`input type=hidden`</a>
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-input-image" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-image" tabindex="-1">
               <a data-cite="html/input.html#image-button-state-(type=image)">`input type=image`</a>
             </th>
             <td>
@@ -1518,16 +1518,16 @@
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                 <a href="#index-aria-radio">`radio`</a>
-                or <a href="#index-aria-switch">`switch`</a>.
+                or <a href="#index-aria-switch">`switch`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-input-month" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-month" tabindex="-1">
               <a data-cite="html/input.html#month-state-(type=month)">`input type=month`</a>
             </th>
             <td>
@@ -1538,12 +1538,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-number" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-number" tabindex="-1">
               <a data-cite="html/input.html#number-state-(type=number)">`input type=number`</a>
             </th>
             <td>
@@ -1554,13 +1555,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `spinbutton` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `spinbutton` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-password" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-password" tabindex="-1">
               <a data-cite="html/input.html#password-state-(type=password)">`input type=password`</a>
             </th>
             <td>
@@ -1571,14 +1572,14 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-radio" tabindex="-1">
-            <th>
-              <a data-cite=
-              "html/input.html#radio-button-state-(type=radio)">`input type=radio`</a>
+          <tr>
+            <th id="el-input-radio" tabindex="-1">
+              <a data-cite="html/input.html#radio-button-state-(type=radio)">`input type=radio`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-radio">radio</a></code>
@@ -1603,8 +1604,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-input-range" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-range" tabindex="-1">
               <a data-cite="html/input.html#range-state-(type=range)">`input type=range`</a>
             </th>
             <td>
@@ -1615,16 +1616,18 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or <a href="#att-min">`aria-valuemin`</a> attributes on `input type=range`.
+                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or 
+                <a href="#att-min">`aria-valuemin`</a> attributes on `input type=range`.
               </p>
               <p>
-                Otherwise, any <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> and any other `aria-*` attributes applicable
-                to the `slider` role.
+                Otherwise, any 
+                <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> 
+                and any other `aria-*` attributes applicable to the `slider` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-reset" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-reset" tabindex="-1">
               <a data-cite="html/input.html#reset-button-state-(type=reset)">`input type=reset`</a>
             </th>
             <td>
@@ -1635,13 +1638,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `button` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `button` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-search" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-search" tabindex="-1">
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=search`</a>,
               with no [^input/list^] attribute
             </th>
@@ -1653,13 +1656,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `searchbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `searchbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-submit" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-submit" tabindex="-1">
               <a data-cite="html/input.html#submit-button-state-(type=submit)">`input type=submit`</a>
             </th>
             <td>
@@ -1670,14 +1673,15 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `button` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `button` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-tel" tabindex="-1">
-            <th>
-              <a data-cite="html/input.html#telephone-state-(type=tel)">`input type=tel`</a>, with no [^input/list^] attribute
+          <tr>
+            <th id="el-input-tel" tabindex="-1">
+              <a data-cite="html/input.html#telephone-state-(type=tel)">`input type=tel`</a>, 
+              with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -1687,13 +1691,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-text" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-text" tabindex="-1">
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>
               or with a missing or invalid `type`, with no [^input/list^] attribute
             </th>
@@ -1705,16 +1709,16 @@
                 Roles:
                 <a href="#index-aria-combobox">`combobox`</a>,
                 <a href="#index-aria-searchbox">`searchbox`</a>
-                or <a href="#index-aria-spinbutton">`spinbutton`</a>.
+                or <a href="#index-aria-spinbutton">`spinbutton`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-input-text-list" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-text-list" tabindex="-1">
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>,
               <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`search`</a>,
               <a data-cite="html/input.html#telephone-state-(type=tel)">`tel`</a>,
@@ -1734,13 +1738,13 @@
               </p>
               <p>
                 Otherwise, any
-                <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> and
-                any other `aria-*` attributes applicable to the `combobox` role.
+                <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> 
+                and any other `aria-*` attributes applicable to the `combobox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-time" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-time" tabindex="-1">
               <a data-cite="html/input.html#time-state-(type=time)">`input type=time`</a>
             </th>
             <td>
@@ -1751,15 +1755,15 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-url" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-url" tabindex="-1">
               <a data-cite="html/input.html#url-state-(type=url)">`input type=url`</a>
-              with no
-              [^input/list^] attribute
+              with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
@@ -1769,13 +1773,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-input-week" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-week" tabindex="-1">
               <a data-cite="html/input.html#week-state-(type=week)">`input type=week`</a>
             </th>
             <td>
@@ -1786,12 +1790,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-ins" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-ins" tabindex="-1">
               [^ins^]
             </th>
             <td>
@@ -1802,13 +1807,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-kbd" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-kbd" tabindex="-1">
               [^kbd^]
             </th>
             <td>
@@ -1819,13 +1824,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-label" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-label" tabindex="-1">
               [^label^]
             </th>
             <td>
@@ -1836,12 +1841,12 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-legend" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-legend" tabindex="-1">
               [^legend^]
             </th>
             <td>
@@ -1852,12 +1857,12 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-li" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-li" tabindex="-1">
               [^li^]
             </th>
             <td>
@@ -1880,27 +1885,29 @@
               <p>
                 DPub Roles:
                 <a data-cite="dpub-aria-1.0#doc-biblioentry">`doc-biblioentry`</a>,
-                <a data-cite="dpub-aria-1.0#doc-endnote">`doc-endnote`</a>.
+                <a data-cite="dpub-aria-1.0#doc-endnote">`doc-endnote`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-link" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-link" tabindex="-1">
               [^link^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-main" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-main" tabindex="-1">
               [^main^]
             </th>
             <td>
@@ -1911,24 +1918,26 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `main` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `main` role.
               </p>
             </td>
           </tr>
-          <tr id="el-map" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-map" tabindex="-1">
               [^map^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-mark" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-mark" tabindex="-1">
               [^mark^]
             </th>
             <td>
@@ -1939,13 +1948,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-math" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-math" tabindex="-1">
               <a data-cite="html/embedded-content-other.html#mathml">`math`</a>
             </th>
             <td>
@@ -1956,13 +1965,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `math` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `math` role.
               </p>
             </td>
           </tr>
-          <tr id="el-menu" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-menu" tabindex="-1">
               [^menu^]
             </th>
             <td>
@@ -1981,27 +1990,29 @@
                 <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-tablist">`tablist`</a>,
                 <a href="#index-aria-toolbar">`toolbar`</a>
-                or <a href="#index-aria-tree">`tree`</a>.
+                or <a href="#index-aria-tree">`tree`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-meta" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-meta" tabindex="-1">
               [^meta^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-meter" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-meter" tabindex="-1">
               [^meter^]
             </th>
             <td>
@@ -2012,15 +2023,17 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or <a href="#att-min">`aria-valuemin`</a> attributes on `meter` elements.
+                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or 
+                <a href="#att-min">`aria-valuemin`</a> attributes on `meter` elements.
               </p>
               <p>
-                Otherwise, any <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a>.
+                Otherwise, any 
+                <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-nav" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-nav" tabindex="-1">
               [^nav^]
             </th>
             <td>
@@ -2031,33 +2044,35 @@
                 Roles:
                 <a href="#index-aria-menu">`menu`</a>,
                 <a href="#index-aria-menubar">`menubar`</a>
-                or <a href="#index-aria-tablist">`tablist`</a>.
+                or <a href="#index-aria-tablist">`tablist`</a>
               </p>
               <p>
                 DPub Roles:
                 <a data-cite="dpub-aria-1.0#doc-index">`doc-index`</a>,
                 <a data-cite="dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a>,
-                <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>.
+                <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-noscript" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-noscript" tabindex="-1">
               [^noscript^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-object" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-object" tabindex="-1">
               [^object^]
             </th>
             <td>

--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
                 <a href="#index-aria-main">`main`</a>,
                 <a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-region">`region`</a>.
+                or <a href="#index-aria-region">`region`</a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -454,7 +454,7 @@
                 <a href="#index-aria-note">`note`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>,
                 <a href="#index-aria-region">`region`</a>
-                or <a href="#index-aria-search">`search`</a>.
+                or <a href="#index-aria-search">`search`</a>
               </p>
               <p>
                 DPub Roles:
@@ -500,7 +500,7 @@
             <td>
               <p>
                 If role defined by `ElementInternals`, 
-                <strong class="nosupport">no `role`</strong>.
+                <strong class="nosupport">no `role`</strong>
               </p>
               <p>
                 Otherwise, <a><strong>any</strong> `role`</a>
@@ -621,7 +621,7 @@
               <p>
                 Roles:
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>.
+                or <a href="#index-aria-none">`none`</a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
@@ -646,7 +646,7 @@
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
                 <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-tab">`tab`</a>.
+                or <a href="#index-aria-tab">`tab`</a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -743,7 +743,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>.
               </p>
             </td>
           </tr>
@@ -833,23 +833,25 @@
               </p>
             </td>
           </tr>
-          <tr id="el-dfn" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-dfn" tabindex="-1">
               [^dfn^]
             </th>
             <td>
               <code>role=<a href="#index-aria-term">term</a></code>
             </td>
             <td>
-              <a><strong>Any</strong> `role`</a>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-dialog" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-dialog" tabindex="-1">
               [^dialog^]
             </th>
             <td>
@@ -861,13 +863,13 @@
                 <a href="#index-aria-alertdialog">`alertdialog`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `dialog` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `dialog` role.
               </p>
             </td>
           </tr>
-          <tr id="el-div" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-div" tabindex="-1">
               [^div^]
             </th>
             <td>
@@ -878,13 +880,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-dl" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-dl" tabindex="-1">
               [^dl^]
             </th>
             <td>
@@ -896,16 +898,16 @@
                 <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-list">`list`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>.
+                or <a href="#index-aria-none">`none`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-dt" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-dt" tabindex="-1">
               [^dt^]
             </th>
             <td>
@@ -917,13 +919,13 @@
                 <a href="#index-aria-listitem">`listitem`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-em" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-em" tabindex="-1">
               [^em^]
             </th>
             <td>
@@ -934,13 +936,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-embed" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-embed" tabindex="-1">
               [^embed^]
             </th>
             <td>
@@ -953,16 +955,16 @@
                 <a href="#index-aria-document">`document`</a>,
                 <a href="#index-aria-img">`img`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>.
+                or <a href="#index-aria-none">`none`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-fieldset" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-fieldset" tabindex="-1">
               [^fieldset^]
             </th>
             <td>
@@ -973,16 +975,16 @@
                 Roles:
                 <a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-radiogroup">`radiogroup`</a>.
+                or <a href="#index-aria-radiogroup">`radiogroup`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-figcaption" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-figcaption" tabindex="-1">
               [^figcaption^]
             </th>
             <td>
@@ -993,16 +995,16 @@
                 Roles:
                 <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>.
+                or <a href="#index-aria-none">`none`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-figure" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-figure" tabindex="-1">
               [^figure^]
             </th>
             <td>
@@ -1017,76 +1019,92 @@
               <p>
                 If the `figure` has a `figcaption` descendant:
                 <br>
-                <strong class="nosupport">No `role`</strong>.
+                <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-footer" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-footer" tabindex="-1">
               [^footer^]
             </th>
             <td>
-              If not a descendant of an `article`, `aside`, `main`, `nav`
-              or `section` element, or an element with `role=article`, `complementary`,
-              `main`, `navigation` or `region`
-              then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>.
-              Otherwise <a>no corresponding role</a>.
+              <p>
+                If not a descendant of an `article`, `aside`, `main`, `nav`
+                or `section` element, or an element with `role=article`, `complementary`,
+                `main`, `navigation` or `region`
+                then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
+              </p>
+              <p>
+                Otherwise, <a>no corresponding role</a>
+              </p>
             </td>
             <td>
               <p>
                 Roles:
                 <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                or <a href="#index-aria-presentation">`presentation`</a>
               </p>
               <p>
                 DPub Roles:
-                <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>.
+                <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-form" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-form" tabindex="-1">
               [^form^]
             </th>
             <td>
-              If the [^form^] element has an
-              <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>:
-              <code>role=<a href="#index-aria-form">form</a></code>.
-              Otherwise, <a>no corresponding role</a>.
+              <p>
+                If the [^form^] element has an
+                <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>:
+                <code>role=<a href="#index-aria-form">form</a></code>
+              </p>
+              <p>
+                Otherwise, <a>no corresponding role</a>
+              </p>
             </td>
             <td>
               <p>
                 Roles:
                 <a href="#index-aria-search">`search`</a>,
                 <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                or <a href="#index-aria-presentation">`presentation`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-form-associated-custom-element" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-form-associated-custom-element" tabindex="-1">
               <a>form-associated custom element</a>
             </th>
             <td>
-              Role exposed from author defined {{ElementInternals}}.
-              Otherwise <a>no corresponding role</a>.
+              <p>
+                Role exposed from author defined {{ElementInternals}}
+              </p>
+              <p>
+                Otherwise <a>no corresponding role</a>
+              </p>
             </td>
             <td>
-              <p>If role defined by `ElementInternals`, <strong class="nosupport">no `role`</strong>.</p>
-              <p>Otherwise, form-related roles:
+              <p>
+                If role defined by `ElementInternals`, 
+                <strong class="nosupport">no `role`</strong>
+              </p>
+              <p>
+                Otherwise, form-related roles:
                 <a href="#index-aria-button">`button`</a>,
                 <a href="#index-aria-checkbox">`checkbox`</a>,
                 <a href="#index-aria-combobox">`combobox`</a>,
@@ -1099,89 +1117,99 @@
                 <a href="#index-aria-slider">`slider`</a>,
                 <a href="#index-aria-spinbutton">`spinbutton`</a>,
                 <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-textbox">`textbox`</a>.
+                or <a href="#index-aria-textbox">`textbox`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-h1-h6" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-h1-h6" tabindex="-1">
               <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1 to h6`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-heading">heading</a></code>,
-              `aria-level` = the number in the element's tag name.
+              `aria-level` = the number in the element's tag name
             </td>
             <td>
               <p>
                 Roles:
                 <a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-tab">`tab`</a>.
+                or <a href="#index-aria-tab">`tab`</a>
               </p>
               <p>
                 DPub Role:
                 <a data-cite="dpub-aria-1.0#doc-subtitle">`doc-subtitle`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-head" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-head" tabindex="-1">
               [^head^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>.
+              </p>
             </td>
           </tr>
-          <tr id="el-header" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-header" tabindex="-1">
               [^header^]
             </th>
             <td>
-              If not a descendant of an `article`, `aside`, `main`,
-              `nav` or `section` element, or an element with `role=article`,
-              `complementary`, `main`, `navigation`
-              or `region` then <code>role=<a href="#index-aria-banner">banner</a></code>.
-              Otherwise <a>no corresponding role</a>
+              <p>
+                If not a descendant of an `article`, `aside`, `main`,
+                `nav` or `section` element, or an element with `role=article`,
+                `complementary`, `main`, `navigation` or `region` then 
+                <code>role=<a href="#index-aria-banner">banner</a></code>
+              </p>
+              <p>
+                Otherwise, <a>no corresponding role</a>
+              </p>
             </td>
             <td>
               <p>
                 Roles:
                 <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                or <a href="#index-aria-presentation">`presentation`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-hgroup" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-hgroup" tabindex="-1">
               [^hgroup^]
             </th>
-            <td><a>No corresponding role</a></td>
             <td>
-              <p><a><strong>Any</strong> `role`</a>.</p>
+              <a>No corresponding role</a>
+            </td>
+            <td>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-hr" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-hr" tabindex="-1">
               [^hr^]
             </th>
             <td>
@@ -1191,31 +1219,33 @@
               <p>
                 Roles:
                 <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                or <a href="#index-aria-presentation">`presentation`</a>
               </p>
               <p>
                 DPub Role:
                 <a data-cite="dpub-aria-1.0#doc-pagebreak">`doc-pagebreak`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `separator` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `separator` role.
               </p>
             </td>
           </tr>
-          <tr id="el-html" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-html" tabindex="-1">
               [^html^]
             </th>
             <td>
               <code>role=<a href="#index-aria-document">document</a></code>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>.
+              </p>
             </td>
           </tr>
-          <tr id="el-i" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-i" tabindex="-1">
               [^i^]
             </th>
             <td>
@@ -1226,13 +1256,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-iframe" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-iframe" tabindex="-1">
               [^iframe^]
             </th>
             <td>
@@ -1245,16 +1275,16 @@
                 <a href="#index-aria-document">`document`</a>,
                 <a href="#index-aria-img">`img`</a>,
                 <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                or <a href="#index-aria-presentation">`presentation`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-img" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-img" tabindex="-1">
               [^img^] with [^img/alt^]`="some text"`
             </th>
             <td>
@@ -1280,29 +1310,30 @@
               </p>
               <p>
                 DPub Role:
-                <a data-cite="dpub-aria-1.0#doc-cover">`doc-cover`</a>.
+                <a data-cite="dpub-aria-1.0#doc-cover">`doc-cover`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-img-empty-alt" tabindex="-1">
-            <th>
-              [^img^] with
-              [^img/alt^]`=""`
+          <tr>
+            <th id="el-img-empty-alt" tabindex="-1">
+              [^img^] with [^img/alt^]`=""`
             </th>
             <td>
               <code>role=<a href="#index-aria-presentation">presentation</a></code>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
-              except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
+              </p>
             </td>
           </tr>
-          <tr id="el-img-no-alt" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-img-no-alt" tabindex="-1">
               [^img^] <a data-cite="html/images.html#unknown-images">without an `alt` attribute</a>
             </th>
             <td>
@@ -1310,17 +1341,19 @@
             </td>
             <td>
               <p>
-                If no accessible name is provided via other <a data-cite=
-              "html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a> (e.g., `aria-labelledby`, `aria-label`): <strong class="nosupport">No `role`</strong>, and
-                <strong>no `aria-*` attributes</strong> except `aria-hidden="true"`.
+                If no accessible name is provided via other 
+                <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a> (e.g., `aria-labelledby`, `aria-label`): 
+                <strong class="nosupport">No `role`</strong>, and
+                <strong>no `aria-*` attributes</strong> except `aria-hidden="true"`
               </p>
               <p>
-                Otherwise, if the `img` has an author defined accessible name, see <a href="#el-img">`img` with `alt="some text"`</a>.
+                Otherwise, if the `img` has an author defined accessible name, 
+                see <a href="#el-img">`img` with `alt="some text"`</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-input-button" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-input-button" tabindex="-1">
               <a data-cite="html/input.html#button-state-(type=button)">`input type=button`</a>
             </th>
             <td>
@@ -1336,11 +1369,11 @@
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
                 <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-tab">`tab`</a>.
+                or <a href="#index-aria-tab">`tab`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -2091,8 +2091,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-ol" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-ol" tabindex="-1">
               [^ol^]
             </th>
             <td>
@@ -2114,13 +2114,13 @@
                 or <a href="#index-aria-tree">`tree`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-optgroup" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-optgroup" tabindex="-1">
               [^optgroup^]
             </th>
             <td>
@@ -2131,13 +2131,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `group` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `group` role.
               </p>
             </td>
           </tr>
-          <tr id="el-option" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-option" tabindex="-1">
               [^option^] element that is in a <a data-cite=
               "html/input.html#attr-input-list">list of options</a> or that
               represents a suggestion in a [^datalist^]
@@ -2158,8 +2158,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-output" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-output" tabindex="-1">
               [^output^]
             </th>
             <td>
@@ -2170,13 +2170,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-p" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-p" tabindex="-1">
               [^p^]
             </th>
             <td>
@@ -2187,31 +2187,35 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-param" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-param" tabindex="-1">
               [^param^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-picture" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-picture" tabindex="-1">
               [^picture^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <p><strong class="nosupport">No `role`</strong></p>
+              <p>
+                <strong class="nosupport">No `role`</strong>
+              </p>
               <div class="addition proposed">
                 <p>
                   Authors MAY specify the <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden`</a> attribute on the `picture` element.
@@ -2220,8 +2224,8 @@
               </div>
             </td>
           </tr>
-          <tr id="el-pre" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-pre" tabindex="-1">
               [^pre^]
             </th>
             <td>
@@ -2232,13 +2236,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-progress" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-progress" tabindex="-1">
               [^progress^]
             </th>
             <td>
@@ -2249,15 +2253,18 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> attribute on `progress` elements.
+                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> attribute 
+                on `progress` elements.
               </p>
               <p>
-                Otherwise, any <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> and any other `aria-*` attributes applicable to the `progressbar` role.
+                Otherwise, 
+                any <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> 
+                and any other `aria-*` attributes applicable to the `progressbar` role.
               </p>
             </td>
           </tr>
-          <tr id="el-q" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-q" tabindex="-1">
               [^q^]
             </th>
             <td>
@@ -2268,13 +2275,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-rp" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-rp" tabindex="-1">
               [^rp^]
             </th>
             <td>
@@ -2285,13 +2292,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-rt" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-rt" tabindex="-1">
               [^rt^]
             </th>
             <td>
@@ -2302,13 +2309,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-ruby" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-ruby" tabindex="-1">
               [^ruby^]
             </th>
             <td>
@@ -2319,13 +2326,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-s" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-s" tabindex="-1">
               [^s^]
             </th>
             <td>
@@ -2336,13 +2343,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-samp" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-samp" tabindex="-1">
               [^samp^]
             </th>
             <td>
@@ -2353,13 +2360,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-script" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-script" tabindex="-1">
               [^script^]
             </th>
             <td>
@@ -2371,15 +2378,19 @@
               </p>
             </td>
           </tr>
-          <tr id="el-section" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-section" tabindex="-1">
               [^section^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-region">region</a></code> if the
-              [^section^] element has an <a data-cite=
-              "html-aam-1.0#dfn-accessible-name" data-link-type=
-              "dfn">accessible name</a>. Otherwise, <a>no corresponding role</a>.
+              <p>
+                <code>role=<a href="#index-aria-region">region</a></code> if the
+                [^section^] element has an 
+                <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>
+              </p> 
+              <p>
+                Otherwise, <a>no corresponding role</a>
+              </p>
             </td>
             <td>
               <p>
@@ -2437,13 +2448,13 @@
                 <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-select" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-select" tabindex="-1">
               [^select^] (with NO `multiple` attribute and NO `size`
               attribute having value greater than `1`)
             </th>
@@ -2454,15 +2465,18 @@
               <p>
                 Role: <a href="#index-aria-menu">`menu`</a>
               </p>
-              <p>Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.</p>
               <p>
-                Otherwise, any <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> and
-                any other `aria-*` attributes applicable to the `combobox` or `menu` role.
+                Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.
+              </p>
+              <p>
+                Otherwise, 
+                any <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> 
+                and any other `aria-*` attributes applicable to the `combobox` or `menu` role.
               </p>
             </td>
           </tr>
-          <tr id="el-select-multiple-or-size-greater-1" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-select-multiple-or-size-greater-1" tabindex="-1">
               [^select^] (with a `multiple` attribute or a `size` attribute
               having value greater than `1`)
             </th>
@@ -2473,22 +2487,31 @@
               <p>
                 <strong class="nosupport">No `role`</strong>
               </p>
-              <p>Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.</p>
               <p>
-                Otherwise, any <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> and
-                any other `aria-*` attributes applicable to the `listbox` role.
+                Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.
+              </p>
+              <p>
+                Otherwise, 
+                any <a data-cite="wai-aria-1.1#global_states">global `aria-*` attributes</a> 
+                and any other `aria-*` attributes applicable to the `listbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-slot" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-slot" tabindex="-1">
               [^slot^]
             </th>
-            <td><a>No corresponding role</a></td>
-            <td><p><strong class="nosupport">No `role` or `aria-*` attributes</strong></p></td>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
+            </td>
           </tr>
-          <tr id="el-small" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-small" tabindex="-1">
               [^small^]
             </th>
             <td>
@@ -2499,24 +2522,26 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-source" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-source" tabindex="-1">
               [^source^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <p><strong class="nosupport">No `role` or `aria-*` attributes</strong></p>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-span" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-span" tabindex="-1">
               [^span^]
             </th>
             <td>
@@ -2527,13 +2552,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-strong" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-strong" tabindex="-1">
               [^strong^]
             </th>
             <td>
@@ -2544,13 +2569,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-style" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-style" tabindex="-1">
               [^style^]
             </th>
             <td>
@@ -2562,8 +2587,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-sub" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-sub" tabindex="-1">
               [^sub^]
             </th>
             <td>
@@ -2574,13 +2599,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-summary" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-summary" tabindex="-1">
               [^summary^]
             </th>
             <td>
@@ -2591,13 +2616,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `button` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `button` role.
               </p>
             </td>
           </tr>
-          <tr id="el-sup" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-sup" tabindex="-1">
               [^sup^]
             </th>
             <td>
@@ -2608,13 +2633,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-svg" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-svg" tabindex="-1">
               <a data-cite="html/embedded-content-other.html#svg-0">`SVG`</a>
             </th>
             <td>
@@ -2626,13 +2651,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-table" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-table" tabindex="-1">
               [^table^]
             </th>
             <td>
@@ -2643,13 +2668,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-tbody" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-tbody" tabindex="-1">
               [^tbody^]
             </th>
             <td>
@@ -2660,24 +2685,26 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-template" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-template" tabindex="-1">
               [^template^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <p><strong class="nosupport">No `role` or `aria-*` attributes</strong></p>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-textarea" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-textarea" tabindex="-1">
               [^textarea^]
             </th>
             <td>
@@ -2688,13 +2715,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `textbox` role.
               </p>
             </td>
           </tr>
-          <tr id="el-tfoot" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-tfoot" tabindex="-1">
               [^tfoot^]
             </th>
             <td>
@@ -2705,13 +2732,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-thead" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-thead" tabindex="-1">
               [^thead^]
             </th>
             <td>
@@ -2722,13 +2749,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-time" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-time" tabindex="-1">
               [^time^]
             </th>
             <td>
@@ -2739,86 +2766,90 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-title" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-title" tabindex="-1">
               [^title^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <p><strong class="nosupport">No `role` or `aria-*` attributes</strong></p>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-td" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-td" tabindex="-1">
               [^td^]
             </th>
             <td>
               <p>
                 <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
-                `table` element is exposed as a `role=table`.
+                `table` element is exposed as a `role=table`
               </p>
               <p>
                 <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
-                `table` element is exposed as a `role=grid` or `treegrid`.
+                `table` element is exposed as a `role=grid` or `treegrid`
               </p>
               <p>
                 <a>No corresponding role</a> if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`.
+                as a `role=table`, `grid` or `treegrid`
               </p>
             </td>
             <td>
               <p>
                 <strong class="nosupport">No `role`</strong> if the ancestor `table`
                 element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any</strong> `role`</a>.
+                <a><strong>any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-th" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-th" tabindex="-1">
               [^th^]
             </th>
             <td>
               <p>
                 <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`cell`</a> if the ancestor
-                `table` element is exposed as a `role=table`.
+                <a href="#index-aria-rowheader">`rowheader`</a> or 
+                <a href="#index-aria-rowheader">`cell`</a> if the ancestor
+                `table` element is exposed as a `role=table`
               </p>
               <p>
                 <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or <a href="#index-aria-rowheader">`gridcell`</a> if the ancestor
-                `table` element is exposed as a `role=grid` or `treegrid`.
+                <a href="#index-aria-rowheader">`rowheader`</a> or 
+                <a href="#index-aria-rowheader">`gridcell`</a> if the ancestor
+                `table` element is exposed as a `role=grid` or `treegrid`
              </p>
               <p>
                 <a>No corresponding role</a> if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`.
+                as a `role=table`, `grid` or `treegrid`
               </p>
             </td>
             <td>
               <p>
                 <strong class="nosupport">No `role`</strong> if the ancestor `table`
                 element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any</strong> `role`</a>.
+                <a><strong>any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-tr" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-tr" tabindex="-1">
               [^tr^]
             </th>
             <td>
@@ -2828,27 +2859,29 @@
               <p>
                 <strong class="nosupport">No `role`</strong> if the ancestor `table`
                 element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any</strong> `role`</a>.
+                <a><strong>any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-track" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-track" tabindex="-1">
               [^track^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <p><strong class="nosupport">No `role` or `aria-*` attributes</strong></p>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-u" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-u" tabindex="-1">
               [^u^]
             </th>
             <td>
@@ -2859,13 +2892,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-ul" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-ul" tabindex="-1">
               [^ul^]
             </th>
             <td>
@@ -2884,16 +2917,16 @@
                 <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-tablist">`tablist`</a>,
                 <a href="#index-aria-toolbar">`toolbar`</a>
-                or <a href="#index-aria-tree">`tree`</a>.
+                or <a href="#index-aria-tree">`tree`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-var" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-var" tabindex="-1">
               [^var^]
             </th>
             <td>
@@ -2904,13 +2937,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-video" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-video" tabindex="-1">
               [^video^]
             </th>
             <td>
@@ -2921,13 +2954,13 @@
                 Role: <a href="#index-aria-application">`application`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `application` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `application` role.
               </p>
             </td>
           </tr>
-          <tr id="el-wbr" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-wbr" tabindex="-1">
               [^wbr^]
             </th>
             <td>
@@ -2947,14 +2980,13 @@
       </table>
 
       <p>
-        The elements marked with <dfn>No corresponding role</dfn>, in the
-        second column of the table do not have any <a>implicit ARIA semantics</a>,
-        but they do have meaning and this meaning may be
-        represented in roles, states and properties not provided by ARIA, and
-        exposed to users of assistive technology via accessibility APIs. It is
-        therefore recommended that authors add a `role` attribute to a
-        semantically neutral element such as a [^div^] or [^span^], rather than
-        overriding the semantics of the listed elements.
+        The elements marked with <dfn>No corresponding role</dfn>, in the second column of 
+        the table do not have any <a>implicit ARIA semantics</a>, but they do have meaning 
+        and this meaning may be represented in roles, states and properties not provided 
+        by ARIA, and exposed to users of assistive technology via accessibility APIs. 
+        It is therefore recommended that authors add a `role` attribute to a semantically 
+        neutral element such as a [^div^] or [^span^], rather than overriding the semantics 
+        of the listed elements.
       </p>
       <div class="note">
         <p>

--- a/index.html
+++ b/index.html
@@ -285,10 +285,9 @@
           </tr>
         </thead>
         <tbody>
-          <tr id="el-a" tabindex="-1">
-            <th>
-              [^a^] with
-              [^a/href^]
+          <tr>
+            <th id="el-a" tabindex="-1">
+              [^a^] with [^a/href^]
             </th>
             <td>
               <code>role=<a href="#index-aria-link">link</a></code>
@@ -317,17 +316,19 @@
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
                 any `aria-*` attributes applicable to the allowed roles.
+              </p>
               <p>
                 It is NOT RECOMMENDED to use `aria-disabled="true"` on an
                 `a` element with an `href` attribute.
               </p>
               <div class="note">
-                If a link needs to be "disabled", <a href="#example-communicate-a-disabled-link-with-aria">remove the `href` attribute</a>.
+                If a link needs to be programmatically communicated as "disabled", 
+                <a href="#example-communicate-a-disabled-link-with-aria">remove the `href` attribute</a>.
               </div>
             </td>
           </tr>
-          <tr id="el-a-no-href" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-a-no-href" tabindex="-1">
               [^a^] without [^a/href^]
             </th>
             <td>
@@ -338,13 +339,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-abbr" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-abbr" tabindex="-1">
               [^abbr^]
             </th>
             <td>
@@ -360,8 +361,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-address" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-address" tabindex="-1">
               [^address^]
             </th>
             <td>
@@ -372,13 +373,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-area" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-area" tabindex="-1">
               [^area^] with [^area/href^]
             </th>
             <td>
@@ -389,32 +390,33 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <a href=
-                "#index-aria-link">`link`</a> role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the 
+                <a href="#index-aria-link">`link`</a> role.
               </p>
             </td>
           </tr>
-          <tr id="el-area-no-href" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-area-no-href" tabindex="-1">
               [^area^] without [^area/href^]
             </th>
             <td><a>No corresponding role</a></td>
             <td>
               <div class="addition proposed">
-                <p>Roles:
+                <p>
+                  Roles:
                   <a href="#index-aria-button">`button`</a>
                   or <a href="#index-aria-link">`link`</a>
                 </p>
                 <p>
-                  <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                  any `aria-*` attributes applicable to the allowed roles.
+                  <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                  and any `aria-*` attributes applicable to the allowed roles.
                 </p>
               </div>
             </td>
           </tr>
-          <tr id="el-article" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-article" tabindex="-1">
               [^article^]
             </th>
             <td>
@@ -432,13 +434,13 @@
                 or <a href="#index-aria-region">`region`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-aside" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-aside" tabindex="-1">
               [^aside^]
             </th>
             <td>
@@ -463,13 +465,13 @@
                 or <a data-cite="dpub-aria-1.0#doc-tip">`doc-tip`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-audio" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-audio" tabindex="-1">
               [^audio^]
             </th>
             <td>
@@ -481,14 +483,14 @@
                 <a href="#index-aria-application">`application`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the <a href=
-                "#index-aria-application">`application`</a> role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the 
+                <a href="#index-aria-application">`application`</a> role.
               </p>
             </td>
           </tr>
-          <tr id="el-autonomous-custom-element" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-autonomous-custom-element" tabindex="-1">
               <a>autonomous custom element</a>
             </th>
             <td>
@@ -496,74 +498,87 @@
               Otherwise <a>no corresponding role</a>.
             </td>
             <td>
-              <p>If role defined by `ElementInternals`, <strong class="nosupport">no `role`</strong>.</p>
+              <p>
+                If role defined by `ElementInternals`, 
+                <strong class="nosupport">no `role`</strong>.
+              </p>
               <p>
                 Otherwise, <a><strong>any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-b" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-b" tabindex="-1">
               [^b^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <p>
+                <a>No corresponding role</a>
+              </p>
             </td>
             <td>
-              <a><strong>Any</strong> `role`</a>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-base" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-base" tabindex="-1">
               [^base^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-bdi" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-bdi" tabindex="-1">
               [^bdi^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <a><strong>Any</strong> `role`</a>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-bdo" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-bdo" tabindex="-1">
               [^bdo^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <a><strong>Any</strong> `role`</a>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-blockquote" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-blockquote" tabindex="-1">
               [^blockquote^]
             </th>
             <td>
@@ -574,13 +589,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-body" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-body" tabindex="-1">
               [^body^]
             </th>
             <td>
@@ -591,14 +606,12 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
-                and any `aria-*` attributes applicable to the
-                <a href="#index-aria-document">`document`</a> role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-br" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-br" tabindex="-1">
               [^br^]
             </th>
             <td>
@@ -611,13 +624,12 @@
                 or <a href="#index-aria-none">`none`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-button" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-button" tabindex="-1">
               [^button^]
             </th>
             <td>
@@ -637,13 +649,13 @@
                 or <a href="#index-aria-tab">`tab`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-canvas" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-canvas" tabindex="-1">
               [^canvas^]
             </th>
             <td>
@@ -654,13 +666,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-caption" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-caption" tabindex="-1">
               [^caption^]
             </th>
             <td>
@@ -671,79 +683,89 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
-          <tr id="el-cite" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-cite" tabindex="-1">
               [^cite^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <a><strong>Any</strong> `role`</a>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-code" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-code" tabindex="-1">
               [^code^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <a><strong>Any</strong> `role`</a>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-col" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-col" tabindex="-1">
               [^col^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-colgroup" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-colgroup" tabindex="-1">
               [^colgroup^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              <p>
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+              </p>
             </td>
           </tr>
-          <tr id="el-data" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-data" tabindex="-1">
               [^data^]
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
-              <a><strong>Any</strong> `role`</a>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a><strong>Any</strong> `role`</a>
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-datalist" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-datalist" tabindex="-1">
               [^datalist^]
             </th>
             <td>
@@ -760,8 +782,8 @@
               </p>
             </td>
           </tr>
-          <tr id="el-dd" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-dd" tabindex="-1">
               [^dd^]
             </th>
             <td>
@@ -772,13 +794,13 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `definition` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `definition` role.
               </p>
             </td>
           </tr>
-          <tr id="el-del" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-del" tabindex="-1">
               [^del^]
             </th>
             <td>
@@ -789,13 +811,13 @@
                 <a><strong>Any</strong> `role`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
               </p>
             </td>
           </tr>
-          <tr id="el-details" tabindex="-1">
-            <th>
+          <tr>
+            <th id="el-details" tabindex="-1">
               [^details^]
             </th>
             <td>
@@ -806,8 +828,8 @@
                 <strong class="nosupport">No `role`</strong>
               </p>
               <p>
-                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the `group` role.
+                <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the `group` role.
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -743,7 +743,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>.
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -1050,7 +1050,7 @@
                 or <a href="#index-aria-presentation">`presentation`</a>
               </p>
               <p>
-                DPub Roles:
+                DPub Role:
                 <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
               </p>
               <p>
@@ -1159,7 +1159,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>.
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -1240,7 +1240,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>.
+                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -1328,7 +1328,7 @@
             <td>
               <p>
                 <strong class="nosupport">No `role` or `aria-*` attributes</strong>
-                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
+                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>
               </p>
             </td>
           </tr>


### PR DESCRIPTION
there have been some markup inconsistencies in the HTML elements table.  this PR is looking to correct those.
Additionally, this PR moves the IDs from the `tr` element to the `th` for each row.  This is because the `tabindex=-1` is causing chromium to calculate an accessible name for the row based on all the cells, and that's not very pleasant.  Moving to the `th` negates this name calculation while still providing a reasonable place to move focus to for each permalinked row.

This PR also removes the errant line "and any aria-* attributes applicable to the document role. " from the `body` element.  This should have been removed when body was corrected to not have the implicit role of `document`.  There is no normative change here though, as `document` doesn't have any attributes that are specifically supported by it, beyond global aria attributes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/387.html" title="Last updated on Dec 7, 2021, 2:01 PM UTC (f40226e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/387/8f39cb7...f40226e.html" title="Last updated on Dec 7, 2021, 2:01 PM UTC (f40226e)">Diff</a>