### PR TITLE
Clarify and consolidate img ARIA allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -1607,8 +1607,8 @@
               <p>
                 If the `img` has no `alt` attribute or accessible name:
                 <a><strong class="nosupport">No `role`</strong></a> other than the  
-                <code>role=<a href="#index-aria-img">img</a></code>, <code>role=<a href="#index-aria-none">none</a></code> or
-                <code><a href="#index-aria-presentation">presentation</a></code> roles, which are NOT RECOMMENDED.
+                <code>role=<a href="#index-aria-none">none</a></code> or <code><a href="#index-aria-presentation">presentation</a></code> roles.
+                (<code>role=<a href="#index-aria-img">img</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 If the `img` has an empty `alt=""` attribute and no `aria-label` or `aria-labelledby` attributes to provide it an accessible name:

--- a/index.html
+++ b/index.html
@@ -1603,7 +1603,7 @@
               <p>
                 If the `img` has no `alt` attribute or accessible name:
                 <a><strong class="nosupport">No `role`</strong></a> other than the  
-                <code>role=<a href="#index-aria-img">img</a></code> role which is NOT RECOMMENDED.
+                <code>role=<a href="#index-aria-img">img</a></code> role, which is NOT RECOMMENDED.
               </p>
               <p>
                 If the `img` has an empty `alt=""` attribute and no `aria-label` or `aria-labelledby` attributes to provide it an accessible name:

--- a/index.html
+++ b/index.html
@@ -1601,16 +1601,19 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other the roles 
-                <code>role=<a href="#index-aria-img">img</a></code>,
-                <code>role=<a href="#index-aria-none">none</a></code> or
-                <code><a href="#index-aria-presentation">presentation</a></code>, which are NOT RECOMMENDED.
+                If the `img` has no `alt` attribute or accessible name:
+                <a><strong class="nosupport">No `role`</strong></a> other than the  
+                <code>role=<a href="#index-aria-img">img</a></code> role which is NOT RECOMMENDED.
+              </p>
+              <p>
+                If the `img` has an empty `alt=""` attribute and no `aria-label` or `aria-labelledby` attributes to provide it an accessible name:
+                <a><strong class="nosupport">No `role`</strong></a> other than the <code>role=<a href="#index-aria-none">none</a></code> or
+                <code><a href="#index-aria-presentation">presentation</a></code> roles, which are NOT RECOMMENDED.
               </p>
               <p>
                 <strong>No `aria-*` attributes</strong>
                 except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
               </p>
-
               <p>
                 Otherwise, if the `img` has an author defined accessible name, 
                 see <a href="#el-img">`img` with an accessible name</a>.

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/453">3 October 2023 - Correction:</a>
+          Update the <a href="#el-img">`img`</a> element allowances to be based on whether the element is named, or not.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/462">21 August 2023 - Addition:</a>
           Update the <a href="#el-address">`address`</a> and <a href="#el-hgroup">`hgroup`</a> element allowances per their updated mapping to the `group` role.
         </li>

--- a/index.html
+++ b/index.html
@@ -1558,6 +1558,9 @@
                 <a href="#index-aria-menuitem">`menuitem`</a>,
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
+                <span class="addition">
+                  <a href="#index-aria-meter">`meter`</a>,
+                </span>
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-progressbar">`progressbar`</a>,
                 <span class="correction">

--- a/index.html
+++ b/index.html
@@ -1600,10 +1600,12 @@
               </div>
             </td>
             <td>
+              <div class="correction proposed">
               <p>
                 If the `img` has no `alt` attribute or accessible name:
                 <a><strong class="nosupport">No `role`</strong></a> other than the  
-                <code>role=<a href="#index-aria-img">img</a></code> role, which is NOT RECOMMENDED.
+                <code>role=<a href="#index-aria-img">img</a></code>, <code>role=<a href="#index-aria-none">none</a></code> or
+                <code><a href="#index-aria-presentation">presentation</a></code> roles, which are NOT RECOMMENDED.
               </p>
               <p>
                 If the `img` has an empty `alt=""` attribute and no `aria-label` or `aria-labelledby` attributes to provide it an accessible name:
@@ -1618,6 +1620,7 @@
                 Otherwise, if the `img` has an author defined accessible name, 
                 see <a href="#el-img">`img` with an accessible name</a>.
               </p>
+              </div>
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1527,7 +1527,10 @@
           </tr>
           <tr>
             <th id="el-img" tabindex="-1">
-              [^img^] with [^img/alt^]`="some text"`
+              <div class="correction proposed">
+                [^img^] with an accessible name. E.g., [^img/alt^]`="some text"` or as provided by other 
+                <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>
+              </div>
             </th>
             <td>
               <code>role=<a href="#index-aria-img">img</a></code>
@@ -1564,42 +1567,39 @@
             </td>
           </tr>
           <tr>
-            <th id="el-img-empty-alt" tabindex="-1">
-              [^img^] with [^img/alt^]`=""`
+            <th id="el-img-no-name" tabindex="-1">
+              [^img^] with no accessible name.
             </th>
             <td>
-              <code>role=<a href="#index-aria-presentation">presentation</a></code>
+              <div class="proposed correction">
+                <p id="el-img-empty-alt">
+                  If the `img` has an empty `alt` ([^img/alt^]`=""`) and lacks any other 
+                  <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>:<br>
+                  <code>role=<a href="#index-aria-none">none</a></code>, 
+                  <code>role=<a href="#index-aria-presentation">presentation</a></code>
+                </p>
+                <p id="el-img-no-alt" tabindex="-1">
+                  If the `img` <a data-cite="html/images.html#unknown-images">lacks an `alt` attribute</a> and lacks any other 
+                  <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>:<br>
+                  <code>role=<a href="#index-aria-img">img</a></code>
+                </p>
+              </div>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-presentation">presentation</a></code>, which is NOT RECOMMENDED
+                <a><strong class="nosupport">No `role`</strong></a> other the roles 
+                <code>role=<a href="#index-aria-img">img</a></code>,
+                <code>role=<a href="#index-aria-none">none</a></code> or
+                <code><a href="#index-aria-presentation">presentation</a></code>, which are NOT RECOMMENDED.
               </p>
               <p>
                 <strong>No `aria-*` attributes</strong>
                 except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
               </p>
-            </td>
-          </tr>
-          <tr>
-            <th id="el-img-no-alt" tabindex="-1">
-              [^img^] <a data-cite="html/images.html#unknown-images">without an `alt` attribute</a>
-            </th>
-            <td>
-              <code>role=<a href="#index-aria-img">img</a></code>
-            </td>
-            <td>
-              <p>
-                If no <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a> is provided via other 
-                <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a> (e.g., `aria-labelledby`, `aria-label`): 
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-img">img</a></code>, which is NOT RECOMMENDED.
-              </p>
-              <p>
-                <strong>No `aria-*` attributes</strong>
-                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
-              </p>
+
               <p>
                 Otherwise, if the `img` has an author defined accessible name, 
-                see <a href="#el-img">`img` with `alt="some text"`</a>.
+                see <a href="#el-img">`img` with an accessible name</a>.
               </p>
             </td>
           </tr>


### PR DESCRIPTION
This PR closes #424 and #452

This update serves to both clarify that an image with a name, regardless of how that name is provided, should allow the specified roles.

Additionally, it consolidates the expectations for an image with an empty alt, or a missing alt so long as they also have no accessible name.

Using the implicit role of the image, for all instances, has already been marked as not recommended, so errors should not be exposed for that, but rather warnings, if the conformance checker exposes non-error messages.

[Test cases for the passing examples](https://w3c.github.io/html-aria/tests/img-allowed-roles.html)


- [x] [HTML validator](https://github.com/validator/validator/issues/1599)
- [ ] [IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/1704)
- [x] [axe-core PR filed to allow meter element](https://github.com/dequelabs/axe-core/pull/4055) (otherwise these changes are already implemented in axe-core
- [x] [ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/70)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/453.html" title="Last updated on Sep 5, 2023, 12:28 PM UTC (b52cd36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/453/70e3d30...b52cd36.html" title="Last updated on Sep 5, 2023, 12:28 PM UTC (b52cd36)">Diff</a>