### PR TITLE
Correction: add missing allowance for aria-* on meter element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2415,7 +2415,8 @@
               </p>
               <p>
                 Otherwise, any 
-                <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
+                <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>
+                and any other `aria-*` attributes applicable to the `progressbar` role.
               </p>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -2416,7 +2416,7 @@
               <p>
                 Otherwise, any 
                 <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>
-                and any other `aria-*` attributes applicable to the `progressbar` role.
+                and any other `aria-*` attributes applicable to the `meter` role.
               </p>
             </td>
           </tr>


### PR DESCRIPTION
closes #517

adds missing allowance for any aria-* attributes applicable to the meter role.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/519.html" title="Last updated on Apr 30, 2024, 4:19 PM UTC (ba58521)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/519/63adba1...ba58521.html" title="Last updated on Apr 30, 2024, 4:19 PM UTC (ba58521)">Diff</a>