### PR TITLE
Update: naming prohibited changes for hgroup, address, rp

### DIFF
--- a/index.html
+++ b/index.html
@@ -560,9 +560,8 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-group">`group`</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -1441,9 +1440,8 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-group">`group`</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
@@ -2566,6 +2564,7 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
+              <p class="addition"><a>Naming Prohibited</a></p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.

--- a/index.html
+++ b/index.html
@@ -569,7 +569,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-group">`group`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <a href="#index-aria-group">`group`</a> SHOULD NOT be used.
               </p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
@@ -1449,7 +1449,7 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-group">`group`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <a href="#index-aria-group">`group`</a> SHOULD NOT be used.
               </p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/462">21 August 2023 - Addition:</a>
+          Update the <a href="#el-address">`address`</a> and <a href="#el-hgroup">`hgroup`</a> element allowances per their updated mapping to the `group` role.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/455">9 July 2023 - Addition:</a>
           Update the <a href="#el-aside">`aside`</a> element to allow the dpub `doc-glossary` role.
         </li>


### PR DESCRIPTION
hgroup, and address have each been mapped to the group role, and thus no longer prohibit naming.

rp is not an element that _should_ be exposed to users, and even when it is - if ruby content is not supported - then it really should not be given a name then, either.

Closes #462.  Closes #461.


- [x] [HTML validator](https://github.com/validator/validator/issues/1626)
- [x] [IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/1593) (address is good to go, issue about hgroup)
- [x] axe core did not flag these elements for their use of aria-label or aria-labelledby. 
- [x] [ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/pull/74)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/463.html" title="Last updated on Aug 21, 2023, 3:22 PM UTC (ec5f91b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/463/9c74a5d...ec5f91b.html" title="Last updated on Aug 21, 2023, 3:22 PM UTC (ec5f91b)">Diff</a>