### PR TITLE
Update: hidden attribute clarifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -3641,7 +3641,8 @@
                   Use the `disabled` attribute on any element that is allowed the `disabled` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a> attribute on any element that is allowed the `disabled` attribute in HTML, or any element with a WAI-ARIA role which allows the `aria-disabled` attribute</a>.
+                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a> attribute on any element that is allowed the `disabled` attribute in HTML, 
+                  or any element with a WAI-ARIA role which allows the `aria-disabled` attribute</a>.
                 </p>
                 <p>
                   Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
@@ -3660,19 +3661,22 @@
               </td>
               <td>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on any HTML element that allows <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>, with the following exception:
+                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on any HTML element that allows <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> to 
+                  be specified, with the exception of focusable elements and the <a href="#el-body">`body`</a> element.
                 </p>
                 <p>
-                  Authors SHOULD NOT use the `aria-hidden="true"` attribute on any element which also has a `hidden` attribute.
+                  It is NOT RECOMMENDED to use `aria-hidden="true"` on any element which also has the `hidden` attribute specified.
                 </p>
-
-                <!-- this will be covered as part of issue 221 -->
-                <!-- <p>
-                  Authors MUST NOT use `aria-hidden="true"` on an element that can receive keyboard focus, or on an ancestor element to an element or elements which can receive keyboard focus.
-                </p>
-                <p>
-                  Any elements which can receive keyboard focus, interactive elements or otherwise, MUST have their ability to receive keyboard focus removed while the `aria-hidden="true"` attribute is present. For instance, by using `tabindex="-1"` on any focusable elements with `aria-hidden="true"`, or setting `tabindex="-1"` to focusable elements that are descendants of an `aria-hidden="true"` containing element.
-                </p> -->
+                <div class="note">
+                  A focusable element is any element which can be focused by use of keyboard or pointer device. Focusable elements are not always elements which
+                  can be tabbed to via a keyboard. For instance, an element with `tabindex="-1"` is focusable but is not a tabbable element.
+                </div>
+                <div class="note">
+                  Using `aria-hidden="true"` on an element that has the `hidden` attribute is at best an unnecessary redundancy. At worst its usage can 
+                  prevent access to the content if the `hidden` attribute's default UA style of `display: none` has been purposeuflly overwritten by an author or user style sheet.
+                  Finally, if the `hidden` attribute has the value of `until-found`, the use of `aria-hidden=true` will prevent this content from being discoverable to users of assistive
+                  technology when it is found via a browser's in-page find feature and visually rendered to users.
+                </div>
               </td>
             </tr>
             <tr id="att-placeholder" tabindex="-1">
@@ -3688,7 +3692,8 @@
                   `placeholder` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a> attribute on any element that is allowed the `placeholder` attribute in HTML, or any element with a WAI-ARIA role which allows the `aria-placeholder` attribute.
+                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a> attribute on any element that is allowed the `placeholder` attribute in HTML, 
+                  or any element with a WAI-ARIA role which allows the `aria-placeholder` attribute.
                 </p>
                 <p>
                   Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.

--- a/index.html
+++ b/index.html
@@ -3665,7 +3665,7 @@
                   be specified, with the exception of focusable elements and the <a href="#el-body">`body`</a> element.
                 </p>
                 <p>
-                  It is NOT RECOMMENDED to use `aria-hidden="true"` on any element which also has the `hidden` attribute specified.
+                  It is generally NOT RECOMMENDED for authors to use `aria-hidden="true"` on any element which also has the `hidden` attribute specified. However, authors MUST NOT use `aria-hidden="true"` on any element which also has the `hidden` attribute specified in the `until-found` state.
                 </p>
                 <div class="note">
                   A focusable element is any element which can be focused by use of keyboard or pointer device. Focusable elements are not always elements which

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/507">13 December 2024 - Addition:</a>
+          Clarify the allowance for `aria-hidden` when used with the `hidden` attribute.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/489">4 October 2023 - Addition:</a>
           Update the button element and input type=button,image,reset,submit elements to allow the `separator` role.
         </li>


### PR DESCRIPTION
Update expectations for use of aria-hidden with the hidden attribute.

Clarify that the use of aria-hidden on an element with the hidden element is generally not recommended - but authors MUST NOT declare these attributes together if the hidden attribute is in the 'until-found' state.

- [x] [HTML validator](https://github.com/validator/validator/issues/1692)
- [x] [IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/1844)
- [ ] [axe-core](https://github.com/dequelabs/axe-core/issues/4333)
- [x] [ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/76/)

example use case that should result in errors from checkers:
```
<div hidden aria-hidden=true>
  content that can be found, but will remain inaccessible per aria-hidden attribute
</div>
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/507.html" title="Last updated on Dec 13, 2024, 5:46 PM UTC (a5ed1c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/507/4cd9bdc...a5ed1c6.html" title="Last updated on Dec 13, 2024, 5:46 PM UTC (a5ed1c6)">Diff</a>