### PR TITLE
Correction: conditionally revise allowed attributes and roles on summary element

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/435">31 May 2023 - Correction:</a>
+          Conditionally revise allowed `aria-*` attributes and roles on <a href="#el-summary">`summary`</a> element.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/410">31 May 2023 - Correction:</a>
           Update <a href="#el-li">`li`</a> element role allowances in context to the element's ancestral relationship, or lack of, 
           to a list element parent.

--- a/index.html
+++ b/index.html
@@ -2879,7 +2879,7 @@
             </td>
           </tr>
           <tr>
-            <th id="el-summary" tabindex="-1">
+            <th id="]" tabindex="-1">
               [^summary^]
             </th>
             <td>
@@ -2897,7 +2897,7 @@
                   <a><strong class="nosupport">No `role`</strong></a> if the `summary` element is a 
                   <a data-cite="html/interactive-elements.html#summary-for-its-parent-details">summary for its parent details</a>.
                 </p>
-                <p class="proposed correction">
+                <p>
                   <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
                   `aria-disabled`, and `aria-haspopup` attributes.
                 </p>

--- a/index.html
+++ b/index.html
@@ -2879,7 +2879,7 @@
             </td>
           </tr>
           <tr>
-            <th id="]" tabindex="-1">
+            <th id="el-summary" tabindex="-1">
               [^summary^]
             </th>
             <td>

--- a/index.html
+++ b/index.html
@@ -2887,8 +2887,8 @@
                 <a>No corresponding role</a>
               </p>
               <div class="note">
-                Many, but not all, user agents expose the `summary` element with an implicit ARIA <code>role=<a href="#index-aria-button">button</a></code>
-                role.
+                Many, but not all, user agents expose the `summary` element with an implicit ARIA 
+                <code>role=<a href="#index-aria-button">button</a></code>.
               </div>
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -2884,13 +2884,21 @@
               </div>
             </td>
             <td>
-              <p>
-                <a><strong class="nosupport">No `role`</strong></a>
-              </p>
-              <p class="proposed correction">
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
-                `aria-disabled`, and `aria-haspopup` attributes.
-              </p>
+              <div class="proposed correction">
+                <p>
+                  <a><strong class="nosupport">No `role`</strong></a> if the `summary` element is a 
+                  <a data-cite="html/interactive-elements.html#summary-for-its-parent-details">summary for its parent details</a>.
+                </p>
+                <p class="proposed correction">
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
+                  `aria-disabled`, and `aria-haspopup` attributes.
+                </p>
+                <p>
+                  Otherwise, authors MAY specifiy <a><strong>Any `role`</strong></a>, and any 
+                  <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
+                  and any `aria-*` attributes applicable to the allowed roles.
+                </p>
+               </div>
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -2887,9 +2887,9 @@
               <p>
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
-              <p>
+              <p class="proposed correction">
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
-                <span class="proposed correction">`aria-disabled`, and `aria-haspopup` attributes.</span>
+                `aria-disabled`, and `aria-haspopup` attributes.
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -2788,8 +2788,8 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `button` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
+                <span class="proposed correction">`aria-disabled`, and `aria-haspopup` attributes.</span>
               </p>
             </td>
           </tr>


### PR DESCRIPTION
Normative follow-on from #434

The spec was updated to note that the summary element doesnt' always map to the button element.  The allowed attributes indicated that all attributes that were applicable to the button role were allowed.  However, in practice this doesn't make sense and could break or be in contradiction to the implicit semantics.

The allowed aria-* attributes for the button role include 
* aria-disabled
* aria-haspopup
* aria-expanded
* aria-pressed

Edit: after testing, `aria-expanded` and `aria-pressed` provide zero value on a `summary` element, as they are presently ignored by user agents (browsers/AT).  https://codepen.io/scottohara/pen/ZEjZPoR

<details>
  <summary>markup and results of linked codepen</summary>
<pre><code>
&lt;details open>
	&lt;summary aria-pressed=false>test 1&lt;/summary>
	aria-pressed on summary element
&lt;/details>

&lt;details open>
	&lt;summary aria-expanded=false>test 2&lt;/summary>
	aria-expanded=false on summary element
&lt;/details>

&lt;details open>
	&lt;summary aria-haspopup=dialog>test 3&lt;/summary>
	aria-haspopup=dialog on summary element
&lt;/details>

&lt;details open>
	&lt;summary aria-disabled=true>test 4&lt;/summary>
	aria-disabled=true on summary element
&lt;/details>
</code></pre>

<pre>
test 1
JAWS/NVDA+Chromium/Gecko - attribute ignored
Narrator+Edge - attribute ignored / UIA ignores attr
iOS/macos safari/firefox+VO - ignored

test 2
JAWS/NVDA+Chromium/Gecko - attribute ignored
Narrator+Edge - attribute ignored / UIA ignores attr
iOS/macos safari/firefox+VO - ignored

test 3
JAWS/NVDA+Chromium/Gecko - announces as a button menu
Narrator+Edge - has popup
macOS VO + Safari - has popup
iOS VO + safari, macOS VO firefox - ignored

test 4
JAWS/NVDA+Chromium/Gecko - disabled state conveyed
Narrator+Edge - disabled
iOS/macOS Safari/firefox+VO - disabled
</pre>
</details>

Concerning the allowed roles for a summary element.  A summary element can be one of two things, the 'summary for its parent details' - where it acts as the triggering element for the disclosure widget.  Or, if it doesn't meet the conditions to be that (e.g., it is not a child of a details element, or it is not the first instance of a summary element - e.g., it's the 2+ summary element within a details), then it is treated as a generic element, so any role/attribute should be allowed.

<!-- Important:
  for PRs that introduce normative changes the 'needs implementation commitment' 
  and the 'needs changelog entry' labels are needed.  If this is not a PR that
  introduces normative changes, then these labels can be removed.

  For normative changes, log the necessary bugs/rule change requests to the 
  following checkers. If a checker has already implemented the rule, then
  mark it as complete and remove the todo/link.
-->

test cases - https://w3c.github.io/html-aria/tests/summary-allowances.html

- [x] HTML Validator
- [x] IBM equal access accessibility checker
- [ ] axe-core
- [x] ARC toolkit

(linked issues to each checker referenced in the following thread)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/435.html" title="Last updated on May 31, 2023, 2:30 PM UTC (f0a0495)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/435/f7ed5ff...f0a0495.html" title="Last updated on May 31, 2023, 2:30 PM UTC (f0a0495)">Diff</a>