### PR TITLE
Editorial: fix typo in li element guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -2257,7 +2257,7 @@
                   if the parent list element has an implicit or explicit `list` role.
                 </p>
                 <p>
-                  Otherwise, <a><strong>any `role`</strong></a> if the parent list item does not expose an implicit or explicit `list` role.
+                  Otherwise, <a><strong>any `role`</strong></a> if the parent list element does not expose an implicit or explicit `list` role.
                 </p>
                 <p class="note">
                   See <a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, or


### PR DESCRIPTION
Previous: "... if the parent list item does not ...."

Corrected text: "... if the parent list element does not ..."

closes #512


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/515.html" title="Last updated on Apr 15, 2024, 2:47 PM UTC (15d487c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/515/2c9c9a2...15d487c.html" title="Last updated on Apr 15, 2024, 2:47 PM UTC (15d487c)">Diff</a>