### PR TITLE
chore: auto-publish Proposed Edited Recommendation

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,17 +6,17 @@ on:
       - gh-pages
   pull_request: {}
 
-# jobs:
-#   validate-and-publish:
-#     name: Validate and Publish
-#     runs-on: ubuntu-latest # only linux supported at present
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: w3c/spec-prod@v2
-#         with:
-#           TOOLCHAIN: respec
-#           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-#           W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
-#           W3C_NOTIFICATIONS_CC: "${{ secrets.CC }}"
-#           W3C_BUILD_OVERRIDE: |
-#             specStatus: CRD
+jobs:
+  validate-and-publish:
+    name: Validate and Publish
+    runs-on: ubuntu-latest # only linux supported at present
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webapps/2014JulSep/0627.html"
+          W3C_NOTIFICATIONS_CC: "${{ secrets.CC }}"
+          W3C_BUILD_OVERRIDE: |
+            specStatus: PER


### PR DESCRIPTION
Hi @scottaohara, this will get the document up automatically on TR again 🤞. 

In the coming coming days, I'll send the automatically generated changelog code. We can then work together to make to make sure the changes are clear/evident for AC review, etc.  

Note: we need a "perEnd" date in the ReSpec config. 
