### PR TITLE
docs: remove superfluous/confusing semicolon

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@
         </p>
         <pre class="HTML example" title="Do not specify elements as generic">
           &lt;!-- Avoid doing this! -->
-          &lt;article role="generic" ...>...&lt;/article>;
+          &lt;article role="generic" ...>...&lt;/article>
         </pre>
         <p>
           Additionally, ARIA specifically mentions in <a data-cite="wai-aria-1.2/#host_general_conflict">Conflicts with Host Language Semantics</a> 


### PR DESCRIPTION
(Apologies for the freestyle approach—spotted these issues, just working through notes, this should be it for immediate suggestions, if these are light enough to be considered for PRs.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/j9t/html-aria/pull/479.html" title="Last updated on Jul 10, 2023, 2:05 PM UTC (6e12b3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/479/cd75f5e...j9t:6e12b3d.html" title="Last updated on Jul 10, 2023, 2:05 PM UTC (6e12b3d)">Diff</a>