### PR TITLE
Editorial - Improve understandability of "Figure" in "Rules of ARIA attribute usage by HTML element" table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1275,7 +1275,8 @@
                 If the `figure` has no `figcaption` descendant:
                 <br>
                 <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-figure">figure</a></code> is NOT RECOMMENDED.
-              </p>              
+              </p>       
+              <p>
                 If the `figure` has a `figcaption` descendant:
                 <br>
                 <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-figure">figure</a></code>, which is NOT RECOMMENDED. 

--- a/index.html
+++ b/index.html
@@ -1275,15 +1275,12 @@
                 If the `figure` has no `figcaption` descendant:
                 <br>
                 <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-figure">figure</a></code> is NOT RECOMMENDED.
-              </p>
-              <p class="addition proposed">
+              </p>              
                 If the `figure` has a `figcaption` descendant:
                 <br>
-
-                DPub Role:
-                <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>.</p>
-
-                <p>Otherwise, <code><a href="#index-aria-figure">figure</a></code> is allowed, but NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-figure">figure</a></code>, which is NOT RECOMMENDED. 
+                <br>
+                <span class="addition proposed">DPub Role: if the `figure` has a `figcaption` descendant <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>.</span>
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 

--- a/index.html
+++ b/index.html
@@ -1279,8 +1279,9 @@
                 If the `figure` has a `figcaption` descendant:
                 <br>
                 <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-figure">figure</a></code>, which is NOT RECOMMENDED. 
-                <br>
-                <span class="addition proposed">DPub Role: if the `figure` has a `figcaption` descendant <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>.</span>
+              </p>
+              <p class="addition proposed">
+                DPub Role: if the `figure` has a `figcaption` descendant <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 


### PR DESCRIPTION
Closes #497 by rewording the "Figure" row in "Rules of ARIA attribute usage by HTML element" table:
- edited if-if-else condition (where else was never applicable)
- re-organized content for a better readability and understandability
- added consistency with other instances of "no rule other than ***, which is not recommended".

---
labels: editorial
---


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/html-aria/pull/498.html" title="Last updated on Mar 26, 2025, 2:12 PM UTC (744469b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/498/1cf4fc1...giacomo-petri:744469b.html" title="Last updated on Mar 26, 2025, 2:12 PM UTC (744469b)">Diff</a>