### PR TITLE
Correction for HTML element role mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,11 @@
       </p>
       <ul>
         <li>
+          <a href="https://github.com/w3c/html-aria/pull/550">23 July 2025 - Correction:</a>
+          Clarify that the <a href="#el-html">`html`</a> element is a `generic` element, and that
+          neither the `document` or `generic` roles are recommended to be used on the element.
+        </li>
+        <li>
           <a href="https://github.com/w3c/html-aria/pull/525">23 December 2024 - Addition:</a>
           Update the <a href="#el-img">`img`</a> element to allow the `math` role.
         </li>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="en-us">
   <head>
     <meta charset="utf-8">
     <title>ARIA in HTML</title>

--- a/index.html
+++ b/index.html
@@ -1531,11 +1531,12 @@
               [^html^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-document">document</a></code>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-document">document</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-document">document</a></code> 
+                or <code><a href="#index-aria-generic">generic</a></code>, which are NOT RECOMMENDED.
               </p>
               <p>
                 <strong>No `aria-*` attributes</strong>.


### PR DESCRIPTION
per https://github.com/w3c/aria/pull/2504 - the html element doesn't actually map to the `document` role - rather a parent `document node` to the `html` element is what exposes the `document` role of a web page.

This update fixes the spec to match the updated HTML aam mapping / matches reality.  

The `generic` role is being added as an "allowed" but not recommended role to the `html` element.  The `document` role is being kept as an allowed role for the `html` element.  The rational there being that this has been in the spec for a long time and even when specified on the html element, from what i can tell, there's no pro/con to its inclusion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/550.html" title="Last updated on Jul 23, 2025, 5:09 PM UTC (7abe723)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/550/a4ba0a6...7abe723.html" title="Last updated on Jul 23, 2025, 5:09 PM UTC (7abe723)">Diff</a>