### PR TITLE
disallow aria-hidden on body element

### DIFF
--- a/index.html
+++ b/index.html
@@ -804,8 +804,7 @@
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 <span class="addition proposal">
-                  with the exception that authors MUST NOT specify the `aria-hidden` attribute on the
-                  `body` element.
+                  with the exception that authors MUST NOT specify `aria-hidden=true` on the `body` element.
                 </span>
               </p>
             </td>

--- a/index.html
+++ b/index.html
@@ -802,7 +802,11 @@
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
+                <span class="addition proposal">
+                  with the exception that authors MUST NOT specify the `aria-hidden` attribute on the
+                  `body` element.
+                </span>
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -808,7 +808,7 @@
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 <span class="addition proposal">
-                  with the exception that authors MUST NOT specify `aria-hidden=true` on the `body` element.
+                  allowed for the `generic` role, with the exception that authors MUST NOT specify `aria-hidden=true` on the `body` element.
                 </span>
               </p>
             </td>

--- a/index.html
+++ b/index.html
@@ -64,12 +64,16 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/447">6 March 2023 - Addition:</a>
+          Disallow `aria-hidden=true` on the `body` element.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/415">13 February 2023 - Addition:</a>
-           update figure role allowances to include `doc-example`.
+           Update `figure` element role allowances to include `doc-example`.
         </li>
         <li>
           <a href="https://github.com/w3c/html-aria/pull/437">07 November 2022 - Correction:</a>
-           Revisions to 'any role' term description.
+          Revisions to 'any role' term description.
         </li>
         <li>
           <a href="https://github.com/w3c/html-aria/pull/383">14 July 2022 - Correction:</a>


### PR DESCRIPTION
related to https://github.com/w3c/aria/issues/1254

closes #221 - there were comments to do more with aria-hidden rules beyond just disallowing it on body, but i'm going to make a new issue for potentially covering those topics.

---
labels: needs implementation commitment, needs changelog entry
---

<!-- Important:
  for PRs that introduce normative changes the 'needs implementation commitment' 
  and the 'needs changelog entry' labels are needed.  If this is not a PR that
  introduces normative changes, then these labels can be removed.

  For normative changes, log the necessary bugs/rule change requests to the 
  following checkers. If a checker has already implemented the rule, then
  mark it as complete and remove the todo/link.
-->

- [x] [HTML validator](https://github.com/validator/validator/issues/1559)
- [x] [IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/1336)
- [x] axe-core already supports this rule
- [x] [ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/67)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/447.html" title="Last updated on Mar 6, 2023, 2:35 PM UTC (9b00091)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/447/0f31dbf...9b00091.html" title="Last updated on Mar 6, 2023, 2:35 PM UTC (9b00091)">Diff</a>