### PR TITLE
fix respec error for 'no role'

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
@@ -353,7 +353,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> and
@@ -370,7 +370,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -387,7 +387,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -500,10 +500,10 @@
             <td>
               <p>
                 If role defined by `ElementInternals`, 
-                <strong class="nosupport">no `role`</strong>
+                <a><strong class="nosupport">no `role`</strong></a>
               </p>
               <p>
-                Otherwise, <a><strong>any</strong> `role`</a>
+                Otherwise, <a><strong>any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -522,7 +522,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -539,7 +539,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -552,7 +552,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -569,7 +569,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -586,7 +586,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -603,7 +603,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
@@ -664,7 +664,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -681,7 +681,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
@@ -697,7 +697,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -714,7 +714,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -731,7 +731,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -744,7 +744,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -757,7 +757,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -774,7 +774,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
@@ -792,7 +792,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -809,7 +809,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -826,7 +826,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -843,7 +843,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -878,7 +878,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -934,7 +934,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1015,12 +1015,12 @@
               <p>
                 If the `figure` has no `figcaption` descendant:
                 <br>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 If the `figure` has a `figcaption` descendant:
                 <br>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1102,7 +1102,7 @@
             <td>
               <p>
                 If role defined by `ElementInternals`, 
-                <strong class="nosupport">no `role`</strong>
+                <a><strong class="nosupport">no `role`</strong></a>
               </p>
               <p>
                 Otherwise, form-related roles:
@@ -1160,7 +1160,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -1201,7 +1201,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1241,7 +1241,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -1254,7 +1254,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1331,7 +1331,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
                 except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>
               </p>
             </td>
@@ -1347,7 +1347,7 @@
               <p>
                 If no accessible name is provided via other 
                 <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a> (e.g., `aria-labelledby`, `aria-label`): 
-                <strong class="nosupport">No `role`</strong>, and
+                <a><strong class="nosupport">No `role`</strong></a>, and
                 <strong>no `aria-*` attributes</strong> except `aria-hidden="true"`
               </p>
               <p>
@@ -1419,7 +1419,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
@@ -1435,7 +1435,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
@@ -1452,7 +1452,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>
@@ -1470,7 +1470,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1487,7 +1487,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
@@ -1503,7 +1503,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -1539,7 +1539,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1556,7 +1556,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1573,7 +1573,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1617,7 +1617,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or 
@@ -1639,7 +1639,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1657,7 +1657,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1674,7 +1674,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1692,7 +1692,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1735,7 +1735,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 Authors SHOULD NOT use the `aria-haspopup` attribute on the indicated `input`s with a `list` attribute.
@@ -1756,7 +1756,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1774,7 +1774,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1791,7 +1791,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1808,7 +1808,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1825,7 +1825,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1842,7 +1842,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
@@ -1858,7 +1858,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a>.
@@ -1913,7 +1913,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -1926,7 +1926,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1943,7 +1943,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -1956,7 +1956,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -1973,7 +1973,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2018,7 +2018,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2031,7 +2031,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or 
@@ -2078,7 +2078,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2139,7 +2139,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2158,7 +2158,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 Authors SHOULD NOT use the `aria-selected` attribute on the `option` element.
@@ -2178,7 +2178,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2195,7 +2195,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2212,7 +2212,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2225,7 +2225,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <div class="addition proposed">
                 <p>
@@ -2244,7 +2244,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2261,7 +2261,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> attribute 
@@ -2283,7 +2283,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2300,7 +2300,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2317,7 +2317,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2334,7 +2334,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2351,7 +2351,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2368,7 +2368,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2385,7 +2385,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2496,7 +2496,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.
@@ -2517,7 +2517,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2530,7 +2530,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2547,7 +2547,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2560,7 +2560,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2577,7 +2577,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2594,7 +2594,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2607,7 +2607,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2624,7 +2624,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2641,7 +2641,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2659,7 +2659,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2676,7 +2676,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2693,7 +2693,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2710,7 +2710,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2723,7 +2723,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong>
+                <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2740,7 +2740,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2757,7 +2757,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2774,7 +2774,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2791,7 +2791,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2815,9 +2815,9 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                <a><strong class="nosupport">No `role`</strong></a> if the ancestor `table`
                 element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any</strong> `role`</a>
+                <a><strong>any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2849,9 +2849,9 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                <a><strong class="nosupport">No `role`</strong></a> if the ancestor `table`
                 element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any</strong> `role`</a>
+                <a><strong>any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2868,9 +2868,9 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role`</strong> if the ancestor `table`
+                <a><strong class="nosupport">No `role`</strong></a> if the ancestor `table`
                 element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any</strong> `role`</a>
+                <a><strong>any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2887,7 +2887,7 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport">No `role` or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>
@@ -2900,7 +2900,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
@@ -2945,7 +2945,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any</strong> `role`</a>
+                <a><strong>Any `role`</strong></a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 


### PR DESCRIPTION
the "no role" definition had no content linking to it.  This was clearly a mistake.  This PR makes instances of "no role" link to the definition.

Other stylistic update is to match the boldness of 'no role' (was all bold) and 'any role' (where previously only 'any' was bold).

closes #357


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/394.html" title="Last updated on Jan 10, 2022, 4:18 PM UTC (ad85868)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/394/f7ad181...ad85868.html" title="Last updated on Jan 10, 2022, 4:18 PM UTC (ad85868)">Diff</a>