### PR TITLE
docs: remove superfluous/confusing comma

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,7 +323,7 @@
           as a `role=list`. However, some user agents suppress a list's
           implicit ARIA semantics if list markers are removed. Authors can
           use `role=list` to reinstate the role if necessary, though this
-          practice would generally not be recommended, otherwise.
+          practice would generally not be recommended otherwise.
         </p>
         <pre class="HTML example" title="Redundant role on list">
           &lt;!-- Generally avoid doing this! -->


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/j9t/html-aria/pull/478.html" title="Last updated on Jul 10, 2023, 2:01 PM UTC (95ee930)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/478/cd75f5e...j9t:95ee930.html" title="Last updated on Jul 10, 2023, 2:01 PM UTC (95ee930)">Diff</a>