### PR TITLE
Update button and input button allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -1777,6 +1777,7 @@
                   <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                   <a href="#index-aria-option">`option`</a>,
                   <a href="#index-aria-radio">`radio`</a>,
+                  <a href="#index-aria-slider">`slider`</a>,
                   <a href="#index-aria-switch">`switch`</a>,
                   <a href="#index-aria-tab">`tab`</a>
                   or <a href="#index-aria-treeitem">`treeitem`</a>. 

--- a/index.html
+++ b/index.html
@@ -833,14 +833,18 @@
                 Roles:
                 <a href="#index-aria-checkbox">`checkbox`</a>,
                 <span class="addition"><a href="#index-aria-combobox">`combobox`</a></span>,
+                <span class="proposed addition"><a href="#index-aria-gridcell">`gridcell`</a></span>,
                 <a href="#index-aria-link">`link`</a>,
                 <a href="#index-aria-menuitem">`menuitem`</a>,
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
-                <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-tab">`tab`</a>. (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
+                <span class="proposed addition"><a href="#index-aria-slider">`slider`</a></span>,
+                <a href="#index-aria-switch">`switch`</a>,
+                <a href="#index-aria-tab">`tab`</a>,
+                or <span class="proposed addition"><a href="#index-aria-treeitem">`treeitem`</a></span>.
+                (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1600,14 +1604,18 @@
                 Roles:
                 <span class="correction"><a href="#index-aria-checkbox">`checkbox`</a>,</span>
                 <span class="addition"><a href="#index-aria-combobox">`combobox`</a>,</span>
+                <span class="proposed addition"><a href="#index-aria-gridcell">`gridcell`</a>,</span>
                 <a href="#index-aria-link">`link`</a>,
                 <a href="#index-aria-menuitem">`menuitem`</a>,
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
-                <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-tab">`tab`</a>. (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
+                <span class="proposed addition"><a href="#index-aria-slider">`slider`</a>,</span>
+                <a href="#index-aria-switch">`switch`</a>,
+                <a href="#index-aria-tab">`tab`</a>,
+                or <span class="addition proposed"><a href="#index-aria-treeitem">`treeitem`</a></span>. 
+                (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -1749,19 +1757,30 @@
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
             <td>
-              <p>
-                Roles:
-                <a href="#index-aria-link">`link`</a>,
-                <a href="#index-aria-menuitem">`menuitem`</a>,
-                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
-                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                <a href="#index-aria-radio">`radio`</a>
-                or <a href="#index-aria-switch">`switch`</a>. (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
-              </p>
-              <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
-              </p>
+              <div class="proposed addition">
+                <p>
+                  The following roles are allowed, but are NOT RECOMMENDED:
+                  <a href="#index-aria-button">`button`</a>,
+                  <a href="#index-aria-checkbox">`checkbox`</a>,
+                  <a href="#index-aria-gridcell">`gridcell`</a>,
+                  <a href="#index-aria-link">`link`</a>,
+                  <a href="#index-aria-menuitem">`menuitem`</a>,
+                  <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                  <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                  <a href="#index-aria-option">`option`</a>,
+                  <a href="#index-aria-radio">`radio`</a>,
+                  <a href="#index-aria-switch">`switch`</a>,
+                  <a href="#index-aria-tab">`tab`</a>
+                  or <a href="#index-aria-treeitem">`treeitem`</a>. 
+                </p>
+                <p>
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
+                  and any `aria-*` attributes applicable to the allowed roles.
+                </p>
+                <p>
+                  If possible, authors SHOULD consider using a different HTML element which allows the specified role.
+                </p>
+              </div>
             </td>
           </tr>
           <tr>
@@ -1872,13 +1891,32 @@
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
             <td>
-              <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-button">button</a></code>, which is NOT RECOMMENDED.
-              </p>
-              <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `button` role.
-              </p>
+              <div class="proposed addition">
+                <p>
+                  The following roles are allowed, but are NOT RECOMMENDED:
+                  <a href="#index-aria-button">`button`</a>,
+                  <a href="#index-aria-checkbox">`checkbox`</a>,
+                  <a href="#index-aria-combobox">`combobox`</a>,
+                  <a href="#index-aria-gridcell">`gridcell`</a>,
+                  <a href="#index-aria-link">`link`</a>,
+                  <a href="#index-aria-menuitem">`menuitem`</a>,
+                  <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                  <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                  <a href="#index-aria-option">`option`</a>,
+                  <a href="#index-aria-radio">`radio`</a>,
+                  <a href="#index-aria-slider">`slider`</a>,
+                  <a href="#index-aria-switch">`switch`</a>,
+                  <a href="#index-aria-tab">`tab`</a>
+                  or <a href="#index-aria-treeitem">`treeitem`</a>.
+                </p>
+                <p>
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
+                  and any `aria-*` attributes applicable to the allowed roles.
+                </p>
+                <p>
+                  If possible, authors SHOULD consider using a different HTML element which allows the specified role.
+                </p>
+              </div>
             </td>
           </tr>
           <tr>
@@ -1907,13 +1945,32 @@
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
             <td>
-              <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-button">button</a></code>, which is NOT RECOMMENDED.
-              </p>
-              <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `button` role.
-              </p>
+              <div class="proposed addition">
+                <p>
+                  The following roles are allowed, but are NOT RECOMMENDED:
+                  <a href="#index-aria-button">`button`</a>,
+                  <a href="#index-aria-checkbox">`checkbox`</a>,
+                  <a href="#index-aria-combobox">`combobox`</a>,
+                  <a href="#index-aria-gridcell">`gridcell`</a>,
+                  <a href="#index-aria-link">`link`</a>,
+                  <a href="#index-aria-menuitem">`menuitem`</a>,
+                  <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                  <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                  <a href="#index-aria-option">`option`</a>,
+                  <a href="#index-aria-radio">`radio`</a>,
+                  <a href="#index-aria-slider">`slider`</a>,
+                  <a href="#index-aria-switch">`switch`</a>,
+                  <a href="#index-aria-tab">`tab`</a>
+                  or <a href="#index-aria-treeitem">`treeitem`</a>.
+                </p>
+                <p>
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
+                  and any `aria-*` attributes applicable to the allowed roles.
+                </p>
+                <p>
+                  If possible, authors SHOULD consider using a different HTML element which allows the specified role.
+                </p>
+              </div>
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -65,8 +65,13 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/469">5 July 2023 - Addition:</a>
+          Update the <a href="#el-button">`button`</a>, <a href="#el-input-button">`input type=button`</a>, <a href="#el-input-image">`input type=image`</a>
+          <a href="#el-input-reset">`input type=reset`</a>, and <a href="#el-input-submit">`input type=submit`</a> elements to align their allowed roles.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/469">29 June 2023 - Addition:</a>
-          Update the <a href="#s">`s`</a> element allowed roles to indicate use of `role=deletion` on the element would be considered redundnat.
+          Update the <a href="#el-s">`s`</a> element allowed roles to indicate use of `role=deletion` on the element would be considered redundnat.
         </li>
         <li>
           <a href="https://github.com/w3c/html-aria/pull/435">31 May 2023 - Correction:</a>
@@ -1793,7 +1798,7 @@
             <td>
               <div class="proposed addition">
                 <p>
-                  The following roles are allowed, but are NOT RECOMMENDED:
+                  Roles:
                   <a href="#index-aria-button">`button`</a>,
                   <a href="#index-aria-checkbox">`checkbox`</a>,
                   <a href="#index-aria-gridcell">`gridcell`</a>,
@@ -1811,9 +1816,6 @@
                 <p>
                   <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
                   and any `aria-*` attributes applicable to the allowed roles.
-                </p>
-                <p>
-                  If possible, authors SHOULD consider using a different HTML element which allows the specified role.
                 </p>
               </div>
             </td>

--- a/tests/input-image-reset-submit.html
+++ b/tests/input-image-reset-submit.html
@@ -66,10 +66,10 @@
 		</h3>
 		<p>
     		Authors are allowed to use the roles
-    		<code>button</code>, <code>checkbox</code>, <code>combobox</code>, <code>gridcell</code>, <code>link</code>, <code>menuitem</code>, <code>menuitemcheckbox</code>, <code>menuitemradio</code>, <code>option</code>, <code>radio</code>, <code>slider</code>, <code>switch</code>, <code>tab</code> or <code>treeitem</code> on a <code>input type=reset</code>, <code>input type=image</code> or <code>input type=submit</code> element, but their use is NOT RECOMMENDED.
+    		<code>button</code>, <code>checkbox</code>, <code>combobox</code>, <code>gridcell</code>, <code>link</code>, <code>menuitem</code>, <code>menuitemcheckbox</code>, <code>menuitemradio</code>, <code>option</code>, <code>radio</code>, <code>slider</code>, <code>switch</code>, <code>tab</code> or <code>treeitem</code> on a <code>input type=reset</code>, <code>input type=image</code> or <code>input type=submit</code> element.
     	</p>
     	<p>
-    		All allowed roles on the button element are now allowed on these elements as well. While there are far better elements to use as a base for these roles, and thus why it is 'not recommended' to specify these updated role allowances on these elements, if an author has no other choice and they end up using these elements to make an otherwise accessible custom widget, there is no reason to preclude their use as other automated and manual checks can call out potential accessibility gaps.
+    		All allowed roles on the button element are now allowed on these elements as well. While there are far better elements to use as a base for these roles, if an author has no other choice and they end up using these elements to make an otherwise accessible custom widget, there is no reason to preclude their use as other automated and manual checks can call out potential accessibility gaps.
     	</p>
 		<div class="flex">
 			<div class="widgetDemo">


### PR DESCRIPTION
closes #444
closes #395
closes #298

These PR supersedes #405

This PR makes the allowances for button-elements (button, input type=button|image|submit|reset) more consistent with each other.  Additionally, slider and gridcell are now listed under the allowed roles for these elements.

the LOE to properly create the necessary UX for some of these roles when specified, especially on the `input` type buttons, is rather large _but_ possible.  Any failures to not implement these properly would be caught by WCAG rules.  Allowing the roles won't change that.

- [ ] HTML validator
- [x] IBM equal access accessibility checker
- [ ] axe-core
- [x] ARC toolkit

(the issues for each of these checkers are referenced later in this thread)


[button and input type=button test cases](https://w3c.github.io/html-aria/tests/button-input-button.html) and 
[input type=reset, image, submit test cases](https://w3c.github.io/html-aria/tests/input-image-reset-submit.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/446.html" title="Last updated on Jul 5, 2023, 3:25 PM UTC (b492937)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/446/51dd212...b492937.html" title="Last updated on Jul 5, 2023, 3:25 PM UTC (b492937)">Diff</a>