### PR TITLE
Editorial: element ordering correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -3132,6 +3132,49 @@
             </td>
           </tr>
           <tr>
+            <th id="el-td" tabindex="-1">
+              [^td^]
+            </th>
+            <td>
+              <p>
+                <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
+                `table` element is exposed as a `role=table`
+              </p>
+              <p>
+                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
+                `table` element is exposed as a `role=grid` or `treegrid`
+              </p>
+              <p>
+                <a>No corresponding role</a> if the ancestor `table` element is not exposed
+                as a `role=table`, `grid` or `treegrid`
+              </p>
+            </td>
+            <td>
+              <p>
+                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
+                <a><strong class="nosupport">no `role`</strong></a>
+                other than the following:
+              </p>
+              <ul>
+                <li>If the ancestor `table` element is exposed as a `role=table`, then
+                <code><a href="#index-aria-cell">cell</a></code>
+                is allowed, but NOT RECOMMENDED.</li>
+                <li>If the ancestor `table` element is exposed as a `role=grid` or `treegrid`, then
+                <code><a href="#index-aria-gridcell">gridcell</a></code>
+                is allowed, but NOT RECOMMENDED.</li>
+              </ul>
+              <p>
+                Otherwise, if the ancestor `table` element is not exposed
+                as a `role=table`, `grid` or `treegrid`,
+                <a><strong>any `role`</strong></a>.
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
             <th id="el-template" tabindex="-1">
               [^template^]
             </th>
@@ -3171,97 +3214,6 @@
             <td>
               <p>
                 <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
-              </p>
-              <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <th id="el-thead" tabindex="-1">
-              [^thead^]
-            </th>
-            <td>
-              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
-            </td>
-            <td>
-              <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
-              </p>
-              <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <th id="el-time" tabindex="-1">
-              [^time^]
-            </th>
-            <td>
-              <code>role=<a href="#index-aria-time">time</a></code>
-            </td>
-            <td>
-              <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-time">time</a></code> is NOT RECOMMENDED.
-              </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
-              <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <th id="el-title" tabindex="-1">
-              [^title^]
-            </th>
-            <td>
-              <a>No corresponding role</a>
-            </td>
-            <td>
-              <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <th id="el-td" tabindex="-1">
-              [^td^]
-            </th>
-            <td>
-              <p>
-                <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
-                `table` element is exposed as a `role=table`
-              </p>
-              <p>
-                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
-                `table` element is exposed as a `role=grid` or `treegrid`
-              </p>
-              <p>
-                <a>No corresponding role</a> if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`
-              </p>
-            </td>
-            <td>
-              <p>
-                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
-                <a><strong class="nosupport">no `role`</strong></a>
-                other than the following:
-              </p>
-              <ul>
-                <li>If the ancestor `table` element is exposed as a `role=table`, then
-                <code><a href="#index-aria-cell">cell</a></code>
-                is allowed, but NOT RECOMMENDED.</li>
-                <li>If the ancestor `table` element is exposed as a `role=grid` or `treegrid`, then
-                <code><a href="#index-aria-gridcell">gridcell</a></code>
-                is allowed, but NOT RECOMMENDED.</li>
-              </ul>
-              <p>
-                Otherwise, if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`,
-                <a><strong>any `role`</strong></a>.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -3321,6 +3273,54 @@
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-thead" tabindex="-1">
+              [^thead^]
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
+              </p>
+              <p>
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-time" tabindex="-1">
+              [^time^]
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-time">time</a></code>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-time">time</a></code> is NOT RECOMMENDED.
+              </p>
+              <p class="addition"><a>Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
+                and any `aria-*` attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-title" tabindex="-1">
+              [^title^]
+            </th>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
               </p>
             </td>
           </tr>


### PR DESCRIPTION
moves td and th elements into the correct alphabetical order in the elements table.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/493.html" title="Last updated on Nov 3, 2023, 12:42 PM UTC (2fe95fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/493/9e49525...2fe95fc.html" title="Last updated on Nov 3, 2023, 12:42 PM UTC (2fe95fc)">Diff</a>