### PR TITLE
Editorial: revise redundant role declaration example

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,12 +318,11 @@
           &lt;main role="Main">...&lt;/main>
         </pre>
         <p>
-          The following uses a `role=list` on an [^ul^] element. This is
-          generally unnecessary, because the `ul` element is implicitly exposed
-          as a `role=list`. However, some user agents suppress a list's
-          implicit ARIA semantics if list markers are removed. Authors can
-          use `role=list` to reinstate the role if necessary, though this
-          practice would generally not be recommended, otherwise.
+          The following uses a `role=list` on an [^ul^] element. As the `ul` element has an implicit role of `list`, 
+          explicitly adding the role would generally be considered redundant. However, some user agents suppress a list's
+          implicit ARIA semantics if the list markers are removed from the visual presentation of the list items. 
+          Generally the redundant declaration of an element's implicit role would not be recommended, but in specific situations
+          such as this, and where the role is necessary to expose, authors can explicitly add the role.
         </p>
         <pre class="HTML example" title="Redundant role on list">
           &lt;!-- Generally avoid doing this! -->

--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@
         </p>
         <pre class="HTML example" title="Do not specify elements as generic">
           &lt;!-- Avoid doing this! -->
-          &lt;article role="generic" ...>...&lt;/article>;
+          &lt;article role="generic" ...>...&lt;/article>
         </pre>
         <p>
           Additionally, ARIA specifically mentions in <a data-cite="wai-aria-1.2/#host_general_conflict">Conflicts with Host Language Semantics</a> 


### PR DESCRIPTION
closes #478

also removes errant instance of `;` in a code example, closing #479


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/482.html" title="Last updated on Jul 12, 2023, 1:52 PM UTC (76280bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/482/60534de...76280bb.html" title="Last updated on Jul 12, 2023, 1:52 PM UTC (76280bb)">Diff</a>