### PR TITLE
Editorial - Removed "or" at the beginning of the list of allowed roles for "form" element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1343,7 +1343,7 @@
             <td>
               <p>
                 Roles:
-                or <a href="#index-aria-none">`none`</a>,
+                <a href="#index-aria-none">`none`</a>,
                 <a href="#index-aria-presentation">`presentation`</a>
                 or <a href="#index-aria-search">`search`</a>. (<code><a href="#index-aria-form">form</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>


### PR DESCRIPTION
- Closes: #499 by removing "or" from the beginning of the sentence.
- URL: https://www.w3.org/TR/html-aria/#el-form
- Issue description:
    In "Rules of ARIA attribute usage by HTML element" table, the "form" allowed explicit roles cell starts with an "or":

    > Roles: or [none](https://www.w3.org/TR/html-aria/#index-aria-none), [presentation](https://www.w3.org/TR/html-aria/#index-aria-presentation) or [search](https://www.w3.org/TR/html-aria/#index-aria-search). ([form](https://www.w3.org/TR/html-aria/#index-aria-form) is also allowed, but NOT RECOMMENDED.)

---
labels: editorial (I cannot set it).
---


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/html-aria/pull/500.html" title="Last updated on Feb 16, 2024, 1:18 PM UTC (3040a83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/500/afb0c65...giacomo-petri:3040a83.html" title="Last updated on Feb 16, 2024, 1:18 PM UTC (3040a83)">Diff</a>