### PR TITLE
update s element mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -2630,11 +2630,11 @@
               [^s^]
             </th>
             <td>
-              <a>No corresponding role</a>
+              <code>role=<a href="#index-aria-deletion">`deletion`</a></code>
             </td>
             <td>
-              <p>
-                <a><strong>Any `role`</strong></a>
+              <p class="proposed addition">
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-deletion">`deletion`</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/469">29 June 2023 - Addition:</a>
+          Update the <a href="#s">`s`</a> element allowed roles to indicate use of `role=deletion` on the element would be considered redundnat.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/435">31 May 2023 - Correction:</a>
           Conditionally revise allowed `aria-*` attributes and roles on <a href="#el-summary">`summary`</a> element.
         </li>


### PR DESCRIPTION
the s element was remapped from generic to role=deletion in html aam. 

the only potential change here for conformance checkers is to signal a warning that use of the deletion role on the s element is unnecessary.

this pr will close #466

Issues filed:

- [ ] [IBM equal access checker](https://github.com/IBMa/equal-access/issues/1518)
- [x] [HTML validator](https://github.com/validator/validator/issues/1604)
- [x] [ARC Toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/71)
- [x] axe-core does not warn about redundant roles, so no issue to file


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/469.html" title="Last updated on Jun 29, 2023, 7:22 PM UTC (9589793)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/469/966b175...9589793.html" title="Last updated on Jun 29, 2023, 7:22 PM UTC (9589793)">Diff</a>