### PR TITLE
Editorial: clarify custom elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -542,7 +542,7 @@
             </th>
             <td>
               Role exposed from author defined {{ElementInternals}}.
-              Otherwise <a>no corresponding role</a>.
+              Otherwise <code>role=<a href="#index-aria-generic">`generic`</a></code>.
             </td>
             <td>
               <p>
@@ -552,7 +552,10 @@
               <p>
                 Otherwise, <a><strong>any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="proposed addition">
+                <a>Naming Prohibited</a> if exposed as the `generic` role, or if exposed
+                as another role which prohibits naming.
+              </p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1158,7 +1161,7 @@
                 Role exposed from author defined {{ElementInternals}}
               </p>
               <p>
-                Otherwise <a>no corresponding role</a>
+                Otherwise <code>role=<a href="#index-aria-generic">`generic`</a></code>
               </p>
             </td>
             <td>
@@ -1182,7 +1185,9 @@
                 <a href="#index-aria-switch">`switch`</a>
                 or <a href="#index-aria-textbox">`textbox`</a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="proposed addition">
+                <a>Naming Prohibited</a> if exposed as the `generic` role.
+              </p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.

--- a/index.html
+++ b/index.html
@@ -541,8 +541,12 @@
               <a>autonomous custom element</a>
             </th>
             <td>
-              Role exposed from author defined {{ElementInternals}}.
-              Otherwise <code>role=<a href="#index-aria-generic">`generic`</a></code>.
+              <p>
+                Role exposed from author defined {{ElementInternals}}
+              </p>
+              <p>
+                Otherwise <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              </p>
             </td>
             <td>
               <p>


### PR DESCRIPTION
- clarifies when naming prohibited is applicable
- clarifies that if not provided a role, then the custom elements will map to `generic`.


Closes #413


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/414.html" title="Last updated on Apr 16, 2022, 3:22 PM UTC (dac3c1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/414/c6d14a9...dac3c1b.html" title="Last updated on Apr 16, 2022, 3:22 PM UTC (dac3c1b)">Diff</a>