### PR TITLE
Addition: update figure role allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -1122,7 +1122,7 @@
                 or <a href="#index-aria-none">`none`</a>
               </p>
               <p>
-                DPub Role:doc-example
+                DPub Role:
                 <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
               </p>
               <p class="proposed addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/415">13 February 2023 - Addition:</a>
+           update figure role allowances to include `doc-example`.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/437">07 November 2022 - Correction:</a>
            Revisions to 'any role' term description.
         </li>

--- a/index.html
+++ b/index.html
@@ -1087,7 +1087,7 @@
                 <br>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="addition proposal">
+              <p class="addition proposed">
                 If the `figure` has a `figcaption` descendant:
                 <br>
                 DPub Role:

--- a/index.html
+++ b/index.html
@@ -1087,10 +1087,11 @@
                 <br>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p>
+              <p class="addition proposal">
                 If the `figure` has a `figcaption` descendant:
                 <br>
-                <a><strong class="nosupport">No `role`</strong></a>
+                DPub Role:
+                <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1121,7 +1122,7 @@
                 or <a href="#index-aria-none">`none`</a>
               </p>
               <p>
-                DPub Role:
+                DPub Role:doc-example
                 <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
               </p>
               <p class="proposed addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>


### PR DESCRIPTION
closes #412

As discussed in https://github.com/w3c/dpub-aria/issues/42#issuecomment-1092558918, `doc-example` is a dpub variant of the `figure` role.  This role being the same as `figure` but with the opportunity of being exposed as an "example" for its role description, needs to be an allowed role for the `figure` element.

create [test case](https://w3c.github.io/html-aria/tests/figure-figcaption.html)

- [x] [HTML validator](https://github.com/validator/validator/issues/1366)
- [x] [IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/847)
- [x] [axe-core](https://github.com/dequelabs/axe-core/issues/3443)
- [x] [ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/63)

Expected results:
`doc-example` is an allowed role for `<figure role=doc-example>...<figcaption>...</figcaption>`
`figure` results in a warning as unnecessary for `<figure role=figure>...<figcaption>...</figcaption>`
no other roles are allowed if a `figcaption` is a child of a `figure` element.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/415.html" title="Last updated on Feb 13, 2023, 3:15 PM UTC (0816660)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/415/8a7d4cb...0816660.html" title="Last updated on Feb 13, 2023, 3:15 PM UTC (0816660)">Diff</a>