### PR TITLE
allow none and presentation on nav element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2056,14 +2056,16 @@
               <p>
                 Roles:
                 <a href="#index-aria-menu">`menu`</a>,
-                <a href="#index-aria-menubar">`menubar`</a>
+                <a href="#index-aria-menubar">`menubar`</a>,
+                <span class="proposed addition"><a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-presentation">`presentation`</a></span>
                 or <a href="#index-aria-tablist">`tablist`</a>
               </p>
               <p>
                 DPub Roles:
                 <a data-cite="dpub-aria-1.0#doc-index">`doc-index`</a>,
-                <a data-cite="dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a>,
-                <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>
+                <a data-cite="dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a>
+                or <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.1#global_states">Global `aria-*` attributes</a> 

--- a/index.html
+++ b/index.html
@@ -4426,6 +4426,10 @@
       <h3>Substantive changes since the last published Recommendation</h3>
       <ul>
         <li>
+          06-Mar-2022:
+          Allow `none` and `presentation` roles on <a href="#el-nav">`nav` element</a>.
+        </li>
+        <li>
           03-Mar-2022:
           Restrict role allowances for <a href="#el-div">`div` element</a> when it is a child of a `dl` element.
         </li>


### PR DESCRIPTION
this gets the nav element in alignment with other elements that would otherwise expose implicit ARIA landmarks

closes #344

---

Need two conformance checkers to accept or indicate commitment to this change before it can be merged:

- [x] [html validator PR](https://github.com/validator/validator/pull/1323)
- [x] [ibm equal access accessibility checker](https://github.com/IBMa/equal-access/issues/726)
- [x] [axe-core](https://github.com/IBMa/equal-access/issues/726)
- [x] [arc toolkit PR](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/pull/60)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/404.html" title="Last updated on Mar 6, 2022, 5:08 PM UTC (f968d95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/404/b2d9fe7...f968d95.html" title="Last updated on Mar 6, 2022, 5:08 PM UTC (f968d95)">Diff</a>