### PR TITLE
Clarification: list additional aria attributes for file and color inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1675,7 +1675,7 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> and `aria-disabled` attribute.
               </p>
             </td>
           </tr>
@@ -1743,7 +1743,8 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
+                `aria-disabled`, `aria-invalid` and `aria-required` attributes.
               </p>
             </td>
           </tr>


### PR DESCRIPTION
closes #457

`input type=file` can allow for the aria-required, invalid and disabled attributes.  These attributes are already supported by checkers.

Additionally, `input type=color` also allows for the `aria-disabled` attribute.  Note HTML does not allow the required attribute for this element, so aria-required and invalid wouldn't be applicable here.

The HTML Validator, IBM equal access, and axe core all support these attributes now.  So this is safe to merge without need for implementation issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/464.html" title="Last updated on May 11, 2023, 2:46 PM UTC (5463e1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/464/591be7c...5463e1f.html" title="Last updated on May 11, 2023, 2:46 PM UTC (5463e1f)">Diff</a>