### PR TITLE
Editorial: fix incorrect link

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
           Update the <a href="#el-aside">`aside`</a> element to allow the dpub `doc-glossary` role.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/469">5 July 2023 - Addition:</a>
+          <a href="https://github.com/w3c/html-aria/pull/446">5 July 2023 - Addition:</a>
           Update the <a href="#el-button">`button`</a>, <a href="#el-input-button">`input type=button`</a>, <a href="#el-input-image">`input type=image`</a>
           <a href="#el-input-reset">`input type=reset`</a>, and <a href="#el-input-submit">`input type=submit`</a> elements to align their allowed roles.
         </li>


### PR DESCRIPTION
fixes incorrect link in changelog to reference the correct github pr


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/494.html" title="Last updated on Nov 8, 2023, 9:11 PM UTC (18e6a26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/494/8a26988...18e6a26.html" title="Last updated on Nov 8, 2023, 9:11 PM UTC (18e6a26)">Diff</a>