### PR TITLE
Editorial: update implict role mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1390,7 +1390,7 @@
               [^i^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>

--- a/index.html
+++ b/index.html
@@ -882,7 +882,7 @@
               [^data^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -2520,7 +2520,7 @@
               [^samp^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -2714,7 +2714,7 @@
               [^span^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>

--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
               [^a^] without [^a/href^]
             </th>
             <td>
-              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn">No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -512,7 +512,9 @@
             <th id="el-area-no-href" tabindex="-1">
               [^area^] without [^area/href^]
             </th>
-            <td><a>No corresponding role</a></td>
+            <td>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+            </td>
             <td>
               <div class="addition proposed">
                 <p>
@@ -637,9 +639,7 @@
               [^b^]
             </th>
             <td>
-              <p>
-                <a>No corresponding role</a>
-              </p>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -670,7 +670,7 @@
               [^bdi^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -688,7 +688,7 @@
               [^bdo^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -2392,7 +2392,7 @@
               [^pre^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -2432,7 +2432,7 @@
               [^q^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -2683,7 +2683,7 @@
               [^small^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>
@@ -3059,7 +3059,7 @@
               [^u^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
               <p>


### PR DESCRIPTION
the following are meant to be treated as generic elements:
- a  no href
- area no href
- b
- bdi
- bdo
- pre
- q
- u
- small
- data
- samp
- span
- i

related to #406

related HTML AAM issue: https://github.com/w3c/html-aam/issues/373


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/425.html" title="Last updated on Jul 18, 2022, 4:07 PM UTC (f8f8f6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/425/ce97bd9...f8f8f6c.html" title="Last updated on Jul 18, 2022, 4:07 PM UTC (f8f8f6c)">Diff</a>