### PR TITLE
Replaced "role=contentinfo" with "role=banner" in "Rules of ARIA attribute usage by HTML element" table (header element)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1460,7 +1460,7 @@
                 (If not a descendant of an `article`, `aside`, `main`, `nav`
                 or `section` element, or an element with `role=article`, `complementary`,
                 `main`, `navigation` or `region`,
-                then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
+                then <code>role=<a href="#index-aria-contentinfo">banner</a></code>
                 is also allowed, but NOT RECOMMENDED.
                 Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
                 is also allowed, but SHOULD NOT be used.)

--- a/index.html
+++ b/index.html
@@ -1460,7 +1460,7 @@
                 (If not a descendant of an `article`, `aside`, `main`, `nav`
                 or `section` element, or an element with `role=article`, `complementary`,
                 `main`, `navigation` or `region`,
-                then <code>role=<a href="#index-aria-contentinfo">banner</a></code>
+                then <code>role=<a href="#index-aria-banner">banner</a></code>
                 is also allowed, but NOT RECOMMENDED.
                 Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
                 is also allowed, but SHOULD NOT be used.)


### PR DESCRIPTION
Closes #501

- **URL**: https://www.w3.org/TR/html-aria/#el-header
- **Issue description**:
    The existing content in the "ARIA role, state, and property allowances" cell for the Header element wrongly specify role=contentinfo instead of role=banner (as follows):
    > Roles: [group](https://www.w3.org/TR/html-aria/#index-aria-group), [none](https://www.w3.org/TR/html-aria/#index-aria-none) or [presentation](https://www.w3.org/TR/html-aria/#index-aria-presentation). (If not a descendant of an article, aside, main, nav or section element, or an element with role=article, complementary, main, navigation or region, then role=[contentinfo](https://www.w3.org/TR/html-aria/#index-aria-contentinfo) is also allowed, but NOT RECOMMENDED. Otherwise, role=[generic](https://www.w3.org/TR/html-aria/#index-aria-generic) is also allowed, but SHOULD NOT be used.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/html-aria/pull/502.html" title="Last updated on Dec 21, 2023, 11:59 AM UTC (571fab8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/502/3a68337...giacomo-petri:571fab8.html" title="Last updated on Dec 21, 2023, 11:59 AM UTC (571fab8)">Diff</a>