### PR TITLE
Update unnamed section mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,11 +531,11 @@
               [^a^] without [^a/href^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -602,14 +602,14 @@
               [^area^] without [^area/href^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <div class="addition">
                 <p>
                   Roles:
                   <a href="#index-aria-button">`button`</a>
-                  or <a href="#index-aria-link">`link`</a>. (<code><a href="#index-aria-generic">`generic`</a></code> is also allowed, but SHOULD NOT BE USED.)
+                  or <a href="#index-aria-link">`link`</a>. (<code><a href="#index-aria-generic">generic</a></code> is also allowed, but SHOULD NOT BE USED.)
                 </p>
                 <p><a>Naming Prohibited</a></p>
                 <p>
@@ -702,7 +702,7 @@
                 Role exposed from author defined {{ElementInternals}}
               </p>
               <p>
-                Otherwise <code>role=<a href="#index-aria-generic">`generic`</a></code>
+                Otherwise <code>role=<a href="#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
@@ -711,7 +711,7 @@
                 <a><strong class="nosupport">no `role`</strong></a>
               </p>
               <p>
-                Otherwise, <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                Otherwise, <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition">
                 <a>Naming Prohibited</a> if exposed as the `generic` role, or if exposed
@@ -728,11 +728,11 @@
               [^b^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -759,11 +759,11 @@
               [^bdi^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -777,11 +777,11 @@
               [^bdo^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -812,11 +812,11 @@
               [^body^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-generic">`generic`</a></code>, which SHOULD NOT be used.
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-generic">generic</a></code>, which SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -974,11 +974,11 @@
               [^data^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -1097,14 +1097,14 @@
               [^div^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p class="addition">
                 If a direct child of a [^dl^] element,
                 only <a href="#index-aria-presentation">`presentation`</a>
                 or <a href="#index-aria-none">`none`</a>. Otherwise,
-                <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -1273,7 +1273,7 @@
                 then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
               </p>
               <p>
-                Otherwise, <code>role=<a href="#index-aria-generic">`generic`</a></code>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
@@ -1287,7 +1287,7 @@
                 `main`, `navigation` or `region`,
                 then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
                 is also allowed, but NOT RECOMMENDED.
-                Otherwise, <code>role=<a href="#index-aria-generic">`generic`</a></code>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
                 is also allowed, but SHOULD NOT be used.)
               </p>
               <p>
@@ -1335,7 +1335,7 @@
                 Role exposed from author defined {{ElementInternals}}
               </p>
               <p>
-                Otherwise <code>role=<a href="#index-aria-generic">`generic`</a></code>
+                Otherwise <code>role=<a href="#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
@@ -1357,7 +1357,7 @@
                 <a href="#index-aria-slider">`slider`</a>,
                 <a href="#index-aria-spinbutton">`spinbutton`</a>,
                 <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-textbox">`textbox`</a>. (<code><a href="#index-aria-generic">`generic`</a></code> is also allowed, but SHOULD NOT be used.)
+                or <a href="#index-aria-textbox">`textbox`</a>. (<code><a href="#index-aria-generic">generic</a></code> is also allowed, but SHOULD NOT be used.)
               </p>
               <p class="addition">
                 <a>Naming Prohibited</a> if exposed as the `generic` role.
@@ -1418,7 +1418,7 @@
                 <code>role=<a href="#index-aria-banner">banner</a></code>
               </p>
               <p>
-                Otherwise, <code>role=<a href="#index-aria-generic">`generic`</a></code>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
@@ -1432,7 +1432,7 @@
                 `main`, `navigation` or `region`,
                 then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
                 is also allowed, but NOT RECOMMENDED.
-                Otherwise, <code>role=<a href="#index-aria-generic">`generic`</a></code>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
                 is also allowed, but SHOULD NOT be used.)
               </p>
               <p class="addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>
@@ -1447,11 +1447,11 @@
               [^hgroup^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -1504,11 +1504,11 @@
               [^i^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2521,11 +2521,11 @@
               [^pre^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2561,11 +2561,11 @@
               [^q^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2649,11 +2649,11 @@
               [^samp^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2713,7 +2713,7 @@
                 <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
               </p> 
               <p>
-                Otherwise, <a>no corresponding role</a>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
@@ -2739,9 +2739,8 @@
                 <a href="#index-aria-search">`search`</a>,
                 <a href="#index-aria-status">`status`</a>
                 or <a href="#index-aria-tabpanel">`tabpanel`</a>.
-                (If the [^section^] element has an
-                <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>,
-                <code>role=<a href="#index-aria-region">region</a></code> is also allowed, but NOT RECOMMENDED.)
+                (<code>role=<a href="#index-aria-region">region</a></code> is also allowed, 
+                but NOT RECOMMENDED. <code>role=<a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.)
               </p>
               <p>
                 DPub Roles:
@@ -2842,11 +2841,11 @@
               [^small^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2873,11 +2872,11 @@
               [^span^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -2971,11 +2970,11 @@
               [^sup^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-superscript">`superscript`</a></code>
+              <code>role=<a href="#index-aria-superscript">superscript</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-superscript">`superscript`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-superscript">superscript</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -3105,11 +3104,11 @@
               [^time^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-time">`time`</a></code>
+              <code>role=<a href="#index-aria-time">time</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-time">`time`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-time">time</a></code> is NOT RECOMMENDED.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -3267,11 +3266,11 @@
               [^u^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-generic">`generic`</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">`generic`</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p class="addition"><a>Naming Prohibited</a></p>
               <p>
@@ -3467,12 +3466,15 @@
           Requirements for use of ARIA attributes in place of equivalent HTML attributes
         </h3>
         <p>
-          Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would be expected. For example, authors MAY specify `aria-disabled=true` on a [^button^] element, while also implementing the necessary scripting to functionally disable the `button`, rather than the use `disabled` attribute.
+          Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would 
+          be expected. For example, authors MAY specify `aria-disabled=true` on a [^button^] element, while also implementing the necessary scripting to functionally 
+          disable the `button`, rather than the use `disabled` attribute.
         </p>
         <p>
-          As stated in
-          <a data-cite="wai-aria-1.2#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
-          when HTML elements use <em>both</em> `aria-*` attributes and their host language (HTML) equivalents, user agents MUST ignore the WAI-ARIA attributes – the native HTML attributes with the same <a>implicit ARIA semantics</a> take precedence. For this reason, authors SHOULD NOT specify both the native HTML attribute and the equivalent `aria-*` attribute on an element. Please review each attribute for any further author specific requirements.
+          As stated in <a data-cite="wai-aria-1.2#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
+          when HTML elements use <em>both</em> `aria-*` attributes and their host language (HTML) equivalents, user agents MUST ignore the WAI-ARIA attributes – the 
+          native HTML attributes with the same <a>implicit ARIA semantics</a> take precedence. For this reason, authors SHOULD NOT specify both the native HTML attribute 
+          and the equivalent `aria-*` attribute on an element. Please review each attribute for any further author specific requirements.
         </p>
         <p>
           The following table represents HTML elements and their attributes which have `aria-*` attribute parity.


### PR DESCRIPTION
closes #474

changes ref of section element without name from 'no corresponding role' to `role=generic`.

other changes made in this PR:
- remove duplicate instances of code elements from ARIA roles (mostly instances of role=generic).
- clarification for section element allowed roles - role=region not recommended in general, not just if the element is named since using the role w/out naming would be useless.  mention authors SHOULD NOT use role=generic on the element, per the change from no corresponding role.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/475.html" title="Last updated on Jun 26, 2023, 1:09 PM UTC (f948181)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/475/a0033ad...f948181.html" title="Last updated on Jun 26, 2023, 1:09 PM UTC (f948181)">Diff</a>