### PR TITLE
correction: allow role=math on img element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1585,6 +1585,9 @@
                 <a href="#index-aria-button">`button`</a>,
                 <a href="#index-aria-checkbox">`checkbox`</a>,
                 <a href="#index-aria-link">`link`</a>,
+                <span class="correction">
+                  <a href="#index-aria-math">`math`</a>,
+                </span>
                 <a href="#index-aria-menuitem">`menuitem`</a>,
                 <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                 <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
@@ -1601,7 +1604,8 @@
                 <a href="#index-aria-slider">`slider`</a>,
                 <a href="#index-aria-switch">`switch`</a>,
                 <a href="#index-aria-tab">`tab`</a> or
-                <a href="#index-aria-treeitem">`treeitem`</a>. (<code><a href="#index-aria-img">img</a></code> is also allowed, but NOT RECOMMENDED.)
+                <a href="#index-aria-treeitem">`treeitem`</a>. 
+                (<code><a href="#index-aria-img">img</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Role:

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/525">23 December 2024 - Addition:</a>
+          Update the <a href="#el-img">`img`</a> element to allow the `math` role.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/533">13 December 2024 - Addition:</a>
           Update to include the `image` role as preferred synonym to the `img` role.
         </li>


### PR DESCRIPTION
closes #523

includes allowance of `role=math` on `img` elements.

Per the ARIA specification:
>While it is not ideal to use an image of a mathematical expression, there exists a significant amount of legacy content where images are used to represent mathematical expressions. Authors SHOULD ensure that images of math are labeled by text that describes the mathematical expression as it might be spoken.

so this role should be allowed for such instances, and any further accessibility gaps caused by the use of the `img` element would be for authors to resolve beyond the scope of what this spec covers.

- [x] [HTML validator - PR merged](https://github.com/validator/validator/pull/1773)
- [ ] [IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/2133)
- [x] [axe-core - PR merged](https://github.com/dequelabs/axe-core/issues/4657)
- [x] [ARC toolkit - PR merged](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/pull/80)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/525.html" title="Last updated on Dec 23, 2024, 2:21 PM UTC (ed55dfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/525/11b9625...ed55dfa.html" title="Last updated on Dec 23, 2024, 2:21 PM UTC (ed55dfa)">Diff</a>