### PR TITLE
chore: Correct minor capitalization typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -640,7 +640,7 @@
                 <p>
                   Roles:
                   <a href="#index-aria-button">`button`</a>
-                  or <a href="#index-aria-link">`link`</a>. (<code><a href="#index-aria-generic">generic</a></code> is also allowed, but SHOULD NOT BE USED.)
+                  or <a href="#index-aria-link">`link`</a>. (<code><a href="#index-aria-generic">generic</a></code> is also allowed, but SHOULD NOT be used.)
                 </p>
                 <p><a>Naming Prohibited</a></p>
                 <p>


### PR DESCRIPTION
Super minor typo(s) but thought I'd correct it, switches "..._SHOULD NOT_ BE USED." to "..._SHOULD NOT_ be used.", which is the capitalization used everywhere else in the document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rschristian/html-aria/pull/534.html" title="Last updated on Dec 17, 2024, 12:11 AM UTC (756ca62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/534/7f7718c...rschristian:756ca62.html" title="Last updated on Dec 17, 2024, 12:11 AM UTC (756ca62)">Diff</a>