### PR TITLE
Chore: revise table styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -487,7 +487,7 @@
         While it is conforming to use [[[dpub-aria-1.0]]] `role` values as outlined in the following table, the current support for 
         exposing the semantics of these values to users of assistive technology is close to non-existent.
       </p>
-      <table class="simple">
+      <table class="data">
         <caption>
           Rules of ARIA attribute usage by HTML element
         </caption>
@@ -3590,7 +3590,7 @@
           requirements for using the `aria-*` attributes that supply the same
           <a>implicit ARIA semantics</a>.
         </p>
-        <table class="simple">
+        <table class="data">
           <caption>
             Rules of ARIA attribute usage by HTML feature
           </caption>
@@ -3998,7 +3998,7 @@
       Additionally, there are certain roles which [[[wai-aria-1.2]]] has specified specific requirements for their allowed descendants. These have been identified in column 3 (Descendant allowances) by indicating to "Refer to the 'Required Owned Elements'" for those particular roles.
     </p>
 
-    <table id="aria-table" class="simple">
+    <table id="aria-table" class="data">
       <caption>
         Allowed descendants of ARIA roles
       </caption>


### PR DESCRIPTION
use the 'data' class, instead of the previous 'simple' class, to give tables some level of visual layout styling

related to resolving #518


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/521.html" title="Last updated on Dec 13, 2024, 5:51 PM UTC (bcbdc52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/521/ea7fbdb...bcbdc52.html" title="Last updated on Dec 13, 2024, 5:51 PM UTC (bcbdc52)">Diff</a>