### PR TITLE
Editorial: clarify summary element role mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -2779,7 +2779,7 @@
                 <a>No corresponding role</a>
               </p>
               <div class="note">
-                Many, but not all, user agents map the `summary` element to the <code>role=<a href="#index-aria-button">button</a></code>
+                Many, but not all, user agents expose the `summary` element with an implicit ARIA <code>role=<a href="#index-aria-button">button</a></code>
                 role.
               </div>
             </td>

--- a/index.html
+++ b/index.html
@@ -2775,7 +2775,13 @@
               [^summary^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-button">button</a></code>
+              <p>
+                <a>No corresponding role</a>
+              </p>
+              <div class="note">
+                Many, but not all, user agents map the `summary` element to the <code>role=<a href="#index-aria-button">button</a></code>
+                role.
+              </div>
             </td>
             <td>
               <p>


### PR DESCRIPTION
Closes #355

Since the original issue was filed, and I have spent more time researching details/summary and trying to get consensus on what to do with the summary element in particular, I think it does make sense to adjust this per JAWS-test's issue.  The role is now stated as "no corresponding role" since there is no direct ARIA mapping in HTML AAM, but the note was added to indicate the reality of how the role is actually mapped.


This PR contains no normative changes, as element roles are not defined by this specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/434.html" title="Last updated on Nov 2, 2022, 2:52 PM UTC (5cdb5f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/434/29e8e29...5cdb5f2.html" title="Last updated on Nov 2, 2022, 2:52 PM UTC (5cdb5f2)">Diff</a>