### PR TITLE
Clarify li element role allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -1908,20 +1908,17 @@
               <code>role=<a href="#index-aria-listitem">listitem</a></code>
             </td>
             <td>
-              <p>
-                Roles:
-                <a href="#index-aria-menuitem">`menuitem`</a>,
-                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
-                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                <a href="#index-aria-option">`option`</a>,
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>,
-                <a href="#index-aria-radio">`radio`</a>,
-                <a href="#index-aria-separator">`separator`</a>,
-                <a href="#index-aria-tab">`tab`</a>
-                or <a href="#index-aria-treeitem">`treeitem`</a>
-              </p>
-              <p>
+              <div class="proposed correction">
+                <p>
+                  If the `li` is not a child of a list element (`ul`, `ol`, `menu`), or the 
+                  list element's implicit `list` role has been overwritten, then 
+                  <a><strong>any `role`</strong></a> that is an allowed child of the parent element.
+                </p>
+                <p>
+                  If the `li` is a child of a `ul`, `ol`, or `menu` with no explicit `role`: 
+                  <strong class="nosupport"><a>No `role`</a></strong>.
+                </p>
+              </div>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.

--- a/index.html
+++ b/index.html
@@ -1910,13 +1910,13 @@
             <td>
               <div class="proposed correction">
                 <p>
-                  If the `li` is not a child of a list element (`ul`, `ol`, `menu`), or the 
-                  list element's implicit `list` role has been overwritten, then 
-                  <a><strong>any `role`</strong></a> that is an allowed child of the parent element.
+                  If the `li` is not a child of a list element 
+                  (<a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, 
+                  <a href="#el-menu">`menu`</a>), or the list element's implicit `list` role 
+                  has been overwritten, then <a><strong>any `role`</strong></a>.
                 </p>
                 <p>
-                  If the `li` is a child of a `ul`, `ol`, or `menu` with no explicit `role`: 
-                  <strong class="nosupport"><a>No `role`</a></strong>.
+                  Otherwise, <strong class="nosupport"><a>no `role`</a></strong>.
                 </p>
               </div>
               <p>

--- a/index.html
+++ b/index.html
@@ -1905,14 +1905,20 @@
               [^li^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-listitem">listitem</a></code>
+              <p>
+                If the `li` is not a child of a list element 
+                (<a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, 
+                <a href="#el-menu">`menu`</a>)
+                <code>role=<a href="#index-aria-listitem">listitem</a></code>.
+              </p>
+              <p>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>.
+              </p>
             </td>
             <td>
               <div class="proposed correction">
                 <p>
-                  If the `li` is not a child of a list element 
-                  (<a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, 
-                  <a href="#el-menu">`menu`</a>), or the list element's implicit `list` role 
+                  If the `li` is not a child of a list element, or the list element's implicit `list` role 
                   has been overwritten, then <a><strong>any `role`</strong></a>.
                 </p>
                 <p>

--- a/index.html
+++ b/index.html
@@ -1943,7 +1943,7 @@
             </th>
             <td>
               <p>
-                If the `li` is not a child of a list element 
+                If the `li` is a child of a list element 
                 (<a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, 
                 <a href="#el-menu">`menu`</a>)
                 <code>role=<a href="#index-aria-listitem">listitem</a></code>.
@@ -1955,11 +1955,13 @@
             <td>
               <div class="proposed correction">
                 <p>
-                  If the `li` is not a child of a list element, or the list element's implicit `list` role 
-                  has been overwritten, then <a><strong>any `role`</strong></a>.
+                  <strong class="nosupport"><a>No `role`</a></strong> if the parent list element has an implicit 
+                  or explicit `list` role.
                 </p>
                 <p>
-                  Otherwise, <strong class="nosupport"><a>no `role`</a></strong>.
+                  Otherwise, <a><strong>any `role`</strong></a> that is an allowed child of the parent list element's
+                  explicit ARIA role.  See <a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, and
+                  <a href="#el-menu">`menu`</a> for allowed roles for these list elements.
                 </p>
               </div>
               <p>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,11 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/410">31 May 2023 - Correction:</a>
+          Update <a href="#el-li">`li`</a> element role allowances in context to the element's ancestral relationship, or lack of, 
+          to a list element parent.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/401">24 March 2023 - Addition:</a>
           The <a href="#el-search">`search`</a> element has been added.
         </li>
@@ -73,7 +78,7 @@
         </li>
         <li>
           <a href="https://github.com/w3c/html-aria/pull/415">13 February 2023 - Addition:</a>
-           Update `figure` element role allowances to include `doc-example`.
+          Update `figure` element role allowances to include `doc-example`.
         </li>
         <li>
           <a href="https://github.com/w3c/html-aria/pull/437">07 November 2022 - Correction:</a>

--- a/index.html
+++ b/index.html
@@ -310,7 +310,7 @@
               </p>
             </th>
             <th>
-              ARIA roles, states and properties which MAY be used
+              ARIA role, state and property allowances
             </th>
           </tr>
         </thead>

--- a/index.html
+++ b/index.html
@@ -1958,7 +1958,8 @@
                 <code>role=<a href="#index-aria-listitem">listitem</a></code>.
               </p>
               <p>
-                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>.
+                Otherwise, if the `li` is not a child of a list element it is exposed as 
+                a <code>role=<a href="#index-aria-generic">generic</a></code>.
               </p>
             </td>
             <td>
@@ -1968,9 +1969,11 @@
                   or explicit `list` role.
                 </p>
                 <p>
-                  Otherwise, <a><strong>any `role`</strong></a> that is an allowed child of the parent list element's
-                  explicit ARIA role.  See <a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, and
-                  <a href="#el-menu">`menu`</a> for allowed roles for these list elements.
+                  Otherwise, <a><strong>any `role`</strong></a>.
+                </p>
+                <p class="note">
+                  See <a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, or
+                  <a href="#el-menu">`menu`</a> for allowed roles for list elements.
                 </p>
               </div>
               <p>


### PR DESCRIPTION
Closes #351

This change is to clarify that if an `li` is a child of a `ul`, `ol`, or `menu` element, and those elements are exposed as a `list`, then no other role can be specified on the `li`.

However, if the parent of the `li` is no longer exposed as a `list`, or if someone were to write invalid markup and use an `li` outside of the expected list > listitem markup pattern, then _any_ role should be allowed on the `li` (so long as the role is a role allowed by the `li`'s parent element) 

For instance,
```
<ul role=table>
  <li role=button>...</li>
</ul>
``` 
is not be allowed as a `button` cannot be a direct child of a `table`.  However, but a `role=row` on the `li` would be allowed in this example.

and 
```
<div>
  <li role=paragraph>...</li>
</div>
```
is invalid HTML, but as the `li` is not a child of a list element, it should be allowed to have any role.

[test cases](https://w3c.github.io/html-aria/tests/li-element-roles.html)



- [x] [HTML Validator](https://github.com/validator/validator/issues/1368)
- [x] [IBM Equal Access Accessibility Checker](https://github.com/IBMa/equal-access/issues/824)
- [ ] [axe-Core](https://github.com/dequelabs/axe-core/issues/3439)
- [x] [ARC Toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/64)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/410.html" title="Last updated on May 31, 2023, 2:16 PM UTC (0b9b50c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/410/4d9fc05...0b9b50c.html" title="Last updated on May 31, 2023, 2:16 PM UTC (0b9b50c)">Diff</a>