### PR TITLE
Addition: allow role=separator on button elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -881,7 +881,9 @@
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
-                <span class="proposed addition"><a href="#index-aria-slider">`slider`</a></span>,
+                <span class="proposed addition">
+                  <a href="#index-aria-separator">`separator`</a>,
+                  <a href="#index-aria-slider">`slider`</a></span>,
                 <a href="#index-aria-switch">`switch`</a>,
                 <a href="#index-aria-tab">`tab`</a>,
                 or <span class="proposed addition"><a href="#index-aria-treeitem">`treeitem`</a></span>.
@@ -1655,7 +1657,9 @@
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                 <a href="#index-aria-option">`option`</a>,
                 <a href="#index-aria-radio">`radio`</a>,
-                <span class="proposed addition"><a href="#index-aria-slider">`slider`</a>,</span>
+                <span class="proposed addition">
+                  <a href="#index-aria-separator">`separator`</a>,
+                  <a href="#index-aria-slider">`slider`</a>,</span>
                 <a href="#index-aria-switch">`switch`</a>,
                 <a href="#index-aria-tab">`tab`</a>,
                 or <span class="addition proposed"><a href="#index-aria-treeitem">`treeitem`</a></span>. 
@@ -1814,6 +1818,7 @@
                   <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                   <a href="#index-aria-option">`option`</a>,
                   <a href="#index-aria-radio">`radio`</a>,
+                  <a href="#index-aria-separator">`separator`</a>,
                   <a href="#index-aria-slider">`slider`</a>,
                   <a href="#index-aria-switch">`switch`</a>,
                   <a href="#index-aria-tab">`tab`</a>
@@ -1947,6 +1952,7 @@
                   <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                   <a href="#index-aria-option">`option`</a>,
                   <a href="#index-aria-radio">`radio`</a>,
+                  <a href="#index-aria-separator">`separator`</a>,
                   <a href="#index-aria-slider">`slider`</a>,
                   <a href="#index-aria-switch">`switch`</a>,
                   <a href="#index-aria-tab">`tab`</a>
@@ -2001,6 +2007,7 @@
                   <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
                   <a href="#index-aria-option">`option`</a>,
                   <a href="#index-aria-radio">`radio`</a>,
+                  <a href="#index-aria-separator">`separator`</a>,
                   <a href="#index-aria-slider">`slider`</a>,
                   <a href="#index-aria-switch">`switch`</a>,
                   <a href="#index-aria-tab">`tab`</a>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/489">4 October 2023 - Addition:</a>
+          Update the button element and input type=button,image,reset,submit elements to allow the `separator` role.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/462">21 August 2023 - Addition:</a>
           Update the <a href="#el-address">`address`</a> and <a href="#el-hgroup">`hgroup`</a> element allowances per their updated mapping to the `group` role.
         </li>


### PR DESCRIPTION
closes #488 

allows role=separator on elements exposed as a button.  

any other author requirements for appropriately setting that up / ensuring the correct information is communicated would still need to be evaluated, but separate from whether the role is allowed or not.

---
labels: needs implementation commitment, needs changelog entry
---


- [x] [HTML validator](https://github.com/validator/validator/issues/1646)
- [x] [IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/1707)
- [x] [axe-core](https://github.com/dequelabs/axe-core/issues/4142) - intends to implement upon merge
- [x] [ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/pull/75) (PR created)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/489.html" title="Last updated on Oct 4, 2023, 5:37 PM UTC (135ffd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/489/fad9632...135ffd0.html" title="Last updated on Oct 4, 2023, 5:37 PM UTC (135ffd0)">Diff</a>