### PR TITLE
Fix links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1609,7 +1609,7 @@
               </p>
               <p>
                 <strong>No `aria-*` attributes</strong>
-                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
+                except <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden="true"`</a>.
               </p>
             </td>
           </tr>
@@ -1628,7 +1628,7 @@
               </p>
               <p>
                 <strong>No `aria-*` attributes</strong>
-                except <a data-cite="wai-aria-1.1#aria-hidden">`aria-hidden="true"`</a>.
+                except <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden="true"`</a>.
               </p>
               <p>
                 Otherwise, if the `img` has an author defined accessible name, 


### PR DESCRIPTION
Some aria-hidden links refer to WAI-ARIA 1.1, not 1.2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/momdo/html-aria/pull/487.html" title="Last updated on Aug 27, 2023, 5:39 PM UTC (8898f6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/487/97a750f...momdo:8898f6d.html" title="Last updated on Aug 27, 2023, 5:39 PM UTC (8898f6d)">Diff</a>