### PR TITLE
Update: acknowledge the image role

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,7 +1217,7 @@
                 <a href="#index-aria-application">`application`</a>,
                 <a href="#index-aria-document">`document`</a>,
                 <a href="#index-aria-img">`img`</a>,
-                <a href="#index-aria-img">`image`</a>
+                <a href="#index-aria-img">`image`</a>,
                 <a href="#index-aria-none">`none`</a>
                 or <a href="#index-aria-presentation">`presentation`</a>.
               </p>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/533">13 December 2024 - Addition:</a>
+          Update to include the `image` role as preferred synonym to the `img` role.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/507">13 December 2024 - Addition:</a>
           Clarify the allowance for `aria-hidden` when used with the `hidden` attribute.
         </li>

--- a/index.html
+++ b/index.html
@@ -1217,6 +1217,7 @@
                 <a href="#index-aria-application">`application`</a>,
                 <a href="#index-aria-document">`document`</a>,
                 <a href="#index-aria-img">`img`</a>,
+                <a href="#index-aria-img">`image`</a>
                 <a href="#index-aria-none">`none`</a>
                 or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
@@ -1563,6 +1564,7 @@
                 <a href="#index-aria-application">`application`</a>,
                 <a href="#index-aria-document">`document`</a>,
                 <a href="#index-aria-img">`img`</a>,
+                <a href="#index-aria-img">`image`</a>,
                 <a href="#index-aria-none">`none`</a>
                 or <a href="#index-aria-presentation">`presentation`</a>.
               </p>
@@ -1581,7 +1583,7 @@
             <td>
               If the `img` has non-empty [^img/alt^] (`alt="some text"`) or an accessible name is provided another 
               <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming method</a>:<br>
-              <code>role=<a href="#index-aria-img">img</a></code>
+              <code>role=<a href="#index-aria-img">img or image</a></code>
             </td>
             <td>
               <p>
@@ -1605,7 +1607,7 @@
                 <a href="#index-aria-slider">`slider`</a>,
                 <a href="#index-aria-switch">`switch`</a>,
                 <a href="#index-aria-tab">`tab`</a> or
-                <a href="#index-aria-treeitem">`treeitem`</a>. (<code><a href="#index-aria-img">img</a></code> is also allowed, but NOT RECOMMENDED.)
+                <a href="#index-aria-treeitem">`treeitem`</a>. (<code><a href="#index-aria-img">img or image</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 DPub Role:
@@ -1632,7 +1634,7 @@
                 <p id="el-img-no-alt" tabindex="-1">
                   If the `img` <a data-cite="html/images.html#unknown-images">lacks an `alt` attribute</a> and lacks any other 
                   <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>:<br>
-                  <code>role=<a href="#index-aria-img">img</a></code>
+                  <code>role=<a href="#index-aria-img">img or image</a></code>
                 </p>
               </div>
             </td>
@@ -1642,7 +1644,7 @@
                 If the `img` has no `alt` attribute or accessible name:
                 <a><strong class="nosupport">No `role`</strong></a> other than the  
                 <code>role=<a href="#index-aria-none">none</a></code> or <code><a href="#index-aria-presentation">presentation</a></code> roles.
-                (<code>role=<a href="#index-aria-img">img</a></code> is also allowed, but NOT RECOMMENDED.)
+                (<code>role=<a href="#index-aria-img">img or image</a></code> is also allowed, but NOT RECOMMENDED.)
               </p>
               <p>
                 If the `img` has an empty `alt=""` attribute and no `aria-label` or `aria-labelledby` attributes to provide it an accessible name:
@@ -2476,8 +2478,9 @@
               <p>
                 Roles:
                 <a href="#index-aria-application">`application`</a>,
-                <a href="#index-aria-document">`document`</a>
-                or <a href="#index-aria-img">`img`</a>.
+                <a href="#index-aria-document">`document`</a>,
+                <a href="#index-aria-img">`img`</a>
+                or <a href="#index-aria-img">`image`</a>.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> and
@@ -4416,7 +4419,7 @@
         </tr>
         <tr>
           <th tabindex="-1" id="index-aria-img">
-            <a data-cite="wai-aria-1.2#img">`img`</a>
+            <a data-cite="wai-aria-1.2#img">`img` or `image`</a>
           </th>
           <td>
             <ul>


### PR DESCRIPTION
[role=`image`](https://w3c.github.io/aria/#image) is the preferred default role, over the previous and still valid `img` role.

update the spec to call out the existence / allowance of the `image` role.

---
labels: needs implementation commitment, needs changelog entry
---

Closes #481

<!-- describe your change -->
<!-- be sure to add a test case when appropriate -->
test case:
```
<div role=image>foo</div>
<!-- or -->
<div role=image aria-label=bar></div>
```

<!-- Important:
  for PRs that introduce normative changes the 'needs implementation commitment' 
  and the 'needs changelog entry' labels are needed.  If this is not a PR that
  introduces normative changes, then these labels can be removed.

  For normative changes, log the necessary bugs/rule change requests to the 
  following checkers. If a checker has already implemented the rule, then
  mark it as complete and remove the todo/link.
-->

- [ ] [HTML validator](https://github.com/validator/validator/issues/1771)
- [x] IBM equal access accessibility checker - already supports the `image` role
- [ ] [axe-core](https://github.com/dequelabs/axe-core/issues/4656)
- [x] [ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/78)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/533.html" title="Last updated on Dec 13, 2024, 7:49 PM UTC (89d6a85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/533/ca48852...89d6a85.html" title="Last updated on Dec 13, 2024, 7:49 PM UTC (89d6a85)">Diff</a>