### PR TITLE
add the new search element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2392,6 +2392,27 @@
             </td>
           </tr>
           <tr>
+            <th id="el-search" tabindex="-1">
+              [^search^]
+            </th>
+            <td>
+              <p>
+                <code>role=<a href="#index-aria-search">search</a></code>
+              </p>
+            </td>
+            <td>
+              <div class="addition proposed">
+                <p>
+                  <a><strong class="nosupport">No `role`</strong></a>
+                </p>
+                <p>
+                  <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                  and any `aria-*` attributes applicable to the allowed roles.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
             <th id="el-section" tabindex="-1">
               [^section^]
             </th>

--- a/index.html
+++ b/index.html
@@ -2669,9 +2669,11 @@
               <div class="addition proposed">
                 <p>
                   Roles:
+                  <a href="#index-aria-form">`form`</a>,
                   <a href="#index-aria-group">`group`</a>,
-                  <a href="#index-aria-none">`none`</a> or
-                  <a href="#index-aria-presentation">`presentation`</a>.
+                  <a href="#index-aria-none">`none`</a>,
+                  <a href="#index-aria-presentation">`presentation`</a> or
+                  <a href="#index-aria-region">`region`</a>.
                   (<code><a href="#index-aria-search">search</a></code> is also allowed, but NOT RECOMMENDED.)
                 </p>
                 <p>

--- a/index.html
+++ b/index.html
@@ -2658,8 +2658,10 @@
               <div class="addition proposed">
                 <p>
                   Roles:
+                  <a href="#index-aria-group">`group`</a>,
                   <a href="#index-aria-none">`none`</a> or
-                  <a href="#index-aria-presentation">`presentation`</a>
+                  <a href="#index-aria-presentation">`presentation`</a>.
+                  (<code><a href="#index-aria-search">search</a></code> is also allowed, but NOT RECOMMENDED.)
                 </p>
                 <p>
                   <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 

--- a/index.html
+++ b/index.html
@@ -2407,10 +2407,12 @@
             <td>
               <div class="addition proposed">
                 <p>
-                  <a><strong class="nosupport">No `role`</strong></a>
+                  Roles:
+                  <a href="#index-aria-none">`none`</a> or
+                  <a href="#index-aria-presentation">`presentation`</a>
                 </p>
                 <p>
-                  <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
                   and any `aria-*` attributes applicable to the allowed roles.
                 </p>
               </div>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/401">24 March 2023 - Addition:</a>
+          The <a href="#el-search">`search`</a> element has been added.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/447">6 March 2023 - Addition:</a>
           Disallow `aria-hidden=true` on the `body` element.
         </li>


### PR DESCRIPTION
closes #371

keeping this straight forward for the new element's initial inclusion.

edit: the allowed roles for this element are the following
`form`,  `group`, `none`, `presentation`, `region` and with the allowed but not recommended use of `search`.

All global `aria-*` attributes would be allowed on this element.

As the element is used in the wild, further updates may be necessary for the allowed roles, but these initial allowances should be more than enough for people who immediately misuse the new element and need to correct themselves while somehow also not being able to correct the actual html element. 

DONE: update changelog for when the element lands and this PR can be merged into the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/401.html" title="Last updated on Mar 24, 2023, 12:47 PM UTC (93cbb7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/401/d4ff854...93cbb7d.html" title="Last updated on Mar 24, 2023, 12:47 PM UTC (93cbb7d)">Diff</a>