### PR TITLE
Editorial: input type=image should match type=reset|submit

### DIFF
--- a/index.html
+++ b/index.html
@@ -1847,7 +1847,8 @@
                   and any `aria-*` attributes applicable to the allowed roles.
                 </p>
                 <p>
-                  If possible, authors SHOULD consider using a different HTML element which allows the specified role.
+                  If possible, authors SHOULD consider using a different HTML element which allows the specified role,
+                  such as the `button` element.
                 </p>
               </div>
             </td>
@@ -1984,7 +1985,8 @@
                   and any `aria-*` attributes applicable to the allowed roles.
                 </p>
                 <p>
-                  If possible, authors SHOULD consider using a different HTML element which allows the specified role.
+                  If possible, authors SHOULD consider using a different HTML element which allows the specified role,
+                  such as the `button` element.
                 </p>
               </div>
             </td>
@@ -2039,7 +2041,8 @@
                   and any `aria-*` attributes applicable to the allowed roles.
                 </p>
                 <p>
-                  If possible, authors SHOULD consider using a different HTML element which allows the specified role.
+                  If possible, authors SHOULD consider using a different HTML element which allows the specified role,
+                  such as the `button` element.
                 </p>
               </div>
             </td>

--- a/index.html
+++ b/index.html
@@ -1826,7 +1826,7 @@
             <td>
               <div class="proposed addition">
                 <p>
-                  Roles:
+                  The following roles are allowed, but are NOT RECOMMENDED:
                   <a href="#index-aria-button">`button`</a>,
                   <a href="#index-aria-checkbox">`checkbox`</a>,
                   <a href="#index-aria-gridcell">`gridcell`</a>,
@@ -1845,6 +1845,9 @@
                 <p>
                   <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
                   and any `aria-*` attributes applicable to the allowed roles.
+                </p>
+                <p>
+                  If possible, authors SHOULD consider using a different HTML element which allows the specified role.
                 </p>
               </div>
             </td>


### PR DESCRIPTION
The allowed roles were made consistent in an earlier PR, but the other accompanying 'not recommended' guidance was missed.

closes #504


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/508.html" title="Last updated on Feb 16, 2024, 3:09 PM UTC (da87e9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/508/ab4990f...da87e9a.html" title="Last updated on Feb 16, 2024, 3:09 PM UTC (da87e9a)">Diff</a>