### PR TITLE
Editorial: fixes accname link ref

### DIFF
--- a/index.html
+++ b/index.html
@@ -2579,7 +2579,7 @@
               <p>
                 <code>role=<a href="#index-aria-region">region</a></code> if the
                 [^section^] element has an 
-                <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a>
+                <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
               </p> 
               <p>
                 Otherwise, <a>no corresponding role</a>

--- a/index.html
+++ b/index.html
@@ -2609,7 +2609,7 @@
                 <a href="#index-aria-status">`status`</a>
                 or <a href="#index-aria-tabpanel">`tabpanel`</a>.
                 (If the [^section^] element has an
-                <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a>,
+                <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>,
                 <code>role=<a href="#index-aria-region">region</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>

--- a/index.html
+++ b/index.html
@@ -1508,7 +1508,7 @@
             </td>
             <td>
               <p>
-                If no <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a> is provided via other 
+                If no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is provided via other 
                 <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a> (e.g., `aria-labelledby`, `aria-label`): 
                 <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-img">img</a></code>, which is NOT RECOMMENDED.
               </p>

--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,7 @@
                 and any `aria-*` attributes applicable to the allowed roles.
               </p>
               <p class="note">
-                A `form` is not exposed as a landmark region unless it has been provided an <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a>.
+                A `form` is not exposed as a landmark region unless it has been provided an <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,7 @@
                 and any `aria-*` attributes applicable to the allowed roles.
               </p>
               <p class="note">
-                A `form` is not exposed as a landmark region unless it has been provided an accessible name.
+                A `form` is not exposed as a landmark region unless it has been provided an <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a>.
               </p>
             </td>
           </tr>
@@ -1508,7 +1508,7 @@
             </td>
             <td>
               <p>
-                If no accessible name is provided via other 
+                If no <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a> is provided via other 
                 <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a> (e.g., `aria-labelledby`, `aria-label`): 
                 <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-img">img</a></code>, which is NOT RECOMMENDED.
               </p>
@@ -2579,7 +2579,7 @@
               <p>
                 <code>role=<a href="#index-aria-region">region</a></code> if the
                 [^section^] element has an 
-                <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>
+                <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a>
               </p> 
               <p>
                 Otherwise, <a>no corresponding role</a>
@@ -2609,7 +2609,7 @@
                 <a href="#index-aria-status">`status`</a>
                 or <a href="#index-aria-tabpanel">`tabpanel`</a>.
                 (If the [^section^] element has an
-                <a data-cite="html-aam-1.0#dfn-accessible-name" data-link-type="dfn">accessible name</a>,
+                <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a>,
                 <code>role=<a href="#index-aria-region">region</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
@@ -3250,7 +3250,7 @@
         <ul>
           <li>[[[using-aria]]] - A practical guide for authors on how to
           add accessibility information to HTML elements using the Accessible
-          Rich Internet Applications specification (ARIA 1.1).
+          Rich Internet Applications specification.
           </li>
           <li>[[[wai-aria-practices-1.2]]] - An author's guide to
             understanding and implementing Accessible Rich Internet Applications.


### PR DESCRIPTION
closes #439 

this PR changes the definition links for accName from pointing to HTML AAM to the accName spec.

Additionally, adds a few more links to the accName spec for instances of 'accessible name' being used, but not linked.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/440.html" title="Last updated on Dec 8, 2022, 3:23 PM UTC (01f58b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/440/a0bddc9...01f58b6.html" title="Last updated on Dec 8, 2022, 3:23 PM UTC (01f58b6)">Diff</a>