### PR TITLE
Editorial: prepare for REC with Candidate Amendments

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,58 +63,58 @@
       </p>
       <ul>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/383">20220714 - Correction:</a>
+          <a href="https://github.com/w3c/html-aria/pull/383">14 July 2022 - Correction:</a>
           Disallow roles and `aria-*` attributes on the <a href="#el-datalist">`datalist`</a> element.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/372">20220416 - Correction:</a>
+          <a href="https://github.com/w3c/html-aria/pull/372">16 April 2022 - Correction:</a>
           <a href="#att-checked">`aria-checked`</a> is not to be used on elements that support the `checked` attribute.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/402">20220403 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/402">03 April 2022 - Addition:</a>
           Identify <a href="dfn-naming-prohibited">Naming Prohibited</a> elements.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/404">20220306 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/404">06 March 2022 - Addition:</a>
           Allow `none` and `presentation` roles on <a href="#el-nav">`nav` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/403">20220303 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/403">03 March 2022 - Addition:</a>
           Restrict role allowances for <a href="#el-div">`div` element</a> when it is a child of a `dl` element.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/396">20220212 - Addition &amp; Correction:</a>
+          <a href="https://github.com/w3c/html-aria/pull/396">12 February 2022 - Addition &amp; Correction:</a>
           Allow `combobox` role on <a href="#el-button">`button` element</a>. 
           Allow `combobox` and `checkbox` roles on <a href="#el-input-button">`input type=button` element</a>. 
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/391">20220118 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/391">18 January 2022 - Addition:</a>
           Added <a href="#docconformance-deprecated">Requirements for deprecated ARIA role, state and property attributes</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/369">20220106 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/369">06 January 2022 - Addition:</a>
           Change allowances for `doc-biblioentry` and `doc-endnote` roles on the <a href="#el-li">`li` element</a>. 
           These roles are deprecated in [[[dpub-aria-1.1]]].
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/381">20211213 - Correction:</a>
+          <a href="https://github.com/w3c/html-aria/pull/381">13 December 2021 - Correction:</a>
           Allow `radio` role on <a href="#el-img">`img alt="some text"` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/353">20211207 - Correction:</a> 
+          <a href="https://github.com/w3c/html-aria/pull/353">07 December 2021 - Correction:</a> 
           Allow only `none` and `presentation` roles for <a href="#el-wbr">`wbr` element</a>. 
           Allow only `aria-hidden` global attribute for <a href="#el-br">`br`</a> and <a href="#el-wbr">`wbr`</a> elements.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/367">20211202 - Addition:</a> 
+          <a href="https://github.com/w3c/html-aria/pull/367">02 December 2021 - Addition:</a> 
           Allow `group` role on <a href="#el-section">`section` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/360">20211116 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/360">16 November 2021 - Addition:</a>
           Allow `link` and `button` roles on <a href="#el-area-no-href">`area` without `href` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/352">20211026 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/352">26 October 2021 - Addition:</a>
           Allow `aria-hidden` attribute on the <a href="#el-picture">`picture` element</a>. 
         </li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -63,58 +63,58 @@
       </p>
       <ul>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/383">14-Jul-2022 - Correction:</a>
+          <a href="https://github.com/w3c/html-aria/pull/383">20220714 - Correction:</a>
           Disallow roles and `aria-*` attributes on the <a href="#el-datalist">`datalist`</a> element.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/372">16-Apr-2022 - Correction:</a>
+          <a href="https://github.com/w3c/html-aria/pull/372">20220416 - Correction:</a>
           <a href="#att-checked">`aria-checked`</a> is not to be used on elements that support the `checked` attribute.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/402">03-Apr-2022 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/402">20220403 - Addition:</a>
           Identify <a href="dfn-naming-prohibited">Naming Prohibited</a> elements.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/404">06-Mar-2022 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/404">20220306 - Addition:</a>
           Allow `none` and `presentation` roles on <a href="#el-nav">`nav` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/403">03-Mar-2022 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/403">20220303 - Addition:</a>
           Restrict role allowances for <a href="#el-div">`div` element</a> when it is a child of a `dl` element.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/396">12-Feb-2022 - Addition &amp; Correction:</a>
+          <a href="https://github.com/w3c/html-aria/pull/396">20220212 - Addition &amp; Correction:</a>
           Allow `combobox` role on <a href="#el-button">`button` element</a>. 
           Allow `combobox` and `checkbox` roles on <a href="#el-input-button">`input type=button` element</a>. 
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/391">18-Jan-2022 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/391">20220118 - Addition:</a>
           Added <a href="#docconformance-deprecated">Requirements for deprecated ARIA role, state and property attributes</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/369">06-Jan-2022 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/369">20220106 - Addition:</a>
           Change allowances for `doc-biblioentry` and `doc-endnote` roles on the <a href="#el-li">`li` element</a>. 
           These roles are deprecated in [[[dpub-aria-1.1]]].
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/381">13-Dec-2021 - Correction:</a>
+          <a href="https://github.com/w3c/html-aria/pull/381">20211213 - Correction:</a>
           Allow `radio` role on <a href="#el-img">`img alt="some text"` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/353">07-Dec-2021: - Correction:</a> 
+          <a href="https://github.com/w3c/html-aria/pull/353">20211207 - Correction:</a> 
           Allow only `none` and `presentation` roles for <a href="#el-wbr">`wbr` element</a>. 
           Allow only `aria-hidden` global attribute for <a href="#el-br">`br`</a> and <a href="#el-wbr">`wbr`</a> elements.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/367">02-Dec-2021 - Addition:</a> 
+          <a href="https://github.com/w3c/html-aria/pull/367">20211202 - Addition:</a> 
           Allow `group` role on <a href="#el-section">`section` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/360">16-Nov-2021 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/360">20211116 - Addition:</a>
           Allow `link` and `button` roles on <a href="#el-area-no-href">`area` without `href` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/352">26-Oct-2021 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/352">20211026 - Addition:</a>
           Allow `aria-hidden` attribute on the <a href="#el-picture">`picture` element</a>. 
         </li>
       </ul>
@@ -122,10 +122,8 @@
         Reviewers of the document can identify candidate additions
         and/or corrections by their distinctive styling in the document:
       </p>
-      <ul>
-        <li class="proposed correction">A proposed correction looks like this.</li>
-        <li class="proposed addition">A proposed addition looks like this.</li>
-      </ul>
+      <p class="correction">Candidate corrections are marked in the document.</p>
+      <p class="addition">Candidate additions are marked in the document.</p>
     </section>
     <section>
       <h2 id="rules-wd">
@@ -346,7 +344,7 @@
         a cell in the third column includes the term
         <dfn><strong>Any</strong> `role`</dfn> it indicates that any `role`
         value apart from the <a>implicit ARIA semantics</a> `role` value,
-        MAY be used, <span class="proposed addition">unless it is the `generic` role
+        MAY be used, <span class="addition">unless it is the `generic` role
         or a role <a href="#docconformance-deprecated">deprecated by ARIA</a>. 
         The `generic` role and deprecated roles SHOULD NOT be used by authors</span>. 
         If a cell in the third column includes the term
@@ -354,7 +352,7 @@
         MUST NOT overwrite the implicit ARIA semantics, or native semantics
         of the HTML element.
       </p>
-      <div class="proposed addition">
+      <div class="addition">
         <p>
           [[wai-aria-1.2|WAI-ARIA]] identifies roles which have 
           <a data-cite="wai-aria-1.2/#prohibitedattributes">prohibited states and properties</a>.
@@ -453,7 +451,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -471,7 +469,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> and any `aria-*` attributes applicable to the allowed roles.
               </p>
@@ -488,7 +486,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -521,7 +519,7 @@
               <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
-              <div class="addition proposed">
+              <div class="addition">
                 <p>
                   Roles:
                   <a href="#index-aria-button">`button`</a>
@@ -629,7 +627,7 @@
               <p>
                 Otherwise, <a><strong>any `role`</strong></a>
               </p>
-              <p class="proposed addition">
+              <p class="addition">
                 <a>Naming Prohibited</a> if exposed as the `generic` role, or if exposed
                 as another role which prohibits naming.
               </p>
@@ -650,7 +648,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -681,7 +679,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -699,7 +697,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -734,7 +732,7 @@
               <p>
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
               </p>
@@ -753,7 +751,7 @@
                 <a href="#index-aria-none">`none`</a>
                 or <a href="#index-aria-presentation">`presentation`</a>
               </p>
-              <p class="proposed addition">
+              <p class="addition">
                 Authors MAY specify the <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on the `br` element.
                 Otherwise, no other allowed `aria-*` attributes.
               </p>
@@ -770,7 +768,7 @@
               <p>
                 Roles:
                 <a href="#index-aria-checkbox">`checkbox`</a>,
-                <span class="proposed addition"><a href="#index-aria-combobox">`combobox`</a></span>,
+                <span class="addition"><a href="#index-aria-combobox">`combobox`</a></span>,
                 <a href="#index-aria-link">`link`</a>,
                 <a href="#index-aria-menuitem">`menuitem`</a>,
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
@@ -814,7 +812,7 @@
               <p>
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
               </p>
@@ -831,7 +829,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -849,7 +847,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -893,7 +891,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -908,7 +906,7 @@
               <code>role=<a href="#index-aria-listbox">listbox</a></code>
             </td>
             <td>
-              <div class="proposed correction">
+              <div class="correction">
                 <p>
                   <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
                 </p>
@@ -943,7 +941,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1010,12 +1008,12 @@
               <code>role=<a href="#index-aria-generic">`generic`</a></code>
             </td>
             <td>
-              <p class="proposed addition">
+              <p class="addition">
                 <a><strong>Any `role`</strong></a> unless a direct child of a [^dl^] element. 
                 Then only <a href="#index-aria-presentation">`presentation`</a>
                 or <a href="#index-aria-none">`none`</a>.
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1072,7 +1070,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1135,7 +1133,7 @@
                 <a href="#index-aria-none">`none`</a>
                 or <a href="#index-aria-presentation">`presentation`</a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1192,7 +1190,7 @@
                 DPub Role:
                 <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>
+              <p class="addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1257,7 +1255,7 @@
                 <a href="#index-aria-switch">`switch`</a>
                 or <a href="#index-aria-textbox">`textbox`</a>
               </p>
-              <p class="proposed addition">
+              <p class="addition">
                 <a>Naming Prohibited</a> if exposed as the `generic` role.
               </p>
               <p>
@@ -1326,7 +1324,7 @@
                 <a href="#index-aria-none">`none`</a>
                 or <a href="#index-aria-presentation">`presentation`</a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>
+              <p class="addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1344,7 +1342,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1398,7 +1396,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1445,7 +1443,7 @@
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-progressbar">`progressbar`</a>,
-                <span class="proposed correction">
+                <span class="correction">
                   <a href="#index-aria-radio">`radio`</a>,
                 </span>
                 <a href="#index-aria-scrollbar">`scrollbar`</a>,
@@ -1509,8 +1507,8 @@
             <td>
               <p>
                 Roles:
-                <span class="proposed correction"><a href="#index-aria-checkbox">`checkbox`</a>,</span>
-                <span class="proposed addition"><a href="#index-aria-combobox">`combobox`</a>,</span>
+                <span class="correction"><a href="#index-aria-checkbox">`checkbox`</a>,</span>
+                <span class="addition"><a href="#index-aria-combobox">`combobox`</a>,</span>
                 <a href="#index-aria-link">`link`</a>,
                 <a href="#index-aria-menuitem">`menuitem`</a>,
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
@@ -1541,7 +1539,7 @@
                 or <a href="#index-aria-switch">`switch`</a>;
                 <a href="#index-aria-button">`button` if used with `aria-pressed`</a>
               </p>
-              <p class="proposed correction">
+              <p class="correction">
                 Authors <a href="#att-checked">MUST NOT use the `aria-checked` attribute on `input type=checkbox` elements</a>.
               </p>
               <p>
@@ -1738,7 +1736,7 @@
                 Role:
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>
               </p>
-              <p class="proposed correction">
+              <p class="correction">
                 Authors <a href="#att-checked">MUST NOT use the
                 `aria-checked` attribute on `input type=radio` elements</a>.
               </p>
@@ -1955,7 +1953,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1973,7 +1971,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1991,7 +1989,7 @@
               <p>
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
               </p>
@@ -2008,7 +2006,7 @@
               <p>
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
               </p>
@@ -2102,7 +2100,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2203,7 +2201,7 @@
                 Roles:
                 <a href="#index-aria-menu">`menu`</a>,
                 <a href="#index-aria-menubar">`menubar`</a>,
-                <span class="proposed addition"><a href="#index-aria-none">`none`</a>,
+                <span class="addition"><a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a></span>
                 or <a href="#index-aria-tablist">`tablist`</a>
               </p>
@@ -2350,7 +2348,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2381,7 +2379,7 @@
               <p>
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
-              <div class="addition proposed">
+              <div class="addition">
                 <p>
                   Authors MAY specify the <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on the `picture` element.
                   Otherwise, no other allowed `aria-*` attributes.
@@ -2400,7 +2398,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2440,7 +2438,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2475,7 +2473,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2510,7 +2508,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2528,7 +2526,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2574,7 +2572,7 @@
                 <a href="#index-aria-dialog">`dialog`</a>,
                 <a href="#index-aria-document">`document`</a>,
                 <a href="#index-aria-feed">`feed`</a>,
-                <span class="addition proposed"><a href="#index-aria-group">`group`</a>,</span>
+                <span class="addition"><a href="#index-aria-group">`group`</a>,</span>
                 <a href="#index-aria-log">`log`</a>,
                 <a href="#index-aria-main">`main`</a>,
                 <a href="#index-aria-marquee">`marquee`</a>,
@@ -2691,7 +2689,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2722,7 +2720,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2740,7 +2738,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2771,7 +2769,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2806,7 +2804,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2940,7 +2938,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -3067,7 +3065,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -3118,7 +3116,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="proposed addition"><a>Naming Prohibited</a></p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -3150,7 +3148,7 @@
               <a>No corresponding role</a>
             </td>
             <td>
-              <div class="proposed correction">
+              <div class="correction">
                 <p>
                   Roles:
                   <a href="#index-aria-none">`none`</a>
@@ -3219,7 +3217,7 @@
 &lt;/figure&gt;
 </pre><!-- source: http://www.geocities.com/SoHo/7373/aquatic.htm#fish -->
       </aside>
-      <section class="proposed addition">
+      <section class="addition">
         <h3 id="docconformance-naming">
           Requirements for use of ARIA attributes to name <!-- and describe --> elements
         </h3>
@@ -3307,7 +3305,7 @@
                 `aria-checked="true"`
               </td>
               <td>
-                <div class="proposed correction">
+                <div class="correction">
                   <p>
                     Use the `checked` attribute on any element that is allowed the `checked` attribute in HTML. 
                     Use the <a data-cite="html/input.html#dom-input-indeterminate">`indeterminate`</a> IDL attribute to indicate the "mixed" state for <a data-cite="html/input.html#checkbox-state-(type=checkbox)">`input type=checkbox`</a> elements.
@@ -3564,7 +3562,7 @@
           </tbody>
         </table>
       </section>
-      <section class="proposed addition">
+      <section class="addition">
         <h2 id="docconformance-deprecated">
           Requirements for deprecated ARIA role, state and property and attributes
         </h2>


### PR DESCRIPTION
A new version of the REC was published today:
  https://www.w3.org/TR/2022/REC-html-aria-20220927/

See https://github.com/w3c/echidna/issues/1048#issuecomment-1233759037

The group can publish a REC with Candidate Amendments (or multiple ones) anytime before the group decides to move to REC with Proposed Amendments.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/siusin/html-aria/pull/430.html" title="Last updated on Oct 3, 2022, 3:30 PM UTC (9e2d6d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/430/2d9bf9e...siusin:9e2d6d6.html" title="Last updated on Oct 3, 2022, 3:30 PM UTC (9e2d6d6)">Diff</a>