### PR TITLE
Explicitly state requirements in 3rd column of conformance table

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
                 <a href="#index-aria-radio">`radio`</a>,
                 <a href="#index-aria-switch">`switch`</a>,
                 <a href="#index-aria-tab">`tab`</a>
-                or <a href="#index-aria-treeitem">`treeitem`</a>
+                or <a href="#index-aria-treeitem">`treeitem`</a>. (<code><a href="#index-aria-link">link</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Roles:
@@ -443,7 +443,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -496,7 +496,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-link">link</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -517,7 +517,7 @@
                 <p>
                   Roles:
                   <a href="#index-aria-button">`button`</a>
-                  or <a href="#index-aria-link">`link`</a>
+                  or <a href="#index-aria-link">`link`</a>. (<code><a href="#index-aria-generic">`generic`</a></code> is also allowed, but SHOULD NOT BE USED.)
                 </p>
                 <p><a>Naming Prohibited</a></p>
                 <p>
@@ -543,7 +543,7 @@
                 <a href="#index-aria-main">`main`</a>,
                 <a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-region">`region`</a>
+                or <a href="#index-aria-region">`region`</a>. (<code><a href="#index-aria-article">article</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -566,7 +566,7 @@
                 <a href="#index-aria-note">`note`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>,
                 <a href="#index-aria-region">`region`</a>
-                or <a href="#index-aria-search">`search`</a>
+                or <a href="#index-aria-search">`search`</a>. (<code><a href="#index-aria-complementary">complementary</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Roles:
@@ -619,7 +619,7 @@
                 <a><strong class="nosupport">no `role`</strong></a>
               </p>
               <p>
-                Otherwise, <a><strong>any `role`</strong></a>
+                Otherwise, <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition">
                 <a>Naming Prohibited</a> if exposed as the `generic` role, or if exposed
@@ -640,7 +640,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -671,7 +671,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -689,7 +689,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -707,7 +707,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-blockquote">`blockquote`</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -724,7 +724,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-generic">`generic`</a></code>, which SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -770,7 +770,7 @@
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
                 <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-tab">`tab`</a>
+                or <a href="#index-aria-tab">`tab`</a>. (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -804,7 +804,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-caption">`caption`</a></code>, which is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -839,7 +839,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-code">`code`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -883,7 +883,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -902,7 +902,10 @@
             <td>
               <div class="correction">
                 <p>
-                  <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                  <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-listbox">listbox</a></code>, which is NOT RECOMMENDED.
+                </p>
+                <p>
+                  <strong>No `aria-*` attributes</strong>.
                 </p>
               </div>
             </td>
@@ -933,7 +936,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-deletion">`deletion`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -951,7 +954,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-group">group</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -968,7 +971,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-term">term</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -986,7 +989,7 @@
             <td>
               <p>
                 Role:
-                <a href="#index-aria-alertdialog">`alertdialog`</a>
+                <a href="#index-aria-alertdialog">`alertdialog`</a>. (<code><a href="#index-aria-dialog">dialog</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1003,9 +1006,10 @@
             </td>
             <td>
               <p class="addition">
-                <a><strong>Any `role`</strong></a> unless a direct child of a [^dl^] element. 
-                Then only <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>.
+                If a direct child of a [^dl^] element,
+                only <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-none">`none`</a>. Otherwise,
+                <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -1062,7 +1066,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-emphasis">`emphasis`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -1105,7 +1109,7 @@
                 Roles:
                 <a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-radiogroup">`radiogroup`</a>
+                or <a href="#index-aria-radiogroup">`radiogroup`</a>. (<code><a href="#index-aria-group">group</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1145,12 +1149,12 @@
               <p>
                 If the `figure` has no `figcaption` descendant:
                 <br>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-figure">figure</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 If the `figure` has a `figcaption` descendant:
                 <br>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-figure">figure</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1178,7 +1182,14 @@
                 Roles:
                 <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>
+                or <a href="#index-aria-none">`none`</a>.
+                (If not a descendant of an `article`, `aside`, `main`, `nav`
+                or `section` element, or an element with `role=article`, `complementary`,
+                `main`, `navigation` or `region`,
+                then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
+                is also allowed, but NOT RECOMMENDED.
+                Otherwise, <code>role=<a href="#index-aria-generic">`generic`</a></code>
+                is also allowed, but SHOULD NOT be used.)
               </p>
               <p>
                 DPub Role:
@@ -1205,7 +1216,7 @@
                 Roles:
                 or <a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-search">`search`</a>
+                or <a href="#index-aria-search">`search`</a>. (<code><a href="#index-aria-form">form</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1247,7 +1258,7 @@
                 <a href="#index-aria-slider">`slider`</a>,
                 <a href="#index-aria-spinbutton">`spinbutton`</a>,
                 <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-textbox">`textbox`</a>
+                or <a href="#index-aria-textbox">`textbox`</a>. (<code><a href="#index-aria-generic">`generic`</a></code> is also allowed, but SHOULD NOT be used.)
               </p>
               <p class="addition">
                 <a>Naming Prohibited</a> if exposed as the `generic` role.
@@ -1271,7 +1282,7 @@
                 Roles:
                 <a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-tab">`tab`</a>
+                or <a href="#index-aria-tab">`tab`</a>. (<code><a href="#index-aria-heading">heading</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Role:
@@ -1316,7 +1327,14 @@
                 Roles:
                 <a href="#index-aria-group">`group`</a>,
                 <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-presentation">`presentation`</a>.
+                (If not a descendant of an `article`, `aside`, `main`, `nav`
+                or `section` element, or an element with `role=article`, `complementary`,
+                `main`, `navigation` or `region`,
+                then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
+                is also allowed, but NOT RECOMMENDED.
+                Otherwise, <code>role=<a href="#index-aria-generic">`generic`</a></code>
+                is also allowed, but SHOULD NOT be used.)
               </p>
               <p class="addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>
               <p>
@@ -1334,7 +1352,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -1354,7 +1372,7 @@
               <p>
                 Roles:
                 <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>
+                or <a href="#index-aria-presentation">`presentation`</a>. (<code><a href="#index-aria-separator">separator</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Role:
@@ -1375,7 +1393,10 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-document">document</a></code>, which is NOT RECOMMENDED.
+              </p>
+              <p>
+                <strong>No `aria-*` attributes</strong>.
               </p>
             </td>
           </tr>
@@ -1388,7 +1409,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -1445,7 +1466,7 @@
                 <a href="#index-aria-slider">`slider`</a>,
                 <a href="#index-aria-switch">`switch`</a>,
                 <a href="#index-aria-tab">`tab`</a> or
-                <a href="#index-aria-treeitem">`treeitem`</a>
+                <a href="#index-aria-treeitem">`treeitem`</a>. (<code><a href="#index-aria-img">img</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Role:
@@ -1466,8 +1487,11 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
-                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-presentation">presentation</a></code>, which is NOT RECOMMENDED
+              </p>
+              <p>
+                <strong>No `aria-*` attributes</strong>
+                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
               </p>
             </td>
           </tr>
@@ -1482,8 +1506,11 @@
               <p>
                 If no accessible name is provided via other 
                 <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a> (e.g., `aria-labelledby`, `aria-label`): 
-                <a><strong class="nosupport">No `role`</strong></a>, and
-                <strong>no `aria-*` attributes</strong> except `aria-hidden="true"`
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-img">img</a></code>, which is NOT RECOMMENDED.
+              </p>
+              <p>
+                <strong>No `aria-*` attributes</strong>
+                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
               </p>
               <p>
                 Otherwise, if the `img` has an author defined accessible name, 
@@ -1510,7 +1537,7 @@
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
                 <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-tab">`tab`</a>
+                or <a href="#index-aria-tab">`tab`</a>. (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1531,7 +1558,7 @@
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                 <a href="#index-aria-option">`option`</a>
                 or <a href="#index-aria-switch">`switch`</a>;
-                <a href="#index-aria-button">`button` if used with `aria-pressed`</a>
+                <a href="#index-aria-button">`button` if used with `aria-pressed`</a>. (<code><a href="#index-aria-checkbox">checkbox</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p class="correction">
                 Authors <a href="#att-checked">MUST NOT use the `aria-checked` attribute on `input type=checkbox` elements</a>.
@@ -1607,7 +1634,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1659,7 +1686,7 @@
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                 <a href="#index-aria-radio">`radio`</a>
-                or <a href="#index-aria-switch">`switch`</a>
+                or <a href="#index-aria-switch">`switch`</a>. (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1693,7 +1720,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-spinbutton">spinbutton</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1728,7 +1755,7 @@
             <td>
               <p>
                 Role:
-                <a href="#index-aria-menuitemradio">`menuitemradio`</a>
+                <a href="#index-aria-menuitemradio">`menuitemradio`</a>. (<code><a href="#index-aria-radio">radio</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p class="correction">
                 Authors <a href="#att-checked">MUST NOT use the
@@ -1754,7 +1781,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-slider">slider</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or 
@@ -1776,7 +1803,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-button">button</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1794,7 +1821,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-searchbox">searchbox</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1811,7 +1838,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-button">button</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1829,7 +1856,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1850,7 +1877,7 @@
                 Roles:
                 <a href="#index-aria-combobox">`combobox`</a>,
                 <a href="#index-aria-searchbox">`searchbox`</a>
-                or <a href="#index-aria-spinbutton">`spinbutton`</a>
+                or <a href="#index-aria-spinbutton">`spinbutton`</a>. (<code><a href="#index-aria-textbox">textbox</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1872,7 +1899,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-combobox">combobox</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 Authors SHOULD NOT use the `aria-haspopup` attribute on the indicated `input`s with a `list` attribute.
@@ -1911,7 +1938,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1945,7 +1972,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-insertion">`insertion`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2025,7 +2052,7 @@
                 <a href="#index-aria-radio">`radio`</a>,
                 <a href="#index-aria-separator">`separator`</a>,
                 <a href="#index-aria-tab">`tab`</a>
-                or <a href="#index-aria-treeitem">`treeitem`</a>
+                or <a href="#index-aria-treeitem">`treeitem`</a>. (<code><a href="#index-aria-listitem">listitem</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
               <p>
@@ -2062,7 +2089,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-main">main</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2110,7 +2137,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-math">math</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2137,7 +2164,7 @@
                 <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-tablist">`tablist`</a>,
                 <a href="#index-aria-toolbar">`toolbar`</a>
-                or <a href="#index-aria-tree">`tree`</a>
+                or <a href="#index-aria-tree">`tree`</a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2171,7 +2198,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-meter">`meter`</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or 
@@ -2197,7 +2224,7 @@
                 <a href="#index-aria-menubar">`menubar`</a>,
                 <span class="addition"><a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a></span>
-                or <a href="#index-aria-tablist">`tablist`</a>
+                or <a href="#index-aria-tablist">`tablist`</a>. (<code><a href="#index-aria-navigation">navigation</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Roles:
@@ -2263,7 +2290,7 @@
                 <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-tablist">`tablist`</a>,
                 <a href="#index-aria-toolbar">`toolbar`</a>
-                or <a href="#index-aria-tree">`tree`</a>
+                or <a href="#index-aria-tree">`tree`</a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2284,7 +2311,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-group">group</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2303,7 +2330,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-option">option</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 Authors SHOULD NOT use the `aria-selected` attribute on the `option` element.
@@ -2323,7 +2350,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-status">status</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2340,7 +2367,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-paragraph">`paragraph`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2390,7 +2417,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2408,7 +2435,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-progressbar">progressbar</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> attribute 
@@ -2430,7 +2457,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2518,7 +2545,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2576,7 +2603,10 @@
                 <a href="#index-aria-presentation">`presentation`</a>,
                 <a href="#index-aria-search">`search`</a>,
                 <a href="#index-aria-status">`status`</a>
-                or <a href="#index-aria-tabpanel">`tabpanel`</a>
+                or <a href="#index-aria-tabpanel">`tabpanel`</a>.
+                (If the [^section^] element has an
+                <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>,
+                <code>role=<a href="#index-aria-region">region</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Roles:
@@ -2625,7 +2655,7 @@
             </td>
             <td>
               <p>
-                Role: <a href="#index-aria-menu">`menu`</a>
+                Role: <a href="#index-aria-menu">`menu`</a>. (<code><a href="#index-aria-combobox">combobox</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.
@@ -2647,7 +2677,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-list">listbox</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.
@@ -2681,7 +2711,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2712,7 +2742,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2730,7 +2760,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-strong">`strong`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2761,7 +2791,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-subscript">`subscript`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2802,7 +2832,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-superscript">`superscript`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2821,7 +2851,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though `graphics-document` is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2838,7 +2868,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-table">table</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2855,7 +2885,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2885,7 +2915,7 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2902,7 +2932,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2919,7 +2949,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -2936,7 +2966,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-time">`time`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2978,9 +3008,22 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> if the ancestor `table`
-                element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any `role`</strong></a>
+                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
+                <a><strong class="nosupport">no `role`</strong></a>
+                other than the following:
+              </p>
+              <ul>
+                <li>If the ancestor `table` element is exposed as a `role=table`, then
+                <code><a href="#index-aria-cell">cell</a></code>
+                is allowed, but NOT RECOMMENDED.</li>
+                <li>If the ancestor `table` element is exposed as a `role=grid` or `treegrid`, then
+                <code><a href="#index-aria-gridcell">gridcell</a></code>
+                is allowed, but NOT RECOMMENDED.</li>
+              </ul>
+              <p>
+                Otherwise, if the ancestor `table` element is not exposed
+                as a `role=table`, `grid` or `treegrid`,
+                <a><strong>any `role`</strong></a>.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -3012,9 +3055,30 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> if the ancestor `table`
-                element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any `role`</strong></a>
+                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
+                <a><strong class="nosupport">no `role`</strong></a>
+                other than the following:
+              </p>
+              <ul>
+                <li>
+                If the ancestor `table` element is exposed as a `role=table`, then
+                <code><a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader">`rowheader`</a> and
+                <a href="#index-aria-rowheader">`cell`</a>
+                are allowed, but NOT RECOMMENDED.
+                </li>
+                <li>
+                If the ancestor `table` element is exposed as a `role=grid` or `treegrid`, then
+                <code><a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader">`rowheader`</a> or
+                <a href="#index-aria-rowheader">`gridcell`</a>
+                are allowed, but NOT RECOMMENDED.
+                </li>
+              </ul>
+              <p>
+                Otherwise, if the ancestor `table` element is not exposed
+                as a `role=table`, `grid` or `treegrid`,
+                <a><strong>any `role`</strong></a>.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -3031,9 +3095,10 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> if the ancestor `table`
-                element has `role=table`, `grid`, or `treegrid`; otherwise
-                <a><strong>any `role`</strong></a>
+                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
+                <a><strong class="nosupport">no `role`</strong></a> other than <code><a href="#index-aria-row">row</a></code>, which is NOT RECOMMENDED;
+                otherwise
+                <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-row">row</a></code> is NOT RECOMMENDED.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -3063,7 +3128,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -3091,7 +3156,7 @@
                 <a href="#index-aria-radiogroup">`radiogroup`</a>,
                 <a href="#index-aria-tablist">`tablist`</a>,
                 <a href="#index-aria-toolbar">`toolbar`</a>
-                or <a href="#index-aria-tree">`tree`</a>
+                or <a href="#index-aria-tree">`tree`</a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 


### PR DESCRIPTION
For all elements that have implicit roles, this change makes the third column of the “Rules of ARIA attribute usage by HTML element” table explicitly state which role values are not recommended or should not be used — that is, the change makes that column explicitly state, for example, “No role other than `presentation`, which is NOT RECOMMENDED”, or “Any role, though `figure` is NOT RECOMMENDED, or “`img` is also allowed, but NOT RECOMMENDED”.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 4, 2022, 8:38 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fhtml-aria%2F1ce2245fe950ca4793993b65e35e771232e4d5fb%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/html-aria%23436.)._
</details>
