### PR TITLE
fix: remove outdated summary warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,11 @@
 <html lang="en-US">
   <head>
     <meta charset="utf-8">
-    <title>ARIA in HTML</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <title>
+      ARIA in HTML
+    </title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"
+    defer></script>
     <script class="remove">
     var respecConfig = {
       editors: [
@@ -46,240 +49,302 @@
   <body data-cite="HTML WAI-ARIA INFRA">
     <section id="abstract">
       <p>
-        This specification defines the authoring rules (author conformance requirements) for the use
-        of [[[wai-aria-1.2]]] and [[[dpub-aria-1.0]]] attributes on [[HTML]] elements.
-        This specification's primary objective is to define requirements for use
-        with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors
-        in their development of web content, including custom interfaces and widgets, which make use of ARIA to
-        complement or extend the features of the host language [[HTML]].
+        This specification defines the authoring rules (author conformance
+        requirements) for the use of [[[wai-aria-1.2]]] and [[[dpub-aria-1.0]]]
+        attributes on [[HTML]] elements. This specification's primary objective
+        is to define requirements for use with conformance checking tools used
+        by authors (i.e., web developers). These requirements will aid authors
+        in their development of web content, including custom interfaces and
+        widgets, which make use of ARIA to complement or extend the features of
+        the host language [[HTML]].
       </p>
     </section>
     <section id="sotd" class="updateable-rec">
       <p>
-        ARIA in HTML is an [[HTML]] specification module. Any HTML features, conformance requirements, or terms that this specification
-        module makes reference to, but does not explicitly define, are defined by the [[HTML|HTML Standard]].
+        ARIA in HTML is an [[HTML]] specification module. Any HTML features,
+        conformance requirements, or terms that this specification module makes
+        reference to, but does not explicitly define, are defined by the
+        [[HTML|HTML Standard]].
       </p>
       <p>
-        Since this specification become a W3C Recommendation on 09 December 2021,
-        the following substantive additions and/or corrections have been proposed:
+        Since this specification become a W3C Recommendation on 09 December
+        2021, the following substantive additions and/or corrections have been
+        proposed:
       </p>
       <ul>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/525">23 December 2024 - Addition:</a>
-          Update the <a href="#el-img">`img`</a> element to allow the `math` role.
+          <a href="https://github.com/w3c/html-aria/pull/525">23 December 2024
+          - Addition:</a> Update the <a href="#el-img">`img`</a> element to
+          allow the `math` role.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/533">13 December 2024 - Addition:</a>
-          Update to include the `image` role as preferred synonym to the `img` role.
+          <a href="https://github.com/w3c/html-aria/pull/533">13 December 2024
+          - Addition:</a> Update to include the `image` role as preferred
+          synonym to the `img` role.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/507">13 December 2024 - Addition:</a>
-          Clarify the allowance for `aria-hidden` when used with the `hidden` attribute.
+          <a href="https://github.com/w3c/html-aria/pull/507">13 December 2024
+          - Addition:</a> Clarify the allowance for `aria-hidden` when used
+          with the `hidden` attribute.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/489">4 October 2023 - Addition:</a>
-          Update the button element and input type=button,image,reset,submit elements to allow the `separator` role.
+          <a href="https://github.com/w3c/html-aria/pull/489">4 October 2023 -
+          Addition:</a> Update the button element and input
+          type=button,image,reset,submit elements to allow the `separator`
+          role.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/453">3 October 2023 - Correction:</a>
-          Update the <a href="#el-img">`img`</a> element allowances to be based on if the element has an accessible name or not.
+          <a href="https://github.com/w3c/html-aria/pull/453">3 October 2023 -
+          Correction:</a> Update the <a href="#el-img">`img`</a> element
+          allowances to be based on if the element has an accessible name or
+          not.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/462">21 August 2023 - Addition:</a>
-          Update the <a href="#el-address">`address`</a> and <a href="#el-hgroup">`hgroup`</a> element allowances per their updated mapping to the `group` role.
+          <a href="https://github.com/w3c/html-aria/pull/462">21 August 2023 -
+          Addition:</a> Update the <a href="#el-address">`address`</a> and
+          <a href="#el-hgroup">`hgroup`</a> element allowances per their
+          updated mapping to the `group` role.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/455">9 July 2023 - Addition:</a>
-          Update the <a href="#el-aside">`aside`</a> element to allow the dpub `doc-glossary` role.
+          <a href="https://github.com/w3c/html-aria/pull/455">9 July 2023 -
+          Addition:</a> Update the <a href="#el-aside">`aside`</a> element to
+          allow the dpub `doc-glossary` role.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/446">5 July 2023 - Addition:</a>
-          Update the <a href="#el-button">`button`</a>, <a href="#el-input-button">`input type=button`</a>, <a href="#el-input-image">`input type=image`</a>
-          <a href="#el-input-reset">`input type=reset`</a>, and <a href="#el-input-submit">`input type=submit`</a> elements to align their allowed roles.
+          <a href="https://github.com/w3c/html-aria/pull/446">5 July 2023 -
+          Addition:</a> Update the <a href="#el-button">`button`</a>, <a href=
+          "#el-input-button">`input type=button`</a>, <a href=
+          "#el-input-image">`input type=image`</a> <a href=
+          "#el-input-reset">`input type=reset`</a>, and <a href=
+          "#el-input-submit">`input type=submit`</a> elements to align their
+          allowed roles.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/469">29 June 2023 - Addition:</a>
-          Update the <a href="#el-s">`s`</a> element allowed roles to indicate use of `role=deletion` on the element would be considered redundnat.
+          <a href="https://github.com/w3c/html-aria/pull/469">29 June 2023 -
+          Addition:</a> Update the <a href="#el-s">`s`</a> element allowed
+          roles to indicate use of `role=deletion` on the element would be
+          considered redundnat.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/435">31 May 2023 - Correction:</a>
-          Conditionally revise allowed `aria-*` attributes and roles on <a href="#el-summary">`summary`</a> element.
+          <a href="https://github.com/w3c/html-aria/pull/435">31 May 2023 -
+          Correction:</a> Conditionally revise allowed `aria-*` attributes and
+          roles on <a href="#el-summary">`summary`</a> element.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/410">31 May 2023 - Correction:</a>
-          Update <a href="#el-li">`li`</a> element role allowances in context to the element's ancestral relationship, or lack of, 
-          to a list element parent.
+          <a href="https://github.com/w3c/html-aria/pull/410">31 May 2023 -
+          Correction:</a> Update <a href="#el-li">`li`</a> element role
+          allowances in context to the element's ancestral relationship, or
+          lack of, to a list element parent.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/401">24 March 2023 - Addition:</a>
-          The <a href="#el-search">`search`</a> element has been added.
+          <a href="https://github.com/w3c/html-aria/pull/401">24 March 2023 -
+          Addition:</a> The <a href="#el-search">`search`</a> element has been
+          added.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/447">6 March 2023 - Addition:</a>
-          Disallow `aria-hidden=true` on the `body` element.
+          <a href="https://github.com/w3c/html-aria/pull/447">6 March 2023 -
+          Addition:</a> Disallow `aria-hidden=true` on the `body` element.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/415">13 February 2023 - Addition:</a>
-          Update `figure` element role allowances to include `doc-example`.
+          <a href="https://github.com/w3c/html-aria/pull/415">13 February 2023
+          - Addition:</a> Update `figure` element role allowances to include
+          `doc-example`.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/437">07 November 2022 - Correction:</a>
-          Revisions to 'any role' term description.
+          <a href="https://github.com/w3c/html-aria/pull/437">07 November 2022
+          - Correction:</a> Revisions to 'any role' term description.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/383">14 July 2022 - Correction:</a>
-          Disallow roles and `aria-*` attributes on the <a href="#el-datalist">`datalist`</a> element.
+          <a href="https://github.com/w3c/html-aria/pull/383">14 July 2022 -
+          Correction:</a> Disallow roles and `aria-*` attributes on the
+          <a href="#el-datalist">`datalist`</a> element.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/372">16 April 2022 - Correction:</a>
-          <a href="#att-checked">`aria-checked`</a> is not to be used on elements that support the `checked` attribute.
+          <a href="https://github.com/w3c/html-aria/pull/372">16 April 2022 -
+          Correction:</a> <a href="#att-checked">`aria-checked`</a> is not to
+          be used on elements that support the `checked` attribute.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/402">03 April 2022 - Addition:</a>
-          Identify <a href="#dfn-naming-prohibited">Naming Prohibited</a> elements.
+          <a href="https://github.com/w3c/html-aria/pull/402">03 April 2022 -
+          Addition:</a> Identify <a href="#dfn-naming-prohibited">Naming
+          Prohibited</a> elements.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/404">06 March 2022 - Addition:</a>
-          Allow `none` and `presentation` roles on <a href="#el-nav">`nav` element</a>.
+          <a href="https://github.com/w3c/html-aria/pull/404">06 March 2022 -
+          Addition:</a> Allow `none` and `presentation` roles on <a href=
+          "#el-nav">`nav` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/403">03 March 2022 - Addition:</a>
-          Restrict role allowances for <a href="#el-div">`div` element</a> when it is a child of a `dl` element.
+          <a href="https://github.com/w3c/html-aria/pull/403">03 March 2022 -
+          Addition:</a> Restrict role allowances for <a href="#el-div">`div`
+          element</a> when it is a child of a `dl` element.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/396">12 February 2022 - Addition &amp; Correction:</a>
-          Allow `combobox` role on <a href="#el-button">`button` element</a>. 
-          Allow `combobox` and `checkbox` roles on <a href="#el-input-button">`input type=button` element</a>. 
+          <a href="https://github.com/w3c/html-aria/pull/396">12 February 2022
+          - Addition & Correction:</a> Allow `combobox` role on <a href=
+          "#el-button">`button` element</a>. Allow `combobox` and `checkbox`
+          roles on <a href="#el-input-button">`input type=button` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/391">18 January 2022 - Addition:</a>
-          Added <a href="#docconformance-deprecated">Requirements for deprecated ARIA role, state and property attributes</a>.
+          <a href="https://github.com/w3c/html-aria/pull/391">18 January 2022 -
+          Addition:</a> Added <a href="#docconformance-deprecated">Requirements
+          for deprecated ARIA role, state and property attributes</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/369">06 January 2022 - Addition:</a>
-          Change allowances for `doc-biblioentry` and `doc-endnote` roles on the <a href="#el-li">`li` element</a>. 
-          These roles are deprecated in [[[dpub-aria-1.1]]].
+          <a href="https://github.com/w3c/html-aria/pull/369">06 January 2022 -
+          Addition:</a> Change allowances for `doc-biblioentry` and
+          `doc-endnote` roles on the <a href="#el-li">`li` element</a>. These
+          roles are deprecated in [[[dpub-aria-1.1]]].
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/381">13 December 2021 - Correction:</a>
-          Allow `radio` role on <a href="#el-img">`img alt="some text"` element</a>.
+          <a href="https://github.com/w3c/html-aria/pull/381">13 December 2021
+          - Correction:</a> Allow `radio` role on <a href="#el-img">`img
+          alt="some text"` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/353">07 December 2021 - Correction:</a> 
-          Allow only `none` and `presentation` roles for <a href="#el-wbr">`wbr` element</a>. 
-          Allow only `aria-hidden` global attribute for <a href="#el-br">`br`</a> and <a href="#el-wbr">`wbr`</a> elements.
+          <a href="https://github.com/w3c/html-aria/pull/353">07 December 2021
+          - Correction:</a> Allow only `none` and `presentation` roles for
+          <a href="#el-wbr">`wbr` element</a>. Allow only `aria-hidden` global
+          attribute for <a href="#el-br">`br`</a> and <a href=
+          "#el-wbr">`wbr`</a> elements.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/367">02 December 2021 - Addition:</a> 
-          Allow `group` role on <a href="#el-section">`section` element</a>.
+          <a href="https://github.com/w3c/html-aria/pull/367">02 December 2021
+          - Addition:</a> Allow `group` role on <a href="#el-section">`section`
+          element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/360">16 November 2021 - Addition:</a>
-          Allow `link` and `button` roles on <a href="#el-area-no-href">`area` without `href` element</a>.
+          <a href="https://github.com/w3c/html-aria/pull/360">16 November 2021
+          - Addition:</a> Allow `link` and `button` roles on <a href=
+          "#el-area-no-href">`area` without `href` element</a>.
         </li>
         <li>
-          <a href="https://github.com/w3c/html-aria/pull/352">26 October 2021 - Addition:</a>
-          Allow `aria-hidden` attribute on the <a href="#el-picture">`picture` element</a>. 
+          <a href="https://github.com/w3c/html-aria/pull/352">26 October 2021 -
+          Addition:</a> Allow `aria-hidden` attribute on the <a href=
+          "#el-picture">`picture` element</a>.
         </li>
       </ul>
       <p>
-        Reviewers of the document can identify candidate additions
-        and/or corrections by their distinctive styling in the document:
+        Reviewers of the document can identify candidate additions and/or
+        corrections by their distinctive styling in the document:
       </p>
-      <p class="correction">Candidate corrections are marked in the document.</p>
-      <p class="addition">Candidate additions are marked in the document.</p>
+      <p class="correction">
+        Candidate corrections are marked in the document.
+      </p>
+      <p class="addition">
+        Candidate additions are marked in the document.
+      </p>
     </section>
     <section>
       <h2 id="rules-wd">
         Author requirements for use of ARIA in HTML
       </h2>
       <p>
-        Authors MAY use the ARIA `role` and `aria-*` attributes to change
-        the exposed meaning (<a data-cite="html/dom.html#semantics-2">semantics</a>) of
-        [=HTML elements=], in accordance with the requirements defined by
-        [[wai-aria-1.2|WAI-ARIA]], except where ARIA features conflict with the
-        <dfn data-cite="wai-aria-1.2#host_general_conflict">strong native semantics</dfn>
-        or are equal to the
-        <dfn data-cite="wai-aria-1.2#implicit_semantics">implicit ARIA semantics</dfn>
-        of a given HTML element. The <a>implicit ARIA semantics</a> for the features
-        of HTML are defined by the [[html-aam-1.0|HTML Accessibility API Mappings]] specification.
+        Authors MAY use the ARIA `role` and `aria-*` attributes to change the
+        exposed meaning (<a data-cite=
+        "html/dom.html#semantics-2">semantics</a>) of [=HTML elements=], in
+        accordance with the requirements defined by [[wai-aria-1.2|WAI-ARIA]],
+        except where ARIA features conflict with the <dfn data-cite=
+        "wai-aria-1.2#host_general_conflict">strong native semantics</dfn> or
+        are equal to the <dfn data-cite=
+        "wai-aria-1.2#implicit_semantics">implicit ARIA semantics</dfn> of a
+        given HTML element. The <a>implicit ARIA semantics</a> for the features
+        of HTML are defined by the [[html-aam-1.0|HTML Accessibility API
+        Mappings]] specification.
       </p>
       <p>
-        Any constraints for the use of ARIA features in HTML defined by this specification 
-        are intended to prevent authors from making assistive technology products report 
-        nonsensical user interface (UI) information that does not represent the actual UI
-        of the document.
+        Any constraints for the use of ARIA features in HTML defined by this
+        specification are intended to prevent authors from making assistive
+        technology products report nonsensical user interface (UI) information
+        that does not represent the actual UI of the document.
       </p>
       <p>
-        Authors MUST NOT use the ARIA `role` and `aria-*` attributes in a manner that conflicts 
-        with the semantics described in the [[[#docconformance]]] and [[[#docconformance-attr]]] 
-        tables. It is NOT RECOMMENDED for authors to set the ARIA `role` and `aria-*` attributes 
-        to values that match the <a>implicit ARIA semantics</a> defined in either table. 
-        Doing so is unnecessary and can potentially lead to unintended consequences.
+        Authors MUST NOT use the ARIA `role` and `aria-*` attributes in a
+        manner that conflicts with the semantics described in the
+        [[[#docconformance]]] and [[[#docconformance-attr]]] tables. It is NOT
+        RECOMMENDED for authors to set the ARIA `role` and `aria-*` attributes
+        to values that match the <a>implicit ARIA semantics</a> defined in
+        either table. Doing so is unnecessary and can potentially lead to
+        unintended consequences.
       </p>
     </section>
     <section class="informative">
-      <h2>ARIA semantics that extend and diverge from HTML</h2>
+      <h2>
+        ARIA semantics that extend and diverge from HTML
+      </h2>
       <p>
-        Through the use of ARIA, authors can specify semantics that go beyond the current 
-        capabilities of native HTML. This can be very useful, as it provides authors the opportunity 
-        to create widgets, or expose specific accessible states and properties to native HTML features 
-        which would not be possible by the use of HTML alone.
+        Through the use of ARIA, authors can specify semantics that go beyond
+        the current capabilities of native HTML. This can be very useful, as it
+        provides authors the opportunity to create widgets, or expose specific
+        accessible states and properties to native HTML features which would
+        not be possible by the use of HTML alone.
       </p>
       <p>
-        For instance, a `button` element has no native HTML feature to expose a "pressed" state.
-        ARIA allows authors to extend the semantics of the element by specifying the `aria-pressed`
-        attribute, allowing for an aural UI that will match the visual presentation of the control.
+        For instance, a `button` element has no native HTML feature to expose a
+        "pressed" state. ARIA allows authors to extend the semantics of the
+        element by specifying the `aria-pressed` attribute, allowing for an
+        aural UI that will match the visual presentation of the control.
       </p>
       <p>
-        In the following example, a `button` element allows for a user to toggle the state of a 
-        setting within a web application. The `aria-pressed` attribute is used to 
-        augment the `button` element. When in the "pressed" state that information can be
-        exposed to users of assistive technologies.
+        In the following example, a `button` element allows for a user to
+        toggle the state of a setting within a web application. The
+        `aria-pressed` attribute is used to augment the `button` element. When
+        in the "pressed" state that information can be exposed to users of
+        assistive technologies.
       </p>
-      <pre class="HTML example" title="Communicate a button's pressed state with ARIA">
-      &lt;button aria-pressed=true>...&lt;/button>
+      <pre class="HTML example" title=
+      "Communicate a button's pressed state with ARIA">
+      &lt;button aria-pressed=true&gt;...&lt;/button&gt;
       </pre>
       <p>
-        There are also situations where certain `aria-*` attributes are allowed for use on elements 
-        with specific `role`s, while the equivalent native attribute is currently not valid in HTML itself.
+        There are also situations where certain `aria-*` attributes are allowed
+        for use on elements with specific `role`s, while the equivalent native
+        attribute is currently not valid in HTML itself.
       </p>
       <p>
-        For instance, HTML has no direct concept of a disabled hyperlink (`a href` element). 
-        Constructs such as `&lt;a href="..." disabled&gt; ... &lt;/a&gt;` are not valid, 
-        and will not be conveyed to assistive technologies. 
+        For instance, HTML has no direct concept of a disabled hyperlink (`a
+        href` element). Constructs such as `&lt;a href="..." disabled&gt; ...
+        &lt;/a&gt;` are not valid, and will not be conveyed to assistive
+        technologies.
       </p>
       <p>
-        ARIA diverges from HTML in this regard and does allow for an `aria-disabled`
-        attribute to be specified on an element with an explicit `role=link`. If an author were
-        to specify an `aria-disabled=true` on an HTML hyperlink, user agents would not functionally
-        treat the hyperlink any differently (it would still be clickable/operable), however it 
-        would be exposed to assistive technologies as being in the disabled state.
+        ARIA diverges from HTML in this regard and does allow for an
+        `aria-disabled` attribute to be specified on an element with an
+        explicit `role=link`. If an author were to specify an
+        `aria-disabled=true` on an HTML hyperlink, user agents would not
+        functionally treat the hyperlink any differently (it would still be
+        clickable/operable), however it would be exposed to assistive
+        technologies as being in the disabled state.
       </p>
       <p>
-        Similarly, while native HTML `option` elements that are descendants of a `select` can 
-        only be set as being `selected`, elements with an explicit `option` role can not only 
-        allow the equivalent `aria-selected`, but also the `aria-checked` attribute, supporting
-        widgets/constructs that go beyond the capabilities of a native `select` element.
+        Similarly, while native HTML `option` elements that are descendants of
+        a `select` can only be set as being `selected`, elements with an
+        explicit `option` role can not only allow the equivalent
+        `aria-selected`, but also the `aria-checked` attribute, supporting
+        widgets/constructs that go beyond the capabilities of a native `select`
+        element.
       </p>
       <p>
-        Unfortunately, in these situations where ARIA and HTML have feature parity, but diverge 
-        in allowances, it can create for a misalignment in support, if not also user experiences. 
-        In situations where ARIA allows a feature not supported by HTML, it will often
-        be in the author's and ultimately the user's best interest to instead implement as a 
-        fully custom ARIA widget.
+        Unfortunately, in these situations where ARIA and HTML have feature
+        parity, but diverge in allowances, it can create for a misalignment in
+        support, if not also user experiences. In situations where ARIA allows
+        a feature not supported by HTML, it will often be in the author's and
+        ultimately the user's best interest to instead implement as a fully
+        custom ARIA widget.
       </p>
       <p>
-        In the following example, a hyperlink needs to be communicated as being in the disabled
-        state. HTML does not allow for the use of the `disabled` attribute on a hyperlink,
-        and using `aria-disabled=true` would communicate the hyperlink as being disabled to 
-        assistive technologies, but would not actually disable the element. The most effective way 
-        to both communicate and actually disable a hyperlink would be to remove the `href` from 
-        the [^a^] element, creating a placeholder. Then, ARIA can be applied to this
-        placeholder link to communicate the element's intended role and state.
+        In the following example, a hyperlink needs to be communicated as being
+        in the disabled state. HTML does not allow for the use of the
+        `disabled` attribute on a hyperlink, and using `aria-disabled=true`
+        would communicate the hyperlink as being disabled to assistive
+        technologies, but would not actually disable the element. The most
+        effective way to both communicate and actually disable a hyperlink
+        would be to remove the `href` from the [^a^] element, creating a
+        placeholder. Then, ARIA can be applied to this placeholder link to
+        communicate the element's intended role and state.
       </p>
       <pre class="HTML example" title="Communicate a disabled link with ARIA">
-      &lt;a role=link aria-disabled=true>...&lt;/a>
+      &lt;a role=link aria-disabled=true&gt;...&lt;/a&gt;
       </pre>
     </section>
     <section class="informative">
@@ -291,24 +356,29 @@
           Avoid overriding interactive elements with non-interactive roles
         </h3>
         <p>
-          ARIA is useful for revising or correcting the role of an element when a different role
-          is necessary to expose to users. However, it is rarely in the user or author's best interest
-          to try and use ARIA to override an interactive element, for instance a `button`, with a role
-          generally exposed by a non-interactive element. For instance, a heading.
+          ARIA is useful for revising or correcting the role of an element when
+          a different role is necessary to expose to users. However, it is
+          rarely in the user or author's best interest to try and use ARIA to
+          override an interactive element, for instance a `button`, with a role
+          generally exposed by a non-interactive element. For instance, a
+          heading.
         </p>
         <p>
-          As an example, the following uses a `role=heading` on a [^button^] element. This is
-          not allowed, because the `button` element has default functionality that conflicts with user 
-          expectations for the heading role.
+          As an example, the following uses a `role=heading` on a [^button^]
+          element. This is not allowed, because the `button` element has
+          default functionality that conflicts with user expectations for the
+          heading role.
         </p>
         <pre class="example HTML" title="Wrong role">
           &lt;button role="heading"&gt;search&lt;/button&gt;
         </pre>
         <p>
-          An author would need to take additional steps to ensure the default functionality and presentation of 
-          the `button` was removed, and even doing so may still not be enough to fully supress the element's 
-          implicit features depending on how the user chooses to engage with the web page. E.g., by turning on 
-          Windows high contrast themes, or viewing the web page in a browser's reader mode.
+          An author would need to take additional steps to ensure the default
+          functionality and presentation of the `button` was removed, and even
+          doing so may still not be enough to fully supress the element's
+          implicit features depending on how the user chooses to engage with
+          the web page. E.g., by turning on Windows high contrast themes, or
+          viewing the web page in a browser's reader mode.
         </p>
       </section>
       <section>
@@ -316,40 +386,48 @@
           Avoid specifying redundant roles
         </h3>
         <p>
-          The following example illustrates a [^button^] element which has also been
-          provided an explicit `role=button`. Specifying this role is unnecessary, as a "button" 
-          element is already exposed with an implicit `button` role. In practice this particular
-          instance of redundancy will likely not have unforeseen side effects, other than 
-          unnecessarily making the markup more verbose, and incorrectly signaling to other authors 
-          that this practice is useful. Please review the section [[[#side-effects]]]
-          for an example of where specifying unnecessary roles can be problematic.
+          The following example illustrates a [^button^] element which has also
+          been provided an explicit `role=button`. Specifying this role is
+          unnecessary, as a "button" element is already exposed with an
+          implicit `button` role. In practice this particular instance of
+          redundancy will likely not have unforeseen side effects, other than
+          unnecessarily making the markup more verbose, and incorrectly
+          signaling to other authors that this practice is useful. Please
+          review the section [[[#side-effects]]] for an example of where
+          specifying unnecessary roles can be problematic.
         </p>
         <pre class="example HTML" title="Redundant role on button">
-          &lt;!-- Avoid doing this! -->
+          &lt;!-- Avoid doing this! --&gt;
           &lt;button role="button"&gt;...&lt;/button&gt;
         </pre>
         <p>
-          Similarly, the following uses a `role=group` on a [^fieldset^] element, and a `role=Main` on a [^main^] element.
-          This is unnecessary, because the `fieldset` element is implicitly exposed as a `role=group`, as is the `main` element 
-          implicitly exposed as a `role=main`. Again, in practice this will likely not have any unforeseen side effects to users 
-          of assistive technology, as long as the declaration of the `role` value uses [=ASCII lowercase=]. 
-          Please see [[[#case-sensitivity]]] for more information.
+          Similarly, the following uses a `role=group` on a [^fieldset^]
+          element, and a `role=Main` on a [^main^] element. This is
+          unnecessary, because the `fieldset` element is implicitly exposed as
+          a `role=group`, as is the `main` element implicitly exposed as a
+          `role=main`. Again, in practice this will likely not have any
+          unforeseen side effects to users of assistive technology, as long as
+          the declaration of the `role` value uses [=ASCII lowercase=]. Please
+          see [[[#case-sensitivity]]] for more information.
         </p>
         <pre class="HTML example" title="Redundant role on fieldset and main">
-          &lt;!-- Avoid doing this! -->
+          &lt;!-- Avoid doing this! --&gt;
           &lt;fieldset role="group"&gt;...&lt;/fieldset&gt;
-          &lt;!-- or this! -->
-          &lt;main role="Main">...&lt;/main>
+          &lt;!-- or this! --&gt;
+          &lt;main role="Main"&gt;...&lt;/main&gt;
         </pre>
         <p>
-          The following uses a `role=list` on an [^ul^] element. As the `ul` element has an implicit role of `list`, 
-          explicitly adding the role would generally be considered redundant. However, some user agents suppress a list's
-          implicit ARIA semantics if the list markers are removed from the visual presentation of the list items. 
-          Generally the redundant declaration of an element's implicit role would not be recommended, but in specific situations
-          such as this, and where the role is necessary to expose, authors can explicitly add the role.
+          The following uses a `role=list` on an [^ul^] element. As the `ul`
+          element has an implicit role of `list`, explicitly adding the role
+          would generally be considered redundant. However, some user agents
+          suppress a list's implicit ARIA semantics if the list markers are
+          removed from the visual presentation of the list items. Generally the
+          redundant declaration of an element's implicit role would not be
+          recommended, but in specific situations such as this, and where the
+          role is necessary to expose, authors can explicitly add the role.
         </p>
         <pre class="HTML example" title="Redundant role on list">
-          &lt;!-- Generally avoid doing this! -->
+          &lt;!-- Generally avoid doing this! --&gt;
           &lt;ul role="list"&gt;...&lt;/ul&gt;
         </pre>
       </section>
@@ -366,92 +444,117 @@
         </p>
         <pre class="HTML example" title="Unintended consequences">
           &lt;details&gt;
-            &lt;!-- Avoid doing this! -->
+            &lt;!-- Avoid doing this! --&gt;
             &lt;summary role="button"&gt;more information&lt;/summary&gt;
             ...
           &lt;/details&gt;
         </pre>
       </section>
       <section>
-        <h3>Adhere to the rules of ARIA</h3>
+        <h3>
+          Adhere to the rules of ARIA
+        </h3>
         <p>
-          [[[wai-aria-1.2]]] defines a number of roles which are not meant to be used
-          by authors. Many of these roles are categorized as <a data-cite="wai-aria-1.2#isAbstract">Abstract Roles</a>
-          which are explicitly stated as not to be used by authors. The following example illustrates the invalid use of an
-          abstract `select` role, where an author likely meant to use the `combobox` role instead.
+          [[[wai-aria-1.2]]] defines a number of roles which are not meant to
+          be used by authors. Many of these roles are categorized as
+          <a data-cite="wai-aria-1.2#isAbstract">Abstract Roles</a> which are
+          explicitly stated as not to be used by authors. The following example
+          illustrates the invalid use of an abstract `select` role, where an
+          author likely meant to use the `combobox` role instead.
         </p>
         <pre class="HTML example" title="Abstract roles are not for authors">
-          &lt;!-- Do not do this! -->
+          &lt;!-- Do not do this! --&gt;
           &lt;div role="select" ...&gt;...&lt;/div&gt;
         </pre>
         <p>
-          ARIA also defines a <a data-cite="wai-aria-1.2#generic">`generic` role</a> which is meant to provide
-          feature parity with a number of HTML elements that do not have more specific ARIA semantics of their
-          own. For instance, HTML's [^div^] and [^span^] elements, among others. ARIA discourages authors from
-          using the `generic` role as its intended purpose is for use by implementors of user agents.
+          ARIA also defines a <a data-cite="wai-aria-1.2#generic">`generic`
+          role</a> which is meant to provide feature parity with a number of
+          HTML elements that do not have more specific ARIA semantics of their
+          own. For instance, HTML's [^div^] and [^span^] elements, among
+          others. ARIA discourages authors from using the `generic` role as its
+          intended purpose is for use by implementors of user agents.
         </p>
         <p>
-          In the following example, rather than using a `generic` role, authors are advised to use a `div` in 
-          place of the `article` element. If changing the HTML element is not possible, specifying a role of 
-          `presentation` or `none` would be acceptable alternaties to remove the implicit role of the `article`.
+          In the following example, rather than using a `generic` role, authors
+          are advised to use a `div` in place of the `article` element. If
+          changing the HTML element is not possible, specifying a role of
+          `presentation` or `none` would be acceptable alternaties to remove
+          the implicit role of the `article`.
         </p>
         <pre class="HTML example" title="Do not specify elements as generic">
-          &lt;!-- Avoid doing this! -->
-          &lt;article role="generic" ...>...&lt;/article>
+          &lt;!-- Avoid doing this! --&gt;
+          &lt;article role="generic" ...&gt;...&lt;/article&gt;
         </pre>
         <p>
-          Additionally, ARIA specifically mentions in <a data-cite="wai-aria-1.2/#host_general_conflict">Conflicts with Host Language Semantics</a> 
-          that if authors use both native HTML features for exposing states and properties as well as their ARIA counterparts, then
-          the host language features take priority over the explicit ARIA attributes that are also used.
+          Additionally, ARIA specifically mentions in <a data-cite=
+          "wai-aria-1.2/#host_general_conflict">Conflicts with Host Language
+          Semantics</a> that if authors use both native HTML features for
+          exposing states and properties as well as their ARIA counterparts,
+          then the host language features take priority over the explicit ARIA
+          attributes that are also used.
         </p>
         <p>
-          For instance, in the following example an author is using HTML's `input type=checkbox` and has specified an `aria-checked=true`. However,
-          user agents are meant to ignore the `aria-checked` attribute. Instead user agents would expose the state based on the native features
-          of the form control.
+          For instance, in the following example an author is using HTML's
+          `input type=checkbox` and has specified an `aria-checked=true`.
+          However, user agents are meant to ignore the `aria-checked`
+          attribute. Instead user agents would expose the state based on the
+          native features of the form control.
         </p>
-        <pre class="HTML example" title="The implicit checked state takes precedent over the explicit ARIA attribute">
-          &lt;!-- Do not do this! -->
-          &lt;input type="checkbox" checked aria-checked="false">
+        <pre class="HTML example" title=
+        "The implicit checked state takes precedent over the explicit ARIA attribute">
+
+          &lt;!-- Do not do this! --&gt;
+          &lt;input type="checkbox" checked aria-checked="false"&gt;
         </pre>
       </section>
       <section>
-        <h3>Adhere to the rules of HTML</h3>
+        <h3>
+          Adhere to the rules of HTML
+        </h3>
         <p>
-          While ARIA can be used to alter the way HTML features are exposed to users of assistive technologies,
-          these modifications do not change the underlying parsing and allowed content models of HTML. For instance,
-          a [^div^] allows an author to specify any role on it. However, this does not mean that the element can then be
-          used in a way that deviates from the rules HTML has defined for the element.
+          While ARIA can be used to alter the way HTML features are exposed to
+          users of assistive technologies, these modifications do not change
+          the underlying parsing and allowed content models of HTML. For
+          instance, a [^div^] allows an author to specify any role on it.
+          However, this does not mean that the element can then be used in a
+          way that deviates from the rules HTML has defined for the element.
         </p>
         <p>
-          For instance, in the following example an author has specified a role of `link` on a `div` element. While
-          HTML allows for a hyperlink (exposed as a `role=link`) to be a descendant of a `p` element, the HTML parser does not
-          allow a `div` to be a descendant of a `p` element. 
+          For instance, in the following example an author has specified a role
+          of `link` on a `div` element. While HTML allows for a hyperlink
+          (exposed as a `role=link`) to be a descendant of a `p` element, the
+          HTML parser does not allow a `div` to be a descendant of a `p`
+          element.
         </p>
-        <pre class="HTML example" title="Revised ARIA semantics with invalid HTML nesting">
-          &lt;!-- Do not do this! -->
-          &lt;p>
-            ... &lt;div role=link tabindex=0>...&lt;/div> ... 
-          &lt;/p>
+        <pre class="HTML example" title=
+        "Revised ARIA semantics with invalid HTML nesting">
+          &lt;!-- Do not do this! --&gt;
+          &lt;p&gt;
+            ... &lt;div role=link tabindex=0&gt;...&lt;/div&gt; ... 
+          &lt;/p&gt;
         </pre>
         <p>
-          The HTML parser will modify the above markup to be output as the following:
+          The HTML parser will modify the above markup to be output as the
+          following:
         </p>
-        <pre class="HTML example" title="Unwanted rendered markup with valid alternative solution">
-          &lt!-- The previous example's markup will render as follows -->
-          &lt;p>...&lt;/p>
-          &lt;div role=link tabindex=0>...&lt;/div> 
+        <pre class="HTML example" title=
+        "Unwanted rendered markup with valid alternative solution">
+          &lt;!-- The previous example's markup will render as follows --&gt;
+          &lt;p&gt;...&lt;/p&gt;
+          &lt;div role=link tabindex=0&gt;...&lt;/div&gt; 
           ... 
-          &lt;p>&lt;/p>
+          &lt;p&gt;&lt;/p&gt;
           
-          &lt;!-- Instead of a div, use a span. Spans are allowed descendants of p elements! -->
-          &lt;p>
-            ... &lt;span role=link tabindex=0>...&lt;/span> ...
-          &lt;/p>
+          &lt;!-- Instead of a div, use a span. Spans are allowed descendants of p elements! --&gt;
+          &lt;p&gt;
+            ... &lt;span role=link tabindex=0&gt;...&lt;/span&gt; ...
+          &lt;/p&gt;
         </pre>
         <p>
-          While this specification indicates the allowed ARIA attributes that can be specified on each HTML element,
-          this example illustrates that even if a role is allowed, the context in which it is used can still result
-          in potential rendering and accessibility issues.
+          While this specification indicates the allowed ARIA attributes that
+          can be specified on each HTML element, this example illustrates that
+          even if a role is allowed, the context in which it is used can still
+          result in potential rendering and accessibility issues.
         </p>
       </section>
     </section>
@@ -460,45 +563,60 @@
         Document conformance requirements for use of ARIA attributes in HTML
       </h2>
       <p>
-        The following table provides normative per-element document conformance requirements for the 
-        use of ARIA markup in HTML documents. Additionally, it identifies the <a>implicit ARIA semantics</a> 
-        that apply to [=HTML elements=]. The <a>implicit ARIA semantics</a> of these elements are defined 
-        in [[html-aam-1.0|HTML AAM]].
+        The following table provides normative per-element document conformance
+        requirements for the use of ARIA markup in HTML documents.
+        Additionally, it identifies the <a>implicit ARIA semantics</a> that
+        apply to [=HTML elements=]. The <a>implicit ARIA semantics</a> of these
+        elements are defined in [[html-aam-1.0|HTML AAM]].
       </p>
       <p>
-        Each language feature (element) in a cell in the first column implies the ARIA semantics 
-        (role, states, and properties) given in the cell in  the second column of the same row. 
-        The third cell in each row defines the ARIA `role` values and `aria-*` attributes which authors MAY specify
-        on the element. Where a cell in the third column includes the term <dfn><strong>Any</strong> `role`</dfn>
-        it indicates that any `role` value <span class="addition correction">MAY be used on the element. However, 
-        it is NOT RECOMMENDED for authors to specify the implicit role of the element, the `generic` role, or a role 
-        <a href="#docconformance-deprecated">deprecated by ARIA</a> on these elements.</span> 
-        If a cell in the third column includes the term <dfn><strong>No `role`</strong></dfn> it indicates 
-        that authors MUST NOT overwrite the implicit ARIA semantics, or native semantics of the HTML element. 
+        Each language feature (element) in a cell in the first column implies
+        the ARIA semantics (role, states, and properties) given in the cell in
+        the second column of the same row. The third cell in each row defines
+        the ARIA `role` values and `aria-*` attributes which authors MAY
+        specify on the element. Where a cell in the third column includes the
+        term <dfn><strong>Any</strong> `role`</dfn> it indicates that any
+        `role` value <span class="addition correction">MAY be used on the
+        element. However, it is NOT RECOMMENDED for authors to specify the
+        implicit role of the element, the `generic` role, or a role <a href=
+        "#docconformance-deprecated">deprecated by ARIA</a> on these
+        elements.</span> If a cell in the third column includes the term
+        <dfn><strong>No `role`</strong></dfn> it indicates that authors MUST
+        NOT overwrite the implicit ARIA semantics, or native semantics of the
+        HTML element.
       </p>
       <div class="addition">
         <p>
-          [[wai-aria-1.2|WAI-ARIA]] identifies roles which have 
-          <a data-cite="wai-aria-1.2/#prohibitedattributes">prohibited states and properties</a>.
-          These roles do not allow certain WAI-ARIA attributes to be specified by authors.
-          HTML elements which expose these implicit WAI-ARIA roles also prohibit authors from
-          specifying these WAI-ARIA attributes.
+          [[wai-aria-1.2|WAI-ARIA]] identifies roles which have <a data-cite=
+          "wai-aria-1.2/#prohibitedattributes">prohibited states and
+          properties</a>. These roles do not allow certain WAI-ARIA attributes
+          to be specified by authors. HTML elements which expose these implicit
+          WAI-ARIA roles also prohibit authors from specifying these WAI-ARIA
+          attributes.
         </p>
         <p>
-          Elements which are identified as <dfn>Naming prohibited</dfn> are those which authors MUST NOT specify an 
-          `aria-label` or `aria-labelledby` attribute, unless the element allows for its implicit role to be overwritten 
-          by an explicit WAI-ARIA role which allows naming from authors. For more information see [[[#docconformance-naming]]].
+          Elements which are identified as <dfn>Naming prohibited</dfn> are
+          those which authors MUST NOT specify an `aria-label` or
+          `aria-labelledby` attribute, unless the element allows for its
+          implicit role to be overwritten by an explicit WAI-ARIA role which
+          allows naming from authors. For more information see
+          [[[#docconformance-naming]]].
         </p>
       </div>
       <p class="note" id="aria-usage-note">
-        While setting an ARIA `role` and/or `aria-*` attribute that matches the <span>implicit ARIA semantics</span>
-        is NOT RECOMMENDED, in some  situations explicitly setting these attributes can be helpful – for instance, 
-        for user agents that do not expose implicit ARIA semantics for certain elements.
+        While setting an ARIA `role` and/or `aria-*` attribute that matches the
+        <span>implicit ARIA semantics</span> is NOT RECOMMENDED, in some
+        situations explicitly setting these attributes can be helpful – for
+        instance, for user agents that do not expose implicit ARIA semantics
+        for certain elements.
       </p>
       <p class="note" id="dpub-usage-note">
-        While it is conforming to use [[[dpub-aria-1.0]]] `role` values as outlined in the following table, the use of these roles
-        is not intended for implementation of websites. If using these role for purposes beyond the scope of the digital publishing 
-        industry, further manual testing will be necessary to ensure the intended experience is provided to users.
+        While it is conforming to use [[[dpub-aria-1.0]]] `role` values as
+        outlined in the following table, the use of these roles is not intended
+        for implementation of websites. If using these role for purposes beyond
+        the scope of the digital publishing industry, further manual testing
+        will be necessary to ensure the intended experience is provided to
+        users.
       </p>
       <table class="data">
         <caption>
@@ -511,8 +629,8 @@
             </th>
             <th>
               <p id="implicit">
-                Implicit ARIA semantics
-                <small>(explicitly assigning these in markup is NOT RECOMMENDED)</small>
+                Implicit ARIA semantics <small>(explicitly assigning these in
+                markup is NOT RECOMMENDED)</small>
               </p>
             </th>
             <th>
@@ -530,36 +648,40 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-button">`button`</a>,
-                <a href="#index-aria-checkbox">`checkbox`</a>,
-                <a href="#index-aria-menuitem">`menuitem`</a>,
-                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
-                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                <a href="#index-aria-option">`option`</a>,
-                <a href="#index-aria-radio">`radio`</a>,
-                <a href="#index-aria-switch">`switch`</a>,
-                <a href="#index-aria-tab">`tab`</a>
-                or <a href="#index-aria-treeitem">`treeitem`</a>. (<code><a href="#index-aria-link">link</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-button">`button`</a>, <a href=
+                "#index-aria-checkbox">`checkbox`</a>, <a href=
+                "#index-aria-menuitem">`menuitem`</a>, <a href=
+                "#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>, <a href=
+                "#index-aria-menuitemradio">`menuitemradio`</a>, <a href=
+                "#index-aria-option">`option`</a>, <a href=
+                "#index-aria-radio">`radio`</a>, <a href=
+                "#index-aria-switch">`switch`</a>, <a href=
+                "#index-aria-tab">`tab`</a> or <a href=
+                "#index-aria-treeitem">`treeitem`</a>. (<code><a href=
+                "#index-aria-link">link</a></code> is also allowed, but NOT
+                RECOMMENDED.)
               </p>
               <p>
-                DPub Roles:
-                <a data-cite="dpub-aria-1.0#doc-backlink">`doc-backlink`</a>,
-                <a data-cite="dpub-aria-1.0#doc-biblioref">`doc-biblioref`</a>,
-                <a data-cite="dpub-aria-1.0#doc-glossref">`doc-glossref`</a>
-                or <a data-cite="dpub-aria-1.0#doc-noteref">`doc-noteref`</a>
+                DPub Roles: <a data-cite=
+                "dpub-aria-1.0#doc-backlink">`doc-backlink`</a>, <a data-cite=
+                "dpub-aria-1.0#doc-biblioref">`doc-biblioref`</a>,
+                <a data-cite="dpub-aria-1.0#doc-glossref">`doc-glossref`</a> or
+                <a data-cite="dpub-aria-1.0#doc-noteref">`doc-noteref`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
               <p>
-                It is NOT RECOMMENDED to use `aria-disabled="true"` on an
-                `a` element with an `href` attribute.
+                It is NOT RECOMMENDED to use `aria-disabled="true"` on an `a`
+                element with an `href` attribute.
               </p>
               <div class="note">
-                If a link needs to be programmatically communicated as "disabled", 
-                <a href="#example-communicate-a-disabled-link-with-aria">remove the `href` attribute</a>.
+                If a link needs to be programmatically communicated as
+                "disabled", <a href=
+                "#example-communicate-a-disabled-link-with-aria">remove the
+                `href` attribute</a>.
               </div>
             </td>
           </tr>
@@ -572,12 +694,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -592,9 +718,13 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -607,11 +737,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <a href="#index-aria-group">`group`</a> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <a href=
+                "#index-aria-group">`group`</a> is NOT RECOMMENDED.
               </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -624,11 +756,13 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-link">link</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-link">link</a></code>, which is NOT
+                RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the 
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
                 <a href="#index-aria-link">`link`</a> role.
               </p>
             </td>
@@ -643,14 +777,18 @@
             <td>
               <div class="addition">
                 <p>
-                  Roles:
-                  <a href="#index-aria-button">`button`</a>
-                  or <a href="#index-aria-link">`link`</a>. (<code><a href="#index-aria-generic">generic</a></code> is also allowed, but SHOULD NOT be used.)
+                  Roles: <a href="#index-aria-button">`button`</a> or <a href=
+                  "#index-aria-link">`link`</a>. (<code><a href=
+                  "#index-aria-generic">generic</a></code> is also allowed, but
+                  SHOULD NOT be used.)
                 </p>
-                <p><a>Naming Prohibited</a></p>
                 <p>
-                  Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                  and any `aria-*` attributes applicable to the allowed roles.
+                  <a>Naming Prohibited</a>
+                </p>
+                <p>
+                  Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                  `aria-*` attributes</a> and any `aria-*` attributes
+                  applicable to the allowed roles.
                 </p>
               </div>
             </td>
@@ -664,18 +802,20 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-application">`application`</a>,
-                <a href="#index-aria-document">`document`</a>,
-                <a href="#index-aria-feed">`feed`</a>,
-                <a href="#index-aria-main">`main`</a>,
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-region">`region`</a>. (<code><a href="#index-aria-article">article</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-document">`document`</a>, <a href=
+                "#index-aria-feed">`feed`</a>, <a href=
+                "#index-aria-main">`main`</a>, <a href=
+                "#index-aria-none">`none`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a> or <a href=
+                "#index-aria-region">`region`</a>. (<code><a href=
+                "#index-aria-article">article</a></code> is also allowed, but
+                NOT RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -684,30 +824,34 @@
               [^aside^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-complementary">complementary</a></code>
+              <code>role=<a href=
+              "#index-aria-complementary">complementary</a></code>
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-feed">`feed`</a>,
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-note">`note`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>,
-                <a href="#index-aria-region">`region`</a>
-                or <a href="#index-aria-search">`search`</a>. (<code><a href="#index-aria-complementary">complementary</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-feed">`feed`</a>, <a href=
+                "#index-aria-none">`none`</a>, <a href=
+                "#index-aria-note">`note`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a>, <a href=
+                "#index-aria-region">`region`</a> or <a href=
+                "#index-aria-search">`search`</a>. (<code><a href=
+                "#index-aria-complementary">complementary</a></code> is also
+                allowed, but NOT RECOMMENDED.)
               </p>
               <p>
-                DPub Roles:
-                <a data-cite="dpub-aria-1.0#doc-dedication">`doc-dedication`</a>,
+                DPub Roles: <a data-cite=
+                "dpub-aria-1.0#doc-dedication">`doc-dedication`</a>,
                 <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>,
                 <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>,
-                <span class="proposed addition"><a data-cite="dpub-aria-1.0#doc-glossary">`doc-glossary`</a>,</span>
+                <span class="proposed addition"><a data-cite=
+                "dpub-aria-1.0#doc-glossary">`doc-glossary`</a>,</span>
                 <a data-cite="dpub-aria-1.0#doc-pullquote">`doc-pullquote`</a>
                 or <a data-cite="dpub-aria-1.0#doc-tip">`doc-tip`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -720,12 +864,11 @@
             </td>
             <td>
               <p>
-                Role:
-                <a href="#index-aria-application">`application`</a>
+                Role: <a href="#index-aria-application">`application`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the 
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
                 <a href="#index-aria-application">`application`</a> role.
               </p>
             </td>
@@ -739,24 +882,28 @@
                 Role exposed from author defined {{ElementInternals}}
               </p>
               <p>
-                Otherwise <code>role=<a href="#index-aria-generic">generic</a></code>
+                Otherwise <code>role=<a href=
+                "#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
               <p>
-                If role defined by `ElementInternals`, 
-                <a><strong class="nosupport">no `role`</strong></a>
+                If role defined by `ElementInternals`, <a><strong class=
+                "nosupport">no `role`</strong></a>
               </p>
               <p>
-                Otherwise, <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                Otherwise, <a><strong>any `role`</strong></a>, though
+                <code><a href="#index-aria-generic">generic</a></code> SHOULD
+                NOT be used.
               </p>
               <p class="addition">
-                <a>Naming Prohibited</a> if exposed as the `generic` role, or if exposed
-                as another role which prohibits naming.
+                <a>Naming Prohibited</a> if exposed as the `generic` role, or
+                if exposed as another role which prohibits naming.
               </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -769,12 +916,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -787,7 +938,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -800,12 +952,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -818,12 +974,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -832,15 +992,19 @@
               [^blockquote^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-blockquote">`blockquote`</a></code>
+              <code>role=<a href=
+              "#index-aria-blockquote">`blockquote`</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-blockquote">`blockquote`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-blockquote">`blockquote`</a></code> is NOT
+                RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -853,14 +1017,18 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-generic">generic</a></code>, which SHOULD NOT be used.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-generic">generic</a></code>, which
+                SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                <span class="addition proposal">
-                  allowed for the `generic` role, with the exception that authors MUST NOT specify `aria-hidden=true` on the `body` element.
-                </span>
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> <span class="addition proposal">allowed
+                for the `generic` role, with the exception that authors MUST
+                NOT specify `aria-hidden=true` on the `body` element.</span>
               </p>
             </td>
           </tr>
@@ -873,13 +1041,13 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>
+                Roles: <a href="#index-aria-none">`none`</a> or <a href=
+                "#index-aria-presentation">`presentation`</a>
               </p>
               <p class="addition">
-                Authors MAY specify the <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on the `br` element.
-                Otherwise, no other allowed `aria-*` attributes.
+                Authors MAY specify the <a data-cite=
+                "wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on the
+                `br` element. Otherwise, no other allowed `aria-*` attributes.
               </p>
             </td>
           </tr>
@@ -892,27 +1060,31 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-checkbox">`checkbox`</a>,
-                <span class="addition"><a href="#index-aria-combobox">`combobox`</a></span>,
-                <span class="proposed addition"><a href="#index-aria-gridcell">`gridcell`</a></span>,
-                <a href="#index-aria-link">`link`</a>,
-                <a href="#index-aria-menuitem">`menuitem`</a>,
-                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
-                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                <a href="#index-aria-option">`option`</a>,
-                <a href="#index-aria-radio">`radio`</a>,
-                <span class="proposed addition">
-                  <a href="#index-aria-separator">`separator`</a>,
-                  <a href="#index-aria-slider">`slider`</a></span>,
-                <a href="#index-aria-switch">`switch`</a>,
-                <a href="#index-aria-tab">`tab`</a>,
-                or <span class="proposed addition"><a href="#index-aria-treeitem">`treeitem`</a></span>.
-                (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-checkbox">`checkbox`</a>,
+                <span class="addition"><a href=
+                "#index-aria-combobox">`combobox`</a></span>, <span class=
+                "proposed addition"><a href=
+                "#index-aria-gridcell">`gridcell`</a></span>, <a href=
+                "#index-aria-link">`link`</a>, <a href=
+                "#index-aria-menuitem">`menuitem`</a>, <a href=
+                "#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>, <a href=
+                "#index-aria-menuitemradio">`menuitemradio`</a>, <a href=
+                "#index-aria-option">`option`</a>, <a href=
+                "#index-aria-radio">`radio`</a>, <span class=
+                "proposed addition"><a href=
+                "#index-aria-separator">`separator`</a>, <a href=
+                "#index-aria-slider">`slider`</a></span>, <a href=
+                "#index-aria-switch">`switch`</a>, <a href=
+                "#index-aria-tab">`tab`</a>, or <span class=
+                "proposed addition"><a href=
+                "#index-aria-treeitem">`treeitem`</a></span>. (<code><a href=
+                "#index-aria-button">button</a></code> is also allowed, but NOT
+                RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -928,8 +1100,9 @@
                 <a><strong>Any `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -942,11 +1115,16 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-caption">`caption`</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-caption">`caption`</a></code>, which
+                is NOT RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
@@ -961,10 +1139,13 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -977,12 +1158,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-code">`code`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-code">`code`</a></code> is NOT RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -995,7 +1180,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -1008,7 +1194,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -1021,12 +1208,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1040,7 +1231,9 @@
             <td>
               <div class="correction">
                 <p>
-                  <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-listbox">listbox</a></code>, which is NOT RECOMMENDED.
+                  <a><strong class="nosupport">No `role`</strong></a> other
+                  than <code><a href="#index-aria-listbox">listbox</a></code>,
+                  which is NOT RECOMMENDED.
                 </p>
                 <p>
                   <strong>No `aria-*` attributes</strong>.
@@ -1060,8 +1253,9 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `definition` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `definition` role.
               </p>
             </td>
           </tr>
@@ -1074,12 +1268,17 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-deletion">`deletion`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-deletion">`deletion`</a></code> is NOT
+                RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1092,11 +1291,14 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-group">group</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-group">group</a></code>, which is
+                NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `group` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `group` role.
               </p>
             </td>
           </tr>
@@ -1109,11 +1311,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-term">term</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-term">term</a></code> is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1126,12 +1330,14 @@
             </td>
             <td>
               <p>
-                Role:
-                <a href="#index-aria-alertdialog">`alertdialog`</a>. (<code><a href="#index-aria-dialog">dialog</a></code> is also allowed, but NOT RECOMMENDED.)
+                Role: <a href="#index-aria-alertdialog">`alertdialog`</a>.
+                (<code><a href="#index-aria-dialog">dialog</a></code> is also
+                allowed, but NOT RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `dialog` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `dialog` role.
               </p>
             </td>
           </tr>
@@ -1144,15 +1350,19 @@
             </td>
             <td>
               <p class="addition">
-                If a direct child of a [^dl^] element,
-                only <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>. Otherwise,
-                <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                If a direct child of a [^dl^] element, only <a href=
+                "#index-aria-presentation">`presentation`</a> or <a href=
+                "#index-aria-none">`none`</a>. Otherwise, <a><strong>any
+                `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1165,15 +1375,15 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-list">`list`</a>,
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>
+                Roles: <a href="#index-aria-group">`group`</a>, <a href=
+                "#index-aria-list">`list`</a>, <a href=
+                "#index-aria-none">`none`</a> or <a href=
+                "#index-aria-presentation">`presentation`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1186,12 +1396,12 @@
             </td>
             <td>
               <p>
-                Role:
-                <a href="#index-aria-listitem">`listitem`</a>
+                Role: <a href="#index-aria-listitem">`listitem`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1204,12 +1414,17 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-emphasis">`emphasis`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-emphasis">`emphasis`</a></code> is NOT
+                RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1222,17 +1437,17 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-application">`application`</a>,
-                <a href="#index-aria-document">`document`</a>,
-                <a href="#index-aria-img">`img`</a>,
-                <a href="#index-aria-img">`image`</a>,
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                Roles: <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-document">`document`</a>, <a href=
+                "#index-aria-img">`img`</a>, <a href=
+                "#index-aria-img">`image`</a>, <a href=
+                "#index-aria-none">`none`</a> or <a href=
+                "#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1245,14 +1460,16 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-radiogroup">`radiogroup`</a>. (<code><a href="#index-aria-group">group</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-none">`none`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a> or <a href=
+                "#index-aria-radiogroup">`radiogroup`</a>. (<code><a href=
+                "#index-aria-group">group</a></code> is also allowed, but NOT
+                RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1265,15 +1482,17 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>
+                Roles: <a href="#index-aria-group">`group`</a>, <a href=
+                "#index-aria-none">`none`</a> or <a href=
+                "#index-aria-presentation">`presentation`</a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1286,23 +1505,24 @@
             </td>
             <td>
               <p>
-                If the `figure` has a valid `figcaption` descendant:
-                <br>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-figure">figure</a></code>, 
-                which is NOT RECOMMENDED.
+                If the `figure` has a valid `figcaption` descendant:<br>
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-figure">figure</a></code>, which is
+                NOT RECOMMENDED.
               </p>
               <p>
-                DPub Role:
-                <a data-cite="dpub-aria-1.0#doc-example">`doc-example`</a>.
+                DPub Role: <a data-cite=
+                "dpub-aria-1.0#doc-example">`doc-example`</a>.
               </p>
               <p>
-                Otherwise, if the `figure` has no `figcaption` descendant:
-                <br>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-figure">figure</a></code> is NOT RECOMMENDED.
+                Otherwise, if the `figure` has no `figcaption` descendant:<br>
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-figure">figure</a></code> is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1312,37 +1532,41 @@
             </th>
             <td>
               <p>
-                If not a descendant of an `article`, `aside`, `main`, `nav`
-                or `section` element, or an element with `role=article`, `complementary`,
-                `main`, `navigation` or `region`
-                then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
+                If not a descendant of an `article`, `aside`, `main`, `nav` or
+                `section` element, or an element with `role=article`,
+                `complementary`, `main`, `navigation` or `region` then
+                <code>role=<a href=
+                "#index-aria-contentinfo">contentinfo</a></code>
               </p>
               <p>
-                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
+                Otherwise, <code>role=<a href=
+                "#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-none">`none`</a>.
-                (If not a descendant of an `article`, `aside`, `main`, `nav`
-                or `section` element, or an element with `role=article`, `complementary`,
-                `main`, `navigation` or `region`,
-                then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
-                is also allowed, but NOT RECOMMENDED.
-                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
-                is also allowed, but SHOULD NOT be used.)
+                Roles: <a href="#index-aria-group">`group`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a> or <a href=
+                "#index-aria-none">`none`</a>. (If not a descendant of an
+                `article`, `aside`, `main`, `nav` or `section` element, or an
+                element with `role=article`, `complementary`, `main`,
+                `navigation` or `region`, then <code>role=<a href=
+                "#index-aria-contentinfo">contentinfo</a></code> is also
+                allowed, but NOT RECOMMENDED. Otherwise, <code>role=<a href=
+                "#index-aria-generic">generic</a></code> is also allowed, but
+                SHOULD NOT be used.)
               </p>
               <p>
-                DPub Role:
-                <a data-cite="dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
+                DPub Role: <a data-cite=
+                "dpub-aria-1.0#doc-footnote">`doc-footnote`</a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>
+              <p class="addition">
+                <a>Naming Prohibited</a> if exposed as `generic`.
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1357,17 +1581,21 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-search">`search`</a>. (<code><a href="#index-aria-form">form</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-none">`none`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a> or <a href=
+                "#index-aria-search">`search`</a>. (<code><a href=
+                "#index-aria-form">form</a></code> is also allowed, but NOT
+                RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
               <p class="note">
-                A `form` is not exposed as a landmark region unless it has been provided an <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>.
+                A `form` is not exposed as a landmark region unless it has been
+                provided an <a data-cite=
+                "accname-1.2/#dfn-accessible-name">accessible name</a>.
               </p>
             </td>
           </tr>
@@ -1380,42 +1608,48 @@
                 Role exposed from author defined {{ElementInternals}}
               </p>
               <p>
-                Otherwise <code>role=<a href="#index-aria-generic">generic</a></code>
+                Otherwise <code>role=<a href=
+                "#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
               <p>
-                If role defined by `ElementInternals`, 
-                <a><strong class="nosupport">no `role`</strong></a>
+                If role defined by `ElementInternals`, <a><strong class=
+                "nosupport">no `role`</strong></a>
               </p>
               <p>
-                Otherwise, form-related roles:
-                <a href="#index-aria-button">`button`</a>,
-                <a href="#index-aria-checkbox">`checkbox`</a>,
-                <a href="#index-aria-combobox">`combobox`</a>,
-                <a href="#index-aria-listbox">`listbox`</a>,
-                <a href="#index-aria-progressbar">`progressbar`</a>,
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-radio">`radio`</a>,
-                <a href="#index-aria-radiogroup">`radiogroup`</a>,
-                <a href="#index-aria-searchbox">`searchbox`</a>,
-                <a href="#index-aria-slider">`slider`</a>,
-                <a href="#index-aria-spinbutton">`spinbutton`</a>,
-                <a href="#index-aria-switch">`switch`</a>
-                or <a href="#index-aria-textbox">`textbox`</a>. (<code><a href="#index-aria-generic">generic</a></code> is also allowed, but SHOULD NOT be used.)
+                Otherwise, form-related roles: <a href=
+                "#index-aria-button">`button`</a>, <a href=
+                "#index-aria-checkbox">`checkbox`</a>, <a href=
+                "#index-aria-combobox">`combobox`</a>, <a href=
+                "#index-aria-listbox">`listbox`</a>, <a href=
+                "#index-aria-progressbar">`progressbar`</a>, <a href=
+                "#index-aria-group">`group`</a>, <a href=
+                "#index-aria-radio">`radio`</a>, <a href=
+                "#index-aria-radiogroup">`radiogroup`</a>, <a href=
+                "#index-aria-searchbox">`searchbox`</a>, <a href=
+                "#index-aria-slider">`slider`</a>, <a href=
+                "#index-aria-spinbutton">`spinbutton`</a>, <a href=
+                "#index-aria-switch">`switch`</a> or <a href=
+                "#index-aria-textbox">`textbox`</a>. (<code><a href=
+                "#index-aria-generic">generic</a></code> is also allowed, but
+                SHOULD NOT be used.)
               </p>
               <p class="addition">
                 <a>Naming Prohibited</a> if exposed as the `generic` role.
               </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-h1-h6" tabindex="-1">
-              <a data-cite="html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1 to h6`</a>
+              <a data-cite=
+              "html/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">`h1
+              to h6`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-heading">heading</a></code>,
@@ -1423,18 +1657,20 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>
-                or <a href="#index-aria-tab">`tab`</a>. (<code><a href="#index-aria-heading">heading</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-none">`none`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a> or <a href=
+                "#index-aria-tab">`tab`</a>. (<code><a href=
+                "#index-aria-heading">heading</a></code> is also allowed, but
+                NOT RECOMMENDED.)
               </p>
               <p>
-                DPub Role:
-                <a data-cite="dpub-aria-1.0#doc-subtitle">`doc-subtitle`</a>
+                DPub Role: <a data-cite=
+                "dpub-aria-1.0#doc-subtitle">`doc-subtitle`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1447,7 +1683,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -1457,33 +1694,36 @@
             </th>
             <td>
               <p>
-                If not a descendant of an `article`, `aside`, `main`,
-                `nav` or `section` element, or an element with `role=article`,
-                `complementary`, `main`, `navigation` or `region` then 
+                If not a descendant of an `article`, `aside`, `main`, `nav` or
+                `section` element, or an element with `role=article`,
+                `complementary`, `main`, `navigation` or `region` then
                 <code>role=<a href="#index-aria-banner">banner</a></code>
               </p>
               <p>
-                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
+                Otherwise, <code>role=<a href=
+                "#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
-                (If not a descendant of an `article`, `aside`, `main`, `nav`
-                or `section` element, or an element with `role=article`, `complementary`,
-                `main`, `navigation` or `region`,
-                then <code>role=<a href="#index-aria-banner">banner</a></code>
-                is also allowed, but NOT RECOMMENDED.
-                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
-                is also allowed, but SHOULD NOT be used.)
+                Roles: <a href="#index-aria-group">`group`</a>, <a href=
+                "#index-aria-none">`none`</a> or <a href=
+                "#index-aria-presentation">`presentation`</a>. (If not a
+                descendant of an `article`, `aside`, `main`, `nav` or `section`
+                element, or an element with `role=article`, `complementary`,
+                `main`, `navigation` or `region`, then <code>role=<a href=
+                "#index-aria-banner">banner</a></code> is also allowed, but NOT
+                RECOMMENDED. Otherwise, <code>role=<a href=
+                "#index-aria-generic">generic</a></code> is also allowed, but
+                SHOULD NOT be used.)
               </p>
-              <p class="addition"><a>Naming Prohibited</a> if exposed as `generic`.</p>
+              <p class="addition">
+                <a>Naming Prohibited</a> if exposed as `generic`.
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1496,11 +1736,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <a href="#index-aria-group">`group`</a> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <a href=
+                "#index-aria-group">`group`</a> is NOT RECOMMENDED.
               </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1513,17 +1755,19 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>. (<code><a href="#index-aria-separator">separator</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-none">`none`</a> or <a href=
+                "#index-aria-presentation">`presentation`</a>. (<code><a href=
+                "#index-aria-separator">separator</a></code> is also allowed,
+                but NOT RECOMMENDED.)
               </p>
               <p>
-                DPub Role:
-                <a data-cite="dpub-aria-1.0#doc-pagebreak">`doc-pagebreak`</a>
+                DPub Role: <a data-cite=
+                "dpub-aria-1.0#doc-pagebreak">`doc-pagebreak`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `separator` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `separator` role.
               </p>
             </td>
           </tr>
@@ -1536,7 +1780,9 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-document">document</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-document">document</a></code>, which
+                is NOT RECOMMENDED.
               </p>
               <p>
                 <strong>No `aria-*` attributes</strong>.
@@ -1552,12 +1798,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -1570,17 +1820,17 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-application">`application`</a>,
-                <a href="#index-aria-document">`document`</a>,
-                <a href="#index-aria-img">`img`</a>,
-                <a href="#index-aria-img">`image`</a>,
-                <a href="#index-aria-none">`none`</a>
-                or <a href="#index-aria-presentation">`presentation`</a>.
+                Roles: <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-document">`document`</a>, <a href=
+                "#index-aria-img">`img`</a>, <a href=
+                "#index-aria-img">`image`</a>, <a href=
+                "#index-aria-none">`none`</a> or <a href=
+                "#index-aria-presentation">`presentation`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1591,46 +1841,43 @@
               </div>
             </th>
             <td>
-              If the `img` has non-empty [^img/alt^] (`alt="some text"`) or an accessible name is provided by another 
-              <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming method</a>, 
-              or the `img` has no `alt` and has not been provided a name:<br>
+              If the `img` has non-empty [^img/alt^] (`alt="some text"`) or an
+              accessible name is provided by another <a data-cite=
+              "html-aam-1.0#img-element-accessible-name-computation">`img`
+              naming method</a>, or the `img` has no `alt` and has not been
+              provided a name:<br>
               <code>role=<a href="#index-aria-img">img or image</a></code>
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-button">`button`</a>,
-                <a href="#index-aria-checkbox">`checkbox`</a>,
-                <a href="#index-aria-link">`link`</a>,
-                <span class="correction">
-                  <a href="#index-aria-math">`math`</a>,
-                </span>
-                <a href="#index-aria-menuitem">`menuitem`</a>,
-                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
-                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                <span class="addition">
-                  <a href="#index-aria-meter">`meter`</a>,
-                </span>
-                <a href="#index-aria-option">`option`</a>,
-                <a href="#index-aria-progressbar">`progressbar`</a>,
-                <span class="correction">
-                  <a href="#index-aria-radio">`radio`</a>,
-                </span>
-                <a href="#index-aria-scrollbar">`scrollbar`</a>,
-                <a href="#index-aria-separator">`separator`</a>,
-                <a href="#index-aria-slider">`slider`</a>,
-                <a href="#index-aria-switch">`switch`</a>,
-                <a href="#index-aria-tab">`tab`</a> or
-                <a href="#index-aria-treeitem">`treeitem`</a>. 
-                (<code><a href="#index-aria-img">img or image</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-button">`button`</a>, <a href=
+                "#index-aria-checkbox">`checkbox`</a>, <a href=
+                "#index-aria-link">`link`</a>, <span class=
+                "correction"><a href="#index-aria-math">`math`</a>,</span>
+                <a href="#index-aria-menuitem">`menuitem`</a>, <a href=
+                "#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>, <a href=
+                "#index-aria-menuitemradio">`menuitemradio`</a>, <span class=
+                "addition"><a href="#index-aria-meter">`meter`</a>,</span>
+                <a href="#index-aria-option">`option`</a>, <a href=
+                "#index-aria-progressbar">`progressbar`</a>, <span class=
+                "correction"><a href="#index-aria-radio">`radio`</a>,</span>
+                <a href="#index-aria-scrollbar">`scrollbar`</a>, <a href=
+                "#index-aria-separator">`separator`</a>, <a href=
+                "#index-aria-slider">`slider`</a>, <a href=
+                "#index-aria-switch">`switch`</a>, <a href=
+                "#index-aria-tab">`tab`</a> or <a href=
+                "#index-aria-treeitem">`treeitem`</a>. (<code><a href=
+                "#index-aria-img">img or image</a></code> is also allowed, but
+                NOT RECOMMENDED.)
               </p>
               <p>
-                DPub Role:
-                <a data-cite="dpub-aria-1.0#doc-cover">`doc-cover`</a>
+                DPub Role: <a data-cite=
+                "dpub-aria-1.0#doc-cover">`doc-cover`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -1641,107 +1888,134 @@
             <td>
               <div class="proposed correction">
                 <p id="el-img-empty-alt">
-                  If the `img` has an empty `alt` ([^img/alt^]`=""`) and lacks any other 
-                  <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>:<br>
-                  <code>role=<a href="#index-aria-none">none</a></code>, 
-                  <code>role=<a href="#index-aria-presentation">presentation</a></code>
+                  If the `img` has an empty `alt` ([^img/alt^]`=""`) and lacks
+                  any other <a data-cite=
+                  "html-aam-1.0#img-element-accessible-name-computation">`img`
+                  naming methods</a>:<br>
+                  <code>role=<a href="#index-aria-none">none</a></code>,
+                  <code>role=<a href=
+                  "#index-aria-presentation">presentation</a></code>
                 </p>
                 <p id="el-img-no-alt" tabindex="-1">
-                  If the `img` <a data-cite="html/images.html#unknown-images">lacks an `alt` attribute</a> and lacks any other 
-                  <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>:<br>
+                  If the `img` <a data-cite=
+                  "html/images.html#unknown-images">lacks an `alt`
+                  attribute</a> and lacks any other <a data-cite=
+                  "html-aam-1.0#img-element-accessible-name-computation">`img`
+                  naming methods</a>:<br>
                   <code>role=<a href="#index-aria-img">img or image</a></code>
                 </p>
               </div>
             </td>
             <td>
               <div class="correction proposed">
-              <p>
-                If the `img` has no `alt` attribute or accessible name:
-                <a><strong class="nosupport">No `role`</strong></a> other than the  
-                <code>role=<a href="#index-aria-none">none</a></code> or <code><a href="#index-aria-presentation">presentation</a></code> roles.
-                (<code>role=<a href="#index-aria-img">img or image</a></code> is also allowed, but NOT RECOMMENDED.)
-              </p>
-              <p>
-                If the `img` has an empty `alt=""` attribute and no `aria-label` or `aria-labelledby` attributes to provide it an accessible name:
-                <a><strong class="nosupport">No `role`</strong></a> other than the <code>role=<a href="#index-aria-none">none</a></code> or
-                <code><a href="#index-aria-presentation">presentation</a></code> roles, which are NOT RECOMMENDED.
-              </p>
-              <p>
-                <strong>No `aria-*` attributes</strong>
-                except <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden="true"`</a>.
-              </p>
-              <p>
-                Otherwise, if the `img` has an author defined accessible name, 
-                see <a href="#el-img">`img` with an accessible name</a>.
-              </p>
+                <p>
+                  If the `img` has no `alt` attribute or accessible name:
+                  <a><strong class="nosupport">No `role`</strong></a> other
+                  than the <code>role=<a href=
+                  "#index-aria-none">none</a></code> or <code><a href=
+                  "#index-aria-presentation">presentation</a></code> roles.
+                  (<code>role=<a href="#index-aria-img">img or image</a></code>
+                  is also allowed, but NOT RECOMMENDED.)
+                </p>
+                <p>
+                  If the `img` has an empty `alt=""` attribute and no
+                  `aria-label` or `aria-labelledby` attributes to provide it an
+                  accessible name: <a><strong class="nosupport">No
+                  `role`</strong></a> other than the <code>role=<a href=
+                  "#index-aria-none">none</a></code> or <code><a href=
+                  "#index-aria-presentation">presentation</a></code> roles,
+                  which are NOT RECOMMENDED.
+                </p>
+                <p>
+                  <strong>No `aria-*` attributes</strong> except <a data-cite=
+                  "wai-aria-1.2#aria-hidden">`aria-hidden="true"`</a>.
+                </p>
+                <p>
+                  Otherwise, if the `img` has an author defined accessible
+                  name, see <a href="#el-img">`img` with an accessible
+                  name</a>.
+                </p>
               </div>
             </td>
           </tr>
           <tr>
             <th id="el-input-button" tabindex="-1">
-              <a data-cite="html/input.html#button-state-(type=button)">`input type=button`</a>
+              <a data-cite="html/input.html#button-state-(type=button)">`input
+              type=button`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
             </td>
             <td>
               <p>
-                Roles:
-                <span class="correction"><a href="#index-aria-checkbox">`checkbox`</a>,</span>
-                <span class="addition"><a href="#index-aria-combobox">`combobox`</a>,</span>
-                <span class="proposed addition"><a href="#index-aria-gridcell">`gridcell`</a>,</span>
-                <a href="#index-aria-link">`link`</a>,
-                <a href="#index-aria-menuitem">`menuitem`</a>,
-                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
-                <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                <a href="#index-aria-option">`option`</a>,
-                <a href="#index-aria-radio">`radio`</a>,
-                <span class="proposed addition">
-                  <a href="#index-aria-separator">`separator`</a>,
-                  <a href="#index-aria-slider">`slider`</a>,</span>
-                <a href="#index-aria-switch">`switch`</a>,
-                <a href="#index-aria-tab">`tab`</a>,
-                or <span class="addition proposed"><a href="#index-aria-treeitem">`treeitem`</a></span>. 
-                (<code><a href="#index-aria-button">button</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <span class="correction"><a href=
+                "#index-aria-checkbox">`checkbox`</a>,</span> <span class=
+                "addition"><a href=
+                "#index-aria-combobox">`combobox`</a>,</span> <span class=
+                "proposed addition"><a href=
+                "#index-aria-gridcell">`gridcell`</a>,</span> <a href=
+                "#index-aria-link">`link`</a>, <a href=
+                "#index-aria-menuitem">`menuitem`</a>, <a href=
+                "#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>, <a href=
+                "#index-aria-menuitemradio">`menuitemradio`</a>, <a href=
+                "#index-aria-option">`option`</a>, <a href=
+                "#index-aria-radio">`radio`</a>, <span class=
+                "proposed addition"><a href=
+                "#index-aria-separator">`separator`</a>, <a href=
+                "#index-aria-slider">`slider`</a>,</span> <a href=
+                "#index-aria-switch">`switch`</a>, <a href=
+                "#index-aria-tab">`tab`</a>, or <span class=
+                "addition proposed"><a href=
+                "#index-aria-treeitem">`treeitem`</a></span>. (<code><a href=
+                "#index-aria-button">button</a></code> is also allowed, but NOT
+                RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-checkbox" tabindex="-1">
-              <a data-cite="html/input.html#checkbox-state-(type=checkbox)">`input type=checkbox`</a>
+              <a data-cite=
+              "html/input.html#checkbox-state-(type=checkbox)">`input
+              type=checkbox`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-checkbox">checkbox</a></code>
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
-                <a href="#index-aria-option">`option`</a>
-                or <a href="#index-aria-switch">`switch`</a>;
-                <a href="#index-aria-button">`button` if used with `aria-pressed`</a>. (<code><a href="#index-aria-checkbox">checkbox</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href=
+                "#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>, <a href=
+                "#index-aria-option">`option`</a> or <a href=
+                "#index-aria-switch">`switch`</a>; <a href=
+                "#index-aria-button">`button` if used with `aria-pressed`</a>.
+                (<code><a href="#index-aria-checkbox">checkbox</a></code> is
+                also allowed, but NOT RECOMMENDED.)
               </p>
               <p class="correction">
-                Authors <a href="#att-checked">MUST NOT use the `aria-checked` attribute on `input type=checkbox` elements</a>.
+                Authors <a href="#att-checked">MUST NOT use the `aria-checked`
+                attribute on `input type=checkbox` elements</a>.
               </p>
               <p>
-                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
               <p class="note">
-                The HTML [^input/checked^] attribute can be used instead of
-                the `aria-checked` attribute for `menuitemcheckbox`, `option`
-                or `switch` roles when used on `type=checkbox`.
+                The HTML [^input/checked^] attribute can be used instead of the
+                `aria-checked` attribute for `menuitemcheckbox`, `option` or
+                `switch` roles when used on `type=checkbox`.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-color" tabindex="-1">
-              <a data-cite="html/input.html#color-state-(type=color)">`input type=color`</a>
+              <a data-cite="html/input.html#color-state-(type=color)">`input
+              type=color`</a>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -1751,13 +2025,15 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> and `aria-disabled` attribute.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and `aria-disabled` attribute.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-date" tabindex="-1">
-              <a data-cite="html/input.html#date-state-(type=date)">`input type=date`</a>
+              <a data-cite="html/input.html#date-state-(type=date)">`input
+              type=date`</a>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -1767,14 +2043,17 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-datetime-local" tabindex="-1">
-              <a data-cite="html/input.html#local-date-and-time-state-(type=datetime-local)">`input type=datetime-local`</a>
+              <a data-cite=
+              "html/input.html#local-date-and-time-state-(type=datetime-local)">
+              `input type=datetime-local`</a>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -1784,32 +2063,38 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-email" tabindex="-1">
-              <a data-cite="html/input.html#e-mail-state-(type=email)">`input type=email`</a>
-              with no [^input/list^] attribute
+              <a data-cite="html/input.html#e-mail-state-(type=email)">`input
+              type=email`</a> with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-textbox">textbox</a></code>, which
+                is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-file" tabindex="-1">
-              <a data-cite="html/input.html#file-upload-state-(type=file)">`input type=file`</a>
+              <a data-cite=
+              "html/input.html#file-upload-state-(type=file)">`input
+              type=file`</a>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -1819,27 +2104,32 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
-                `aria-disabled`, `aria-invalid` and `aria-required` attributes.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a>, `aria-disabled`, `aria-invalid` and
+                `aria-required` attributes.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-hidden" tabindex="-1">
-              <a data-cite="html/input.html#hidden-state-(type=hidden)">`input type=hidden`</a>
+              <a data-cite="html/input.html#hidden-state-(type=hidden)">`input
+              type=hidden`</a>
             </th>
             <td>
               <a>No corresponding role</a>
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-image" tabindex="-1">
-              <a data-cite="html/input.html#image-button-state-(type=image)">`input type=image`</a>
+              <a data-cite=
+              "html/input.html#image-button-state-(type=image)">`input
+              type=image`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
@@ -1848,35 +2138,38 @@
               <div class="proposed addition">
                 <p>
                   The following roles are allowed, but are NOT RECOMMENDED:
-                  <a href="#index-aria-button">`button`</a>,
-                  <a href="#index-aria-checkbox">`checkbox`</a>,
-                  <a href="#index-aria-gridcell">`gridcell`</a>,
-                  <a href="#index-aria-link">`link`</a>,
-                  <a href="#index-aria-menuitem">`menuitem`</a>,
-                  <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                  <a href="#index-aria-button">`button`</a>, <a href=
+                  "#index-aria-checkbox">`checkbox`</a>, <a href=
+                  "#index-aria-gridcell">`gridcell`</a>, <a href=
+                  "#index-aria-link">`link`</a>, <a href=
+                  "#index-aria-menuitem">`menuitem`</a>, <a href=
+                  "#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                   <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                  <a href="#index-aria-option">`option`</a>,
-                  <a href="#index-aria-radio">`radio`</a>,
-                  <a href="#index-aria-separator">`separator`</a>,
-                  <a href="#index-aria-slider">`slider`</a>,
-                  <a href="#index-aria-switch">`switch`</a>,
-                  <a href="#index-aria-tab">`tab`</a>
-                  or <a href="#index-aria-treeitem">`treeitem`</a>. 
+                  <a href="#index-aria-option">`option`</a>, <a href=
+                  "#index-aria-radio">`radio`</a>, <a href=
+                  "#index-aria-separator">`separator`</a>, <a href=
+                  "#index-aria-slider">`slider`</a>, <a href=
+                  "#index-aria-switch">`switch`</a>, <a href=
+                  "#index-aria-tab">`tab`</a> or <a href=
+                  "#index-aria-treeitem">`treeitem`</a>.
                 </p>
                 <p>
-                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                  and any `aria-*` attributes applicable to the allowed roles.
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                  attributes</a> and any `aria-*` attributes applicable to the
+                  allowed roles.
                 </p>
                 <p>
-                  If possible, authors SHOULD consider using a different HTML element which allows the specified role,
-                  such as the `button` element.
+                  If possible, authors SHOULD consider using a different HTML
+                  element which allows the specified role, such as the `button`
+                  element.
                 </p>
               </div>
             </td>
           </tr>
           <tr>
             <th id="el-input-month" tabindex="-1">
-              <a data-cite="html/input.html#month-state-(type=month)">`input type=month`</a>
+              <a data-cite="html/input.html#month-state-(type=month)">`input
+              type=month`</a>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -1886,31 +2179,38 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-number" tabindex="-1">
-              <a data-cite="html/input.html#number-state-(type=number)">`input type=number`</a>
+              <a data-cite="html/input.html#number-state-(type=number)">`input
+              type=number`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-spinbutton">spinbutton</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-spinbutton">spinbutton</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-spinbutton">spinbutton</a></code>,
+                which is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `spinbutton` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `spinbutton` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-password" tabindex="-1">
-              <a data-cite="html/input.html#password-state-(type=password)">`input type=password`</a>
+              <a data-cite=
+              "html/input.html#password-state-(type=password)">`input
+              type=password`</a>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -1920,63 +2220,75 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-radio" tabindex="-1">
-              <a data-cite="html/input.html#radio-button-state-(type=radio)">`input type=radio`</a>
+              <a data-cite=
+              "html/input.html#radio-button-state-(type=radio)">`input
+              type=radio`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-radio">radio</a></code>
             </td>
             <td>
               <p>
-                Role:
-                <a href="#index-aria-menuitemradio">`menuitemradio`</a>. (<code><a href="#index-aria-radio">radio</a></code> is also allowed, but NOT RECOMMENDED.)
+                Role: <a href="#index-aria-menuitemradio">`menuitemradio`</a>.
+                (<code><a href="#index-aria-radio">radio</a></code> is also
+                allowed, but NOT RECOMMENDED.)
               </p>
               <p class="correction">
-                Authors <a href="#att-checked">MUST NOT use the
-                `aria-checked` attribute on `input type=radio` elements</a>.
+                Authors <a href="#att-checked">MUST NOT use the `aria-checked`
+                attribute on `input type=radio` elements</a>.
               </p>
               <p>
-                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> and any `aria-*` attributes
-                applicable to the allowed roles.
+                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
               <p class="note">
-                The HTML [^input/checked^] attribute can be used instead of
-                the `aria-checked` attribute for the `menuitemradio` role
-                when used on `type=radio`.
+                The HTML [^input/checked^] attribute can be used instead of the
+                `aria-checked` attribute for the `menuitemradio` role when used
+                on `type=radio`.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-range" tabindex="-1">
-              <a data-cite="html/input.html#range-state-(type=range)">`input type=range`</a>
+              <a data-cite="html/input.html#range-state-(type=range)">`input
+              type=range`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-slider">slider</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-slider">slider</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-slider">slider</a></code>, which is
+                NOT RECOMMENDED.
               </p>
               <p>
-                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or 
-                <a href="#att-min">`aria-valuemin`</a> attributes on `input type=range`.
+                Authors SHOULD NOT use the <a href=
+                "#att-max">`aria-valuemax`</a> or <a href=
+                "#att-min">`aria-valuemin`</a> attributes on `input
+                type=range`.
               </p>
               <p>
-                Otherwise, any 
-                <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any other `aria-*` attributes applicable to the `slider` role.
+                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any other `aria-*` attributes
+                applicable to the `slider` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-reset" tabindex="-1">
-              <a data-cite="html/input.html#reset-button-state-(type=reset)">`input type=reset`</a>
+              <a data-cite=
+              "html/input.html#reset-button-state-(type=reset)">`input
+              type=reset`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
@@ -1985,54 +2297,62 @@
               <div class="proposed addition">
                 <p>
                   The following roles are allowed, but are NOT RECOMMENDED:
-                  <a href="#index-aria-button">`button`</a>,
-                  <a href="#index-aria-checkbox">`checkbox`</a>,
-                  <a href="#index-aria-combobox">`combobox`</a>,
-                  <a href="#index-aria-gridcell">`gridcell`</a>,
-                  <a href="#index-aria-link">`link`</a>,
-                  <a href="#index-aria-menuitem">`menuitem`</a>,
-                  <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                  <a href="#index-aria-button">`button`</a>, <a href=
+                  "#index-aria-checkbox">`checkbox`</a>, <a href=
+                  "#index-aria-combobox">`combobox`</a>, <a href=
+                  "#index-aria-gridcell">`gridcell`</a>, <a href=
+                  "#index-aria-link">`link`</a>, <a href=
+                  "#index-aria-menuitem">`menuitem`</a>, <a href=
+                  "#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                   <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                  <a href="#index-aria-option">`option`</a>,
-                  <a href="#index-aria-radio">`radio`</a>,
-                  <a href="#index-aria-separator">`separator`</a>,
-                  <a href="#index-aria-slider">`slider`</a>,
-                  <a href="#index-aria-switch">`switch`</a>,
-                  <a href="#index-aria-tab">`tab`</a>
-                  or <a href="#index-aria-treeitem">`treeitem`</a>.
+                  <a href="#index-aria-option">`option`</a>, <a href=
+                  "#index-aria-radio">`radio`</a>, <a href=
+                  "#index-aria-separator">`separator`</a>, <a href=
+                  "#index-aria-slider">`slider`</a>, <a href=
+                  "#index-aria-switch">`switch`</a>, <a href=
+                  "#index-aria-tab">`tab`</a> or <a href=
+                  "#index-aria-treeitem">`treeitem`</a>.
                 </p>
                 <p>
-                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                  and any `aria-*` attributes applicable to the allowed roles.
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                  attributes</a> and any `aria-*` attributes applicable to the
+                  allowed roles.
                 </p>
                 <p>
-                  If possible, authors SHOULD consider using a different HTML element which allows the specified role,
-                  such as the `button` element.
+                  If possible, authors SHOULD consider using a different HTML
+                  element which allows the specified role, such as the `button`
+                  element.
                 </p>
               </div>
             </td>
           </tr>
           <tr>
             <th id="el-input-search" tabindex="-1">
-              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=search`</a>,
-              with no [^input/list^] attribute
+              <a data-cite=
+              "html/input.html#text-(type=text)-state-and-search-state-(type=search)">
+              `input type=search`</a>, with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-searchbox">searchbox</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-searchbox">searchbox</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-searchbox">searchbox</a></code>,
+                which is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `searchbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `searchbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-submit" tabindex="-1">
-              <a data-cite="html/input.html#submit-button-state-(type=submit)">`input type=submit`</a>
+              <a data-cite=
+              "html/input.html#submit-button-state-(type=submit)">`input
+              type=submit`</a>
             </th>
             <td>
               <code>role=<a href="#index-aria-button">button</a></code>
@@ -2041,101 +2361,119 @@
               <div class="proposed addition">
                 <p>
                   The following roles are allowed, but are NOT RECOMMENDED:
-                  <a href="#index-aria-button">`button`</a>,
-                  <a href="#index-aria-checkbox">`checkbox`</a>,
-                  <a href="#index-aria-combobox">`combobox`</a>,
-                  <a href="#index-aria-gridcell">`gridcell`</a>,
-                  <a href="#index-aria-link">`link`</a>,
-                  <a href="#index-aria-menuitem">`menuitem`</a>,
-                  <a href="#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
+                  <a href="#index-aria-button">`button`</a>, <a href=
+                  "#index-aria-checkbox">`checkbox`</a>, <a href=
+                  "#index-aria-combobox">`combobox`</a>, <a href=
+                  "#index-aria-gridcell">`gridcell`</a>, <a href=
+                  "#index-aria-link">`link`</a>, <a href=
+                  "#index-aria-menuitem">`menuitem`</a>, <a href=
+                  "#index-aria-menuitemcheckbox">`menuitemcheckbox`</a>,
                   <a href="#index-aria-menuitemradio">`menuitemradio`</a>,
-                  <a href="#index-aria-option">`option`</a>,
-                  <a href="#index-aria-radio">`radio`</a>,
-                  <a href="#index-aria-separator">`separator`</a>,
-                  <a href="#index-aria-slider">`slider`</a>,
-                  <a href="#index-aria-switch">`switch`</a>,
-                  <a href="#index-aria-tab">`tab`</a>
-                  or <a href="#index-aria-treeitem">`treeitem`</a>.
+                  <a href="#index-aria-option">`option`</a>, <a href=
+                  "#index-aria-radio">`radio`</a>, <a href=
+                  "#index-aria-separator">`separator`</a>, <a href=
+                  "#index-aria-slider">`slider`</a>, <a href=
+                  "#index-aria-switch">`switch`</a>, <a href=
+                  "#index-aria-tab">`tab`</a> or <a href=
+                  "#index-aria-treeitem">`treeitem`</a>.
                 </p>
                 <p>
-                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                  and any `aria-*` attributes applicable to the allowed roles.
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                  attributes</a> and any `aria-*` attributes applicable to the
+                  allowed roles.
                 </p>
                 <p>
-                  If possible, authors SHOULD consider using a different HTML element which allows the specified role,
-                  such as the `button` element.
+                  If possible, authors SHOULD consider using a different HTML
+                  element which allows the specified role, such as the `button`
+                  element.
                 </p>
               </div>
             </td>
           </tr>
           <tr>
             <th id="el-input-tel" tabindex="-1">
-              <a data-cite="html/input.html#telephone-state-(type=tel)">`input type=tel`</a>, 
-              with no [^input/list^] attribute
+              <a data-cite="html/input.html#telephone-state-(type=tel)">`input
+              type=tel`</a>, with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-textbox">textbox</a></code>, which
+                is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-text" tabindex="-1">
-              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>
-              or with a missing or invalid `type`, with no [^input/list^] attribute
+              <a data-cite=
+              "html/input.html#text-(type=text)-state-and-search-state-(type=search)">
+              `input type=text`</a> or with a missing or invalid `type`, with
+              no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-combobox">`combobox`</a>,
-                <a href="#index-aria-searchbox">`searchbox`</a>
-                or <a href="#index-aria-spinbutton">`spinbutton`</a>. (<code><a href="#index-aria-textbox">textbox</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-combobox">`combobox`</a>, <a href=
+                "#index-aria-searchbox">`searchbox`</a> or <a href=
+                "#index-aria-spinbutton">`spinbutton`</a>. (<code><a href=
+                "#index-aria-textbox">textbox</a></code> is also allowed, but
+                NOT RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-text-list" tabindex="-1">
-              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`input type=text`</a>,
-              <a data-cite="html/input.html#text-(type=text)-state-and-search-state-(type=search)">`search`</a>,
-              <a data-cite="html/input.html#telephone-state-(type=tel)">`tel`</a>,
+              <a data-cite=
+              "html/input.html#text-(type=text)-state-and-search-state-(type=search)">
+              `input type=text`</a>, <a data-cite=
+              "html/input.html#text-(type=text)-state-and-search-state-(type=search)">
+              `search`</a>, <a data-cite=
+              "html/input.html#telephone-state-(type=tel)">`tel`</a>,
               <a data-cite="html/input.html#url-state-(type=url)">`url`</a>,
-              <a data-cite="html/input.html#e-mail-state-(type=email)">`email`</a>,
-              or with a missing or invalid `type`, <strong>with a [^input/list^] attribute</strong>
+              <a data-cite=
+              "html/input.html#e-mail-state-(type=email)">`email`</a>, or with
+              a missing or invalid `type`, <strong>with a [^input/list^]
+              attribute</strong>
             </th>
             <td>
               <code>role=<a href="#index-aria-combobox">combobox</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-combobox">combobox</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-combobox">combobox</a></code>, which
+                is NOT RECOMMENDED.
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-haspopup` attribute on the indicated `input`s with a `list` attribute.
+                Authors SHOULD NOT use the `aria-haspopup` attribute on the
+                indicated `input`s with a `list` attribute.
               </p>
               <p>
-                Otherwise, any
-                <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any other `aria-*` attributes applicable to the `combobox` role.
+                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any other `aria-*` attributes
+                applicable to the `combobox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-time" tabindex="-1">
-              <a data-cite="html/input.html#time-state-(type=time)">`input type=time`</a>
+              <a data-cite="html/input.html#time-state-(type=time)">`input
+              type=time`</a>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -2145,32 +2483,37 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-url" tabindex="-1">
-              <a data-cite="html/input.html#url-state-(type=url)">`input type=url`</a>
-              with no [^input/list^] attribute
+              <a data-cite="html/input.html#url-state-(type=url)">`input
+              type=url`</a> with no [^input/list^] attribute
             </th>
             <td>
               <code>role=<a href="#index-aria-textbox">textbox</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-textbox">textbox</a></code>, which
+                is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-input-week" tabindex="-1">
-              <a data-cite="html/input.html#week-state-(type=week)">`input type=week`</a>
+              <a data-cite="html/input.html#week-state-(type=week)">`input
+              type=week`</a>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -2180,8 +2523,9 @@
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
@@ -2194,12 +2538,17 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-insertion">`insertion`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-insertion">`insertion`</a></code> is NOT
+                RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2214,10 +2563,13 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2232,9 +2584,12 @@
               <p>
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
@@ -2249,9 +2604,12 @@
               <p>
                 <a><strong class="nosupport">No `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a>.
               </p>
             </td>
           </tr>
@@ -2261,37 +2619,48 @@
             </th>
             <td>
               <p>
-                If the `li` is a child of a list element 
-                (<a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, 
-                <a href="#el-menu">`menu`</a>)
-                <code>role=<a href="#index-aria-listitem">listitem</a></code>.
+                If the `li` is a child of a list element (<a href=
+                "#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, <a href=
+                "#el-menu">`menu`</a>) <code>role=<a href=
+                "#index-aria-listitem">listitem</a></code>.
               </p>
               <p>
-                Otherwise, if the `li` is not a child of a list element it is exposed as 
-                a <code>role=<a href="#index-aria-generic">generic</a></code>.
+                Otherwise, if the `li` is not a child of a list element it is
+                exposed as a <code>role=<a href=
+                "#index-aria-generic">generic</a></code>.
               </p>
             </td>
             <td>
               <div class="proposed correction">
                 <p>
-                  <strong class="nosupport"><a>No `role`</a></strong> other than <code><a href="#index-aria-listitem">listitem</a></code>, which is NOT RECOMMENDED,
-                  if the parent list element has an implicit or explicit `list` role.
+                  <strong class="nosupport"><a>No `role`</a></strong> other
+                  than <code><a href=
+                  "#index-aria-listitem">listitem</a></code>, which is NOT
+                  RECOMMENDED, if the parent list element has an implicit or
+                  explicit `list` role.
                 </p>
                 <p>
-                  Otherwise, <a><strong>any `role`</strong></a> if the parent list element does not expose an implicit or explicit `list` role.
+                  Otherwise, <a><strong>any `role`</strong></a> if the parent
+                  list element does not expose an implicit or explicit `list`
+                  role.
                 </p>
                 <p class="note">
                   See <a href="#el-ul">`ul`</a>, <a href="#el-ol">`ol`</a>, or
-                  <a href="#el-menu">`menu`</a> for allowed roles for list elements.
+                  <a href="#el-menu">`menu`</a> for allowed roles for list
+                  elements.
                 </p>
               </div>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
               <div class="addition proposal">
-                <p>Authors SHOULD NOT use the following <a href="#docconformance-deprecated">deprecated</a> DPub Roles:
-                  <a data-cite="dpub-aria-1.1#doc-biblioentry">`doc-biblioentry`</a>,
+                <p>
+                  Authors SHOULD NOT use the following <a href=
+                  "#docconformance-deprecated">deprecated</a> DPub Roles:
+                  <a data-cite=
+                  "dpub-aria-1.1#doc-biblioentry">`doc-biblioentry`</a>,
                   <a data-cite="dpub-aria-1.1#doc-endnote">`doc-endnote`</a>.
                 </p>
               </div>
@@ -2306,7 +2675,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -2319,11 +2689,14 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-main">main</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-main">main</a></code>, which is NOT
+                RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `main` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `main` role.
               </p>
             </td>
           </tr>
@@ -2336,7 +2709,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -2351,10 +2725,13 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2367,11 +2744,14 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-math">math</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-math">math</a></code>, which is NOT
+                RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `math` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `math` role.
               </p>
             </td>
           </tr>
@@ -2384,24 +2764,29 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-listbox">`listbox`</a>,
-                <a href="#index-aria-menu">`menu`</a>,
-                <a href="#index-aria-menubar">`menubar`</a>,
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>,
-                <a href="#index-aria-radiogroup">`radiogroup`</a>,
-                <a href="#index-aria-tablist">`tablist`</a>,
-                <a href="#index-aria-toolbar">`toolbar`</a>
-                or <a href="#index-aria-tree">`tree`</a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-group">`group`</a>, <a href=
+                "#index-aria-listbox">`listbox`</a>, <a href=
+                "#index-aria-menu">`menu`</a>, <a href=
+                "#index-aria-menubar">`menubar`</a>, <a href=
+                "#index-aria-none">`none`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a>, <a href=
+                "#index-aria-radiogroup">`radiogroup`</a>, <a href=
+                "#index-aria-tablist">`tablist`</a>, <a href=
+                "#index-aria-toolbar">`toolbar`</a> or <a href=
+                "#index-aria-tree">`tree`</a>. (<code><a href=
+                "#index-aria-list">list</a></code> is also allowed, but NOT
+                RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
               <div class="addition proposal">
-                <p>Authors SHOULD NOT use <a href="#docconformance-deprecated">deprecated</a> <a href="#index-aria-directory">`directory`</a> role.
+                <p>
+                  Authors SHOULD NOT use <a href=
+                  "#docconformance-deprecated">deprecated</a> <a href=
+                  "#index-aria-directory">`directory`</a> role.
                 </p>
               </div>
             </td>
@@ -2415,7 +2800,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -2428,16 +2814,19 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-meter">`meter`</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-meter">`meter`</a></code>, which is
+                NOT RECOMMENDED.
               </p>
               <p>
-                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> or 
-                <a href="#att-min">`aria-valuemin`</a> attributes on `meter` elements.
+                Authors SHOULD NOT use the <a href=
+                "#att-max">`aria-valuemax`</a> or <a href=
+                "#att-min">`aria-valuemin`</a> attributes on `meter` elements.
               </p>
               <p>
-                Otherwise, any 
-                <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>
-                and any other `aria-*` attributes applicable to the `meter` role.
+                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any other `aria-*` attributes
+                applicable to the `meter` role.
               </p>
             </td>
           </tr>
@@ -2450,22 +2839,24 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-menu">`menu`</a>,
-                <a href="#index-aria-menubar">`menubar`</a>,
-                <span class="addition"><a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a></span>
-                or <a href="#index-aria-tablist">`tablist`</a>. (<code><a href="#index-aria-navigation">navigation</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-menu">`menu`</a>, <a href=
+                "#index-aria-menubar">`menubar`</a>, <span class=
+                "addition"><a href="#index-aria-none">`none`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a></span> or
+                <a href="#index-aria-tablist">`tablist`</a>. (<code><a href=
+                "#index-aria-navigation">navigation</a></code> is also allowed,
+                but NOT RECOMMENDED.)
               </p>
               <p>
-                DPub Roles:
-                <a data-cite="dpub-aria-1.0#doc-index">`doc-index`</a>,
-                <a data-cite="dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a>
-                or <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>
+                DPub Roles: <a data-cite=
+                "dpub-aria-1.0#doc-index">`doc-index`</a>, <a data-cite=
+                "dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a> or
+                <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -2478,7 +2869,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -2491,15 +2883,15 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-application">`application`</a>,
-                <a href="#index-aria-document">`document`</a>,
-                <a href="#index-aria-img">`img`</a>
-                or <a href="#index-aria-img">`image`</a>.
+                Roles: <a href="#index-aria-application">`application`</a>,
+                <a href="#index-aria-document">`document`</a>, <a href=
+                "#index-aria-img">`img`</a> or <a href=
+                "#index-aria-img">`image`</a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> and
-                any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -2512,24 +2904,29 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-listbox">`listbox`</a>,
-                <a href="#index-aria-menu">`menu`</a>,
-                <a href="#index-aria-menubar">`menubar`</a>,
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>,
-                <a href="#index-aria-radiogroup">`radiogroup`</a>,
-                <a href="#index-aria-tablist">`tablist`</a>,
-                <a href="#index-aria-toolbar">`toolbar`</a>
-                or <a href="#index-aria-tree">`tree`</a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-group">`group`</a>, <a href=
+                "#index-aria-listbox">`listbox`</a>, <a href=
+                "#index-aria-menu">`menu`</a>, <a href=
+                "#index-aria-menubar">`menubar`</a>, <a href=
+                "#index-aria-none">`none`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a>, <a href=
+                "#index-aria-radiogroup">`radiogroup`</a>, <a href=
+                "#index-aria-tablist">`tablist`</a>, <a href=
+                "#index-aria-toolbar">`toolbar`</a> or <a href=
+                "#index-aria-tree">`tree`</a>. (<code><a href=
+                "#index-aria-list">list</a></code> is also allowed, but NOT
+                RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
               <div class="addition proposal">
-                <p>Authors SHOULD NOT use <a href="#docconformance-deprecated">deprecated</a> <a href="#index-aria-directory">`directory`</a> role.
+                <p>
+                  Authors SHOULD NOT use <a href=
+                  "#docconformance-deprecated">deprecated</a> <a href=
+                  "#index-aria-directory">`directory`</a> role.
                 </p>
               </div>
             </td>
@@ -2543,11 +2940,14 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-group">group</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-group">group</a></code>, which is
+                NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `group` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `group` role.
               </p>
             </td>
           </tr>
@@ -2562,14 +2962,18 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-option">option</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-option">option</a></code>, which is
+                NOT RECOMMENDED.
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-selected` attribute on the `option` element.
+                Authors SHOULD NOT use the `aria-selected` attribute on the
+                `option` element.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> and
-                any other `aria-*` attributes applicable to the `option` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any other `aria-*` attributes applicable to
+                the `option` role.
               </p>
             </td>
           </tr>
@@ -2582,11 +2986,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-status">status</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-status">status</a></code> is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -2599,12 +3005,17 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-paragraph">`paragraph`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-paragraph">`paragraph`</a></code> is NOT
+                RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2617,7 +3028,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -2634,8 +3046,10 @@
               </p>
               <div class="addition">
                 <p>
-                  Authors MAY specify the <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on the `picture` element.
-                  Otherwise, no other allowed `aria-*` attributes.
+                  Authors MAY specify the <a data-cite=
+                  "wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on the
+                  `picture` element. Otherwise, no other allowed `aria-*`
+                  attributes.
                 </p>
               </div>
             </td>
@@ -2649,12 +3063,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2663,20 +3081,24 @@
               [^progress^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-progressbar">progressbar</a></code>
+              <code>role=<a href=
+              "#index-aria-progressbar">progressbar</a></code>
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-progressbar">progressbar</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-progressbar">progressbar</a></code>,
+                which is NOT RECOMMENDED.
               </p>
               <p>
-                Authors SHOULD NOT use the <a href="#att-max">`aria-valuemax`</a> attribute 
-                on `progress` elements.
+                Authors SHOULD NOT use the <a href=
+                "#att-max">`aria-valuemax`</a> attribute on `progress`
+                elements.
               </p>
               <p>
-                Otherwise, 
-                any <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any other `aria-*` attributes applicable to the `progressbar` role.
+                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any other `aria-*` attributes
+                applicable to the `progressbar` role.
               </p>
             </td>
           </tr>
@@ -2689,12 +3111,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2709,10 +3135,13 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -2727,10 +3156,13 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2746,8 +3178,9 @@
                 <a><strong>Any `role`</strong></a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -2760,12 +3193,17 @@
             </td>
             <td>
               <p class="proposed addition">
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-deletion">`deletion`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-deletion">`deletion`</a></code> is NOT
+                RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2778,12 +3216,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2796,7 +3238,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -2812,17 +3255,18 @@
             <td>
               <div class="addition proposed">
                 <p>
-                  Roles:
-                  <a href="#index-aria-form">`form`</a>,
-                  <a href="#index-aria-group">`group`</a>,
-                  <a href="#index-aria-none">`none`</a>,
-                  <a href="#index-aria-presentation">`presentation`</a> or
-                  <a href="#index-aria-region">`region`</a>.
-                  (<code><a href="#index-aria-search">search</a></code> is also allowed, but NOT RECOMMENDED.)
+                  Roles: <a href="#index-aria-form">`form`</a>, <a href=
+                  "#index-aria-group">`group`</a>, <a href=
+                  "#index-aria-none">`none`</a>, <a href=
+                  "#index-aria-presentation">`presentation`</a> or <a href=
+                  "#index-aria-region">`region`</a>. (<code><a href=
+                  "#index-aria-search">search</a></code> is also allowed, but
+                  NOT RECOMMENDED.)
                 </p>
                 <p>
-                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                  and any `aria-*` attributes applicable to the allowed roles.
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                  attributes</a> and any `aria-*` attributes applicable to the
+                  allowed roles.
                 </p>
               </div>
             </td>
@@ -2833,53 +3277,57 @@
             </th>
             <td>
               <p>
-                <code>role=<a href="#index-aria-region">region</a></code> if the
-                [^section^] element has an 
-                <a data-cite="accname-1.2/#dfn-accessible-name">accessible name</a>
-              </p> 
+                <code>role=<a href="#index-aria-region">region</a></code> if
+                the [^section^] element has an <a data-cite=
+                "accname-1.2/#dfn-accessible-name">accessible name</a>
+              </p>
               <p>
-                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
+                Otherwise, <code>role=<a href=
+                "#index-aria-generic">generic</a></code>
               </p>
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-alert">`alert`</a>,
-                <a href="#index-aria-alertdialog">`alertdialog`</a>,
-                <a href="#index-aria-application">`application`</a>,
-                <a href="#index-aria-banner">`banner`</a>,
-                <a href="#index-aria-complementary">`complementary`</a>,
-                <a href="#index-aria-contentinfo">`contentinfo`</a>,
-                <a href="#index-aria-dialog">`dialog`</a>,
-                <a href="#index-aria-document">`document`</a>,
-                <a href="#index-aria-feed">`feed`</a>,
-                <span class="addition"><a href="#index-aria-group">`group`</a>,</span>
-                <a href="#index-aria-log">`log`</a>,
-                <a href="#index-aria-main">`main`</a>,
-                <a href="#index-aria-marquee">`marquee`</a>,
-                <a href="#index-aria-navigation">`navigation`</a>,
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-note">`note`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>,
-                <a href="#index-aria-search">`search`</a>,
-                <a href="#index-aria-status">`status`</a>
-                or <a href="#index-aria-tabpanel">`tabpanel`</a>.
-                (<code>role=<a href="#index-aria-region">region</a></code> is also allowed, 
-                but NOT RECOMMENDED. <code>role=<a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.)
+                Roles: <a href="#index-aria-alert">`alert`</a>, <a href=
+                "#index-aria-alertdialog">`alertdialog`</a>, <a href=
+                "#index-aria-application">`application`</a>, <a href=
+                "#index-aria-banner">`banner`</a>, <a href=
+                "#index-aria-complementary">`complementary`</a>, <a href=
+                "#index-aria-contentinfo">`contentinfo`</a>, <a href=
+                "#index-aria-dialog">`dialog`</a>, <a href=
+                "#index-aria-document">`document`</a>, <a href=
+                "#index-aria-feed">`feed`</a>, <span class="addition"><a href=
+                "#index-aria-group">`group`</a>,</span> <a href=
+                "#index-aria-log">`log`</a>, <a href=
+                "#index-aria-main">`main`</a>, <a href=
+                "#index-aria-marquee">`marquee`</a>, <a href=
+                "#index-aria-navigation">`navigation`</a>, <a href=
+                "#index-aria-none">`none`</a>, <a href=
+                "#index-aria-note">`note`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a>, <a href=
+                "#index-aria-search">`search`</a>, <a href=
+                "#index-aria-status">`status`</a> or <a href=
+                "#index-aria-tabpanel">`tabpanel`</a>. (<code>role=<a href=
+                "#index-aria-region">region</a></code> is also allowed, but NOT
+                RECOMMENDED. <code>role=<a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.)
               </p>
               <p>
-                DPub Roles:
-                <a data-cite="dpub-aria-1.0#doc-abstract">`doc-abstract`</a>,
-                <a data-cite="dpub-aria-1.0#doc-acknowledgments">`doc-acknowledgments`</a>,
+                DPub Roles: <a data-cite=
+                "dpub-aria-1.0#doc-abstract">`doc-abstract`</a>, <a data-cite=
+                "dpub-aria-1.0#doc-acknowledgments">`doc-acknowledgments`</a>,
                 <a data-cite="dpub-aria-1.0#doc-afterword">`doc-afterword`</a>,
                 <a data-cite="dpub-aria-1.0#doc-appendix">`doc-appendix`</a>,
-                <a data-cite="dpub-aria-1.0#doc-bibliography">`doc-bibliography`</a>,
+                <a data-cite=
+                "dpub-aria-1.0#doc-bibliography">`doc-bibliography`</a>,
                 <a data-cite="dpub-aria-1.0#doc-chapter">`doc-chapter`</a>,
                 <a data-cite="dpub-aria-1.0#doc-colophon">`doc-colophon`</a>,
-                <a data-cite="dpub-aria-1.0#doc-conclusion">`doc-conclusion`</a>,
+                <a data-cite=
+                "dpub-aria-1.0#doc-conclusion">`doc-conclusion`</a>,
                 <a data-cite="dpub-aria-1.0#doc-credit">`doc-credit`</a>,
                 <a data-cite="dpub-aria-1.0#doc-credits">`doc-credits`</a>,
-                <a data-cite="dpub-aria-1.0#doc-dedication">`doc-dedication`</a>,
+                <a data-cite=
+                "dpub-aria-1.0#doc-dedication">`doc-dedication`</a>,
                 <a data-cite="dpub-aria-1.0#doc-endnotes">`doc-endnotes`</a>,
                 <a data-cite="dpub-aria-1.0#doc-epigraph">`doc-epigraph`</a>,
                 <a data-cite="dpub-aria-1.0#doc-epilogue">`doc-epilogue`</a>,
@@ -2888,7 +3336,8 @@
                 <a data-cite="dpub-aria-1.0#doc-foreword">`doc-foreword`</a>,
                 <a data-cite="dpub-aria-1.0#doc-glossary">`doc-glossary`</a>,
                 <a data-cite="dpub-aria-1.0#doc-index">`doc-index`</a>,
-                <a data-cite="dpub-aria-1.0#doc-introduction">`doc-introduction`</a>,
+                <a data-cite=
+                "dpub-aria-1.0#doc-introduction">`doc-introduction`</a>,
                 <a data-cite="dpub-aria-1.0#doc-notice">`doc-notice`</a>,
                 <a data-cite="dpub-aria-1.0#doc-pagelist">`doc-pagelist`</a>,
                 <a data-cite="dpub-aria-1.0#doc-part">`doc-part`</a>,
@@ -2899,30 +3348,34 @@
                 <a data-cite="dpub-aria-1.0#doc-toc">`doc-toc`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
           <tr>
             <th id="el-select" tabindex="-1">
-              [^select^] (with NO `multiple` attribute and NO `size`
-              attribute having value greater than `1`)
+              [^select^] (with NO `multiple` attribute and NO `size` attribute
+              having value greater than `1`)
             </th>
             <td>
               <code>role=<a href="#index-aria-combobox">combobox</a></code>
             </td>
             <td>
               <p>
-                Role: <a href="#index-aria-menu">`menu`</a>. (<code><a href="#index-aria-combobox">combobox</a></code> is also allowed, but NOT RECOMMENDED.)
+                Role: <a href="#index-aria-menu">`menu`</a>. (<code><a href=
+                "#index-aria-combobox">combobox</a></code> is also allowed, but
+                NOT RECOMMENDED.)
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.
+                Authors SHOULD NOT use the `aria-multiselectable` attribute on
+                a `select` element.
               </p>
               <p>
-                Otherwise, 
-                any <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any other `aria-*` attributes applicable to the `combobox` or `menu` role.
+                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any other `aria-*` attributes
+                applicable to the `combobox` or `menu` role.
               </p>
             </td>
           </tr>
@@ -2936,15 +3389,18 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-list">listbox</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-list">listbox</a></code>, which is
+                NOT RECOMMENDED.
               </p>
               <p>
-                Authors SHOULD NOT use the `aria-multiselectable` attribute on a `select` element.
+                Authors SHOULD NOT use the `aria-multiselectable` attribute on
+                a `select` element.
               </p>
               <p>
-                Otherwise, 
-                any <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any other `aria-*` attributes applicable to the `listbox` role.
+                Otherwise, any <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any other `aria-*` attributes
+                applicable to the `listbox` role.
               </p>
             </td>
           </tr>
@@ -2957,7 +3413,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -2970,12 +3427,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -2988,7 +3449,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -3001,12 +3463,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -3019,12 +3485,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-strong">`strong`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-strong">`strong`</a></code> is NOT RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -3037,7 +3507,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -3050,12 +3521,17 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-subscript">`subscript`</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-subscript">`subscript`</a></code> is NOT
+                RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -3071,19 +3547,23 @@
             <td>
               <div class="proposed correction">
                 <p>
-                  <a><strong class="nosupport">No `role`</strong></a> if the `summary` element is a 
-                  <a data-cite="html/interactive-elements.html#summary-for-its-parent-details">summary for its parent details</a>.
+                  <a><strong class="nosupport">No `role`</strong></a> if the
+                  `summary` element is a <a data-cite=
+                  "html/interactive-elements.html#summary-for-its-parent-details">
+                  summary for its parent details</a>.
                 </p>
                 <p>
-                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
-                  `aria-disabled`, and `aria-haspopup` attributes.
+                  <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                  attributes</a>, `aria-disabled`, and `aria-haspopup`
+                  attributes.
                 </p>
                 <p>
-                  Otherwise, authors MAY specifiy <a><strong>Any `role`</strong></a>, and any 
-                  <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
+                  Otherwise, authors MAY specifiy <a><strong>Any
+                  `role`</strong></a>, and any <a data-cite=
+                  "wai-aria-1.2#global_states">global `aria-*` attributes</a>
                   and any `aria-*` attributes applicable to the allowed roles.
                 </p>
-               </div>
+              </div>
             </td>
           </tr>
           <tr>
@@ -3091,16 +3571,22 @@
               [^sup^]
             </th>
             <td>
-              <code>role=<a href="#index-aria-superscript">superscript</a></code>
+              <code>role=<a href=
+              "#index-aria-superscript">superscript</a></code>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-superscript">superscript</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-superscript">superscript</a></code> is NOT
+                RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -3109,16 +3595,18 @@
               <a data-cite="html/embedded-content-other.html#svg-0">`SVG`</a>
             </th>
             <td>
-              `role=graphics-document` as defined by
-              <a data-cite="svg-aam-1.0/#details-id-66">SVG AAM</a>
+              `role=graphics-document` as defined by <a data-cite=
+              "svg-aam-1.0/#details-id-66">SVG AAM</a>
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though `graphics-document` is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though `graphics-document`
+                is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -3131,11 +3619,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-table">table</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-table">table</a></code> is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -3148,11 +3638,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -3162,40 +3654,46 @@
             </th>
             <td>
               <p>
-                <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
-                `table` element is exposed as a `role=table`
+                <code>role=<a href="#index-aria-cell">cell</a></code> if the
+                ancestor `table` element is exposed as a `role=table`
               </p>
               <p>
-                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
-                `table` element is exposed as a `role=grid` or `treegrid`
+                <code>role=<a href="#index-aria-gridcell">gridcell</a></code>
+                if the ancestor `table` element is exposed as a `role=grid` or
+                `treegrid`
               </p>
               <p>
-                <a>No corresponding role</a> if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`
+                <a>No corresponding role</a> if the ancestor `table` element is
+                not exposed as a `role=table`, `grid` or `treegrid`
               </p>
             </td>
             <td>
               <p>
-                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
-                <a><strong class="nosupport">no `role`</strong></a>
+                If the ancestor `table` element has `role=table`, `grid`, or
+                `treegrid`, <a><strong class="nosupport">no `role`</strong></a>
                 other than the following:
               </p>
               <ul>
-                <li>If the ancestor `table` element is exposed as a `role=table`, then
-                <code><a href="#index-aria-cell">cell</a></code>
-                is allowed, but NOT RECOMMENDED.</li>
-                <li>If the ancestor `table` element is exposed as a `role=grid` or `treegrid`, then
-                <code><a href="#index-aria-gridcell">gridcell</a></code>
-                is allowed, but NOT RECOMMENDED.</li>
+                <li>If the ancestor `table` element is exposed as a
+                `role=table`, then <code><a href=
+                "#index-aria-cell">cell</a></code> is allowed, but NOT
+                RECOMMENDED.
+                </li>
+                <li>If the ancestor `table` element is exposed as a `role=grid`
+                or `treegrid`, then <code><a href=
+                "#index-aria-gridcell">gridcell</a></code> is allowed, but NOT
+                RECOMMENDED.
+                </li>
               </ul>
               <p>
-                Otherwise, if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`,
-                <a><strong>any `role`</strong></a>.
+                Otherwise, if the ancestor `table` element is not exposed as a
+                `role=table`, `grid` or `treegrid`, <a><strong>any
+                `role`</strong></a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -3208,7 +3706,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -3221,11 +3720,14 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is NOT RECOMMENDED.
+                <a><strong class="nosupport">No `role`</strong></a> other than
+                <code><a href="#index-aria-textbox">textbox</a></code>, which
+                is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `textbox` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `textbox` role.
               </p>
             </td>
           </tr>
@@ -3238,11 +3740,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -3252,52 +3756,55 @@
             </th>
             <td>
               <p>
-                <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or 
-                <a href="#index-aria-rowheader">`cell`</a> if the ancestor
-                `table` element is exposed as a `role=table`
+                <code>role=<a href=
+                "#index-aria-columnheader">columnheader</a></code>, <a href=
+                "#index-aria-rowheader">`rowheader`</a> or <a href=
+                "#index-aria-rowheader">`cell`</a> if the ancestor `table`
+                element is exposed as a `role=table`
               </p>
               <p>
-                <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or 
-                <a href="#index-aria-rowheader">`gridcell`</a> if the ancestor
-                `table` element is exposed as a `role=grid` or `treegrid`
-             </p>
+                <code>role=<a href=
+                "#index-aria-columnheader">columnheader</a></code>, <a href=
+                "#index-aria-rowheader">`rowheader`</a> or <a href=
+                "#index-aria-rowheader">`gridcell`</a> if the ancestor `table`
+                element is exposed as a `role=grid` or `treegrid`
+              </p>
               <p>
-                <a>No corresponding role</a> if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`
+                <a>No corresponding role</a> if the ancestor `table` element is
+                not exposed as a `role=table`, `grid` or `treegrid`
               </p>
             </td>
             <td>
               <p>
-                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
-                <a><strong class="nosupport">no `role`</strong></a>
+                If the ancestor `table` element has `role=table`, `grid`, or
+                `treegrid`, <a><strong class="nosupport">no `role`</strong></a>
                 other than the following:
               </p>
               <ul>
-                <li>
-                If the ancestor `table` element is exposed as a `role=table`, then
-                <code><a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> and
-                <a href="#index-aria-rowheader">`cell`</a>
-                are allowed, but NOT RECOMMENDED.
+                <li>If the ancestor `table` element is exposed as a
+                `role=table`, then <code><a href=
+                "#index-aria-columnheader">columnheader</a></code>, <a href=
+                "#index-aria-rowheader">`rowheader`</a> and <a href=
+                "#index-aria-rowheader">`cell`</a> are allowed, but NOT
+                RECOMMENDED.
                 </li>
-                <li>
-                If the ancestor `table` element is exposed as a `role=grid` or `treegrid`, then
-                <code><a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or
-                <a href="#index-aria-rowheader">`gridcell`</a>
-                are allowed, but NOT RECOMMENDED.
+                <li>If the ancestor `table` element is exposed as a `role=grid`
+                or `treegrid`, then <code><a href=
+                "#index-aria-columnheader">columnheader</a></code>, <a href=
+                "#index-aria-rowheader">`rowheader`</a> or <a href=
+                "#index-aria-rowheader">`gridcell`</a> are allowed, but NOT
+                RECOMMENDED.
                 </li>
               </ul>
               <p>
-                Otherwise, if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`,
-                <a><strong>any `role`</strong></a>.
+                Otherwise, if the ancestor `table` element is not exposed as a
+                `role=table`, `grid` or `treegrid`, <a><strong>any
+                `role`</strong></a>.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -3310,11 +3817,13 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-rowgroup">rowgroup</a></code> is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -3327,12 +3836,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-time">time</a></code> is NOT RECOMMENDED.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-time">time</a></code> is NOT RECOMMENDED.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -3345,7 +3858,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -3358,14 +3872,17 @@
             </td>
             <td>
               <p>
-                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
-                <a><strong class="nosupport">no `role`</strong></a> other than <code><a href="#index-aria-row">row</a></code>, which is NOT RECOMMENDED;
-                otherwise
-                <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-row">row</a></code> is NOT RECOMMENDED.
+                If the ancestor `table` element has `role=table`, `grid`, or
+                `treegrid`, <a><strong class="nosupport">no `role`</strong></a>
+                other than <code><a href="#index-aria-row">row</a></code>,
+                which is NOT RECOMMENDED; otherwise <a><strong>any
+                `role`</strong></a>, though <code><a href=
+                "#index-aria-row">row</a></code> is NOT RECOMMENDED.
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
             </td>
           </tr>
@@ -3378,7 +3895,8 @@
             </td>
             <td>
               <p>
-                <strong class="nosupport"><a>No `role`</a> or `aria-*` attributes</strong>
+                <strong class="nosupport"><a>No `role`</a> or `aria-*`
+                attributes</strong>
               </p>
             </td>
           </tr>
@@ -3391,12 +3909,16 @@
             </td>
             <td>
               <p>
-                <a><strong>Any `role`</strong></a>, though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+                <a><strong>Any `role`</strong></a>, though <code><a href=
+                "#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -3409,26 +3931,29 @@
             </td>
             <td>
               <p>
-                Roles:
-                <a href="#index-aria-group">`group`</a>,
-                <a href="#index-aria-listbox">`listbox`</a>,
-                <a href="#index-aria-menu">`menu`</a>,
-                <a href="#index-aria-menubar">`menubar`</a>,
-                <a href="#index-aria-none">`none`</a>,
-                <a href="#index-aria-presentation">`presentation`</a>,
-                <a href="#index-aria-radiogroup">`radiogroup`</a>,
-                <a href="#index-aria-tablist">`tablist`</a>,
-                <a href="#index-aria-toolbar">`toolbar`</a>
-                or <a href="#index-aria-tree">`tree`</a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but NOT RECOMMENDED.)
+                Roles: <a href="#index-aria-group">`group`</a>, <a href=
+                "#index-aria-listbox">`listbox`</a>, <a href=
+                "#index-aria-menu">`menu`</a>, <a href=
+                "#index-aria-menubar">`menubar`</a>, <a href=
+                "#index-aria-none">`none`</a>, <a href=
+                "#index-aria-presentation">`presentation`</a>, <a href=
+                "#index-aria-radiogroup">`radiogroup`</a>, <a href=
+                "#index-aria-tablist">`tablist`</a>, <a href=
+                "#index-aria-toolbar">`toolbar`</a> or <a href=
+                "#index-aria-tree">`tree`</a>. (<code><a href=
+                "#index-aria-list">list</a></code> is also allowed, but NOT
+                RECOMMENDED.)
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                allowed roles.
               </p>
               <div class="addition proposal">
                 <p>
-                  Authors SHOULD NOT use the <a href="#docconformance-deprecated">deprecated</a> 
-                  <a href="#index-aria-directory">`directory`</a> role.
+                  Authors SHOULD NOT use the <a href=
+                  "#docconformance-deprecated">deprecated</a> <a href=
+                  "#index-aria-directory">`directory`</a> role.
                 </p>
               </div>
             </td>
@@ -3444,10 +3969,13 @@
               <p>
                 <a><strong>Any `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p class="addition">
+                <a>Naming Prohibited</a>
+              </p>
               <p>
-                Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the allowed roles.
+                Otherwise, <a data-cite="wai-aria-1.2#global_states">global
+                `aria-*` attributes</a> and any `aria-*` attributes applicable
+                to the allowed roles.
               </p>
             </td>
           </tr>
@@ -3463,8 +3991,9 @@
                 Role: <a href="#index-aria-application">`application`</a>
               </p>
               <p>
-                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
-                and any `aria-*` attributes applicable to the `application` role.
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*`
+                attributes</a> and any `aria-*` attributes applicable to the
+                `application` role.
               </p>
             </td>
           </tr>
@@ -3478,28 +4007,29 @@
             <td>
               <div class="correction">
                 <p>
-                  Roles:
-                  <a href="#index-aria-none">`none`</a>
-                  or <a href="#index-aria-presentation">`presentation`</a>
+                  Roles: <a href="#index-aria-none">`none`</a> or <a href=
+                  "#index-aria-presentation">`presentation`</a>
                 </p>
                 <p>
-                  Authors MAY specify the <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on the `wbr` element.
-                  Otherwise, no other allowed `aria-*` attributes.
+                  Authors MAY specify the <a data-cite=
+                  "wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on the
+                  `wbr` element. Otherwise, no other allowed `aria-*`
+                  attributes.
                 </p>
               </div>
             </td>
           </tr>
         </tbody>
       </table>
-
       <p>
-        The elements marked with <dfn>No corresponding role</dfn>, in the second column of 
-        the table do not have any <a>implicit ARIA semantics</a>, but they do have meaning 
-        and this meaning may be represented in roles, states and properties not provided 
-        by ARIA, and exposed to users of assistive technology via accessibility APIs. 
-        It is therefore recommended that authors add a `role` attribute to a semantically 
-        neutral element such as a [^div^] or [^span^], rather than overriding the semantics 
-        of the listed elements.
+        The elements marked with <dfn>No corresponding role</dfn>, in the
+        second column of the table do not have any <a>implicit ARIA
+        semantics</a>, but they do have meaning and this meaning may be
+        represented in roles, states and properties not provided by ARIA, and
+        exposed to users of assistive technology via accessibility APIs. It is
+        therefore recommended that authors add a `role` attribute to a
+        semantically neutral element such as a [^div^] or [^span^], rather than
+        overriding the semantics of the listed elements.
       </p>
       <div class="note">
         <p>
@@ -3507,12 +4037,12 @@
           guidance on using ARIA in HTML beyond that which is provided here:
         </p>
         <ul>
-          <li>[[[using-aria]]] - A practical guide for authors on how to
-          add accessibility information to HTML elements using the Accessible
-          Rich Internet Applications specification.
+          <li>[[[using-aria]]] - A practical guide for authors on how to add
+          accessibility information to HTML elements using the Accessible Rich
+          Internet Applications specification.
           </li>
-          <li>[[[wai-aria-practices-1.2]]] - An author's guide to
-            understanding and implementing Accessible Rich Internet Applications.
+          <li>[[[wai-aria-practices-1.2]]] - An author's guide to understanding
+          and implementing Accessible Rich Internet Applications.
           </li>
         </ul>
       </div>
@@ -3547,58 +4077,85 @@
       </aside>
       <section class="addition">
         <h3 id="docconformance-naming">
-          Requirements for use of ARIA attributes to name <!-- and describe --> elements
-        </h3>
-        <!-- <section>
+          Requirements for use of ARIA attributes to name <!-- and describe -->
+          elements
+        </h3><!-- <section>
           <h4>Elements with implicit ARIA roles which prohibit naming</h4> -->
-          <p>
-            Authors MAY use <a data-cite="wai-aria-1.2/#aria-label">`aria-label`</a> and <a data-cite="wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attributes to specify <a data-cite="accname-1.2/#dfn-accessible-name">accessible names</a> for elements which have an implicit or explicit ARIA role which allows naming from authors. [[[wai-aria-1.2]]] defines <a data-cite="wai-aria-1.2/#namefromauthor">roles which allow naming from authors</a> as well as <a data-cite="wai-aria-1.2/#namefromprohibited">roles where author naming is prohibited</a>.
-          </p>
-          <p>
-            Authors MUST NOT specify `aria-label` or `aria-labelledby` on elements with implicit WAI-ARIA roles which cannot be named. HTML elements whose implicit WAI-ARIA roles prohibit naming from authors are identified in [[[#docconformance]]].
-          </p>
-          <p>
-            The following markup example demonstrates a selection of HTML elements with implicit ARIA roles that prohibit naming from authors.
-          </p>
-          <pre class="HTML example" title="Elements with implicit ARIA roles which prohibit naming from authors">
-            &lt;!-- DO NOT do the following! -->
-            &lt;p aria-label="...">...&lt;/p>
+        <p>
+          Authors MAY use <a data-cite=
+          "wai-aria-1.2/#aria-label">`aria-label`</a> and <a data-cite=
+          "wai-aria-1.2/#aria-labelledby">`aria-labelledby`</a> attributes to
+          specify <a data-cite="accname-1.2/#dfn-accessible-name">accessible
+          names</a> for elements which have an implicit or explicit ARIA role
+          which allows naming from authors. [[[wai-aria-1.2]]] defines
+          <a data-cite="wai-aria-1.2/#namefromauthor">roles which allow naming
+          from authors</a> as well as <a data-cite=
+          "wai-aria-1.2/#namefromprohibited">roles where author naming is
+          prohibited</a>.
+        </p>
+        <p>
+          Authors MUST NOT specify `aria-label` or `aria-labelledby` on
+          elements with implicit WAI-ARIA roles which cannot be named. HTML
+          elements whose implicit WAI-ARIA roles prohibit naming from authors
+          are identified in [[[#docconformance]]].
+        </p>
+        <p>
+          The following markup example demonstrates a selection of HTML
+          elements with implicit ARIA roles that prohibit naming from authors.
+        </p>
+        <pre class="HTML example" title=
+        "Elements with implicit ARIA roles which prohibit naming from authors">
+            &lt;!-- DO NOT do the following! --&gt;
+            &lt;p aria-label="..."&gt;...&lt;/p&gt;
 
-            &lt;span aria-label="...">...&lt;span>
+            &lt;span aria-label="..."&gt;...&lt;span&gt;
 
-            &lt;code aria-label="...">...&lt;code>
+            &lt;code aria-label="..."&gt;...&lt;code&gt;
 
-            &lt;div aria-labelledby="...">...&lt;/div>
+            &lt;div aria-labelledby="..."&gt;...&lt;/div&gt;
           </pre>
-          <p>
-            The following markup example demonstrates elements which have explicit WAI-ARIA roles which allow naming from authors. Due to the explicit roles specified on these elements, `aria-label` and `aria-labelledby` attributes are allowed.
-          </p>
-          <pre class="HTML example" title="Elements with explicit ARIA roles which allow naming from authors">
-            &lt;p role="link" tabindex="0" aria-label="...">...&lt;/p>
+        <p>
+          The following markup example demonstrates elements which have
+          explicit WAI-ARIA roles which allow naming from authors. Due to the
+          explicit roles specified on these elements, `aria-label` and
+          `aria-labelledby` attributes are allowed.
+        </p>
+        <pre class="HTML example" title=
+        "Elements with explicit ARIA roles which allow naming from authors">
+            &lt;p role="link" tabindex="0" aria-label="..."&gt;...&lt;/p&gt;
 
-            &lt;span role="button" tabindex="0" aria-label="...">...&lt;span>
+            &lt;span role="button" tabindex="0" aria-label="..."&gt;...&lt;span&gt;
 
-            &lt;div role="article" aria-labelledby="...">...&lt;/div>
-          </pre>
-        <!-- </section> -->
+            &lt;div role="article" aria-labelledby="..."&gt;...&lt;/div&gt;
+          </pre><!-- </section> -->
       </section>
       <section>
         <h3 id="docconformance-attr">
-          Requirements for use of ARIA attributes in place of equivalent HTML attributes
+          Requirements for use of ARIA attributes in place of equivalent HTML
+          attributes
         </h3>
         <p>
-          Unless otherwise stated, authors MAY use `aria-*` attributes in place of their HTML equivalents on HTML elements where the `aria-*` semantics would 
-          be expected. For example, authors MAY specify `aria-disabled=true` on a [^button^] element, while also implementing the necessary scripting to functionally 
-          disable the `button`, rather than the use `disabled` attribute.
+          Unless otherwise stated, authors MAY use `aria-*` attributes in place
+          of their HTML equivalents on HTML elements where the `aria-*`
+          semantics would be expected. For example, authors MAY specify
+          `aria-disabled=true` on a [^button^] element, while also implementing
+          the necessary scripting to functionally disable the `button`, rather
+          than the use `disabled` attribute.
         </p>
         <p>
-          As stated in <a data-cite="wai-aria-1.2#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
-          when HTML elements use <em>both</em> `aria-*` attributes and their host language (HTML) equivalents, user agents MUST ignore the WAI-ARIA attributes – the 
-          native HTML attributes with the same <a>implicit ARIA semantics</a> take precedence. For this reason, authors SHOULD NOT specify both the native HTML attribute 
-          and the equivalent `aria-*` attribute on an element. Please review each attribute for any further author specific requirements.
+          As stated in <a data-cite=
+          "wai-aria-1.2#host_general_conflict">WAI-ARIA's Conflicts with Host
+          Language Semantics</a>, when HTML elements use <em>both</em> `aria-*`
+          attributes and their host language (HTML) equivalents, user agents
+          MUST ignore the WAI-ARIA attributes – the native HTML attributes with
+          the same <a>implicit ARIA semantics</a> take precedence. For this
+          reason, authors SHOULD NOT specify both the native HTML attribute and
+          the equivalent `aria-*` attribute on an element. Please review each
+          attribute for any further author specific requirements.
         </p>
         <p>
-          The following table represents HTML elements and their attributes which have `aria-*` attribute parity.
+          The following table represents HTML elements and their attributes
+          which have `aria-*` attribute parity.
         </p>
         <p>
           Each language feature (element and attribute) in a cell in the first
@@ -3638,42 +4195,58 @@
               <td>
                 <div class="correction">
                   <p>
-                    Use the `checked` attribute on any element that is allowed the `checked` attribute in HTML. 
-                    Use the <a data-cite="html/input.html#dom-input-indeterminate">`indeterminate`</a> IDL attribute to indicate the "mixed" state for <a data-cite="html/input.html#checkbox-state-(type=checkbox)">`input type=checkbox`</a> elements.
+                    Use the `checked` attribute on any element that is allowed
+                    the `checked` attribute in HTML. Use the <a data-cite=
+                    "html/input.html#dom-input-indeterminate">`indeterminate`</a>
+                    IDL attribute to indicate the "mixed" state for
+                    <a data-cite=
+                    "html/input.html#checkbox-state-(type=checkbox)">`input
+                    type=checkbox`</a> elements.
                   </p>
                   <p>
-                    Authors MUST NOT use the <a data-cite="wai-aria-1.2#aria-checked">`aria-checked`</a> attribute on any element where the <a data-cite="html/form-control-infrastructure.html#concept-fe-checked">checkedness</a>, or the 
-                    indeterminate checked value of the element can be in opposition to the current value of the `aria-checked` attribute.
+                    Authors MUST NOT use the <a data-cite=
+                    "wai-aria-1.2#aria-checked">`aria-checked`</a> attribute on
+                    any element where the <a data-cite=
+                    "html/form-control-infrastructure.html#concept-fe-checked">checkedness</a>,
+                    or the indeterminate checked value of the element can be in
+                    opposition to the current value of the `aria-checked`
+                    attribute.
                   </p>
                 </div>
                 <p>
-                  Authors MAY use the `aria-checked` attribute on any other element with a WAI-ARIA role which allows the attribute.
+                  Authors MAY use the `aria-checked` attribute on any other
+                  element with a WAI-ARIA role which allows the attribute.
                 </p>
               </td>
             </tr>
             <tr id="att-disabled" tabindex="-1">
               <th>
-                Any element where the [^input/disabled^]
-                attribute is allowed, including
-                `option` [^option/disabled^] and
-                `optgroup` [^optgroup/disabled^]
+                Any element where the [^input/disabled^] attribute is allowed,
+                including `option` [^option/disabled^] and `optgroup`
+                [^optgroup/disabled^]
               </th>
               <td>
                 `aria-disabled="true"`
               </td>
               <td>
                 <p>
-                  Use the `disabled` attribute on any element that is allowed the `disabled` attribute in HTML.
+                  Use the `disabled` attribute on any element that is allowed
+                  the `disabled` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a> attribute on any element that is allowed the `disabled` attribute in HTML, 
-                  or any element with a WAI-ARIA role which allows the `aria-disabled` attribute</a>.
+                  Authors MAY use the <a data-cite=
+                  "wai-aria-1.2#aria-disabled">`aria-disabled`</a> attribute on
+                  any element that is allowed the `disabled` attribute in HTML,
+                  or any element with a WAI-ARIA role which allows the
+                  `aria-disabled` attribute.
                 </p>
                 <p>
-                  Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
+                  Authors SHOULD NOT use `aria-disabled="true"` on any element
+                  which also has a `disabled` attribute.
                 </p>
                 <p>
-                  Authors MUST NOT use `aria-disabled="false"` on any element which also has a `disabled` attribute.
+                  Authors MUST NOT use `aria-disabled="false"` on any element
+                  which also has a `disabled` attribute.
                 </p>
               </td>
             </tr>
@@ -3686,120 +4259,160 @@
               </td>
               <td>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on any HTML element that allows <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> to 
-                  be specified, with the exception of focusable elements and the <a href="#el-body">`body`</a> element.
+                  Authors MAY use the <a data-cite=
+                  "wai-aria-1.2#aria-hidden">`aria-hidden`</a> attribute on any
+                  HTML element that allows <a data-cite=
+                  "wai-aria-1.2#global_states">global `aria-*` attributes</a>
+                  to be specified, with the exception of focusable elements and
+                  the <a href="#el-body">`body`</a> element.
                 </p>
                 <p>
-                  It is generally NOT RECOMMENDED for authors to use `aria-hidden="true"` on any element which also has the `hidden` attribute specified. However, authors MUST NOT use `aria-hidden="true"` on any element which also has the `hidden` attribute specified in the `until-found` state.
+                  It is generally NOT RECOMMENDED for authors to use
+                  `aria-hidden="true"` on any element which also has the
+                  `hidden` attribute specified. However, authors MUST NOT use
+                  `aria-hidden="true"` on any element which also has the
+                  `hidden` attribute specified in the `until-found` state.
                 </p>
                 <div class="note">
-                  A focusable element is any element which can be focused by use of keyboard or pointer device. Focusable elements are not always elements which
-                  can be tabbed to via a keyboard. For instance, an element with `tabindex="-1"` is focusable but is not a tabbable element.
+                  A focusable element is any element which can be focused by
+                  use of keyboard or pointer device. Focusable elements are not
+                  always elements which can be tabbed to via a keyboard. For
+                  instance, an element with `tabindex="-1"` is focusable but is
+                  not a tabbable element.
                 </div>
                 <div class="note">
-                  Using `aria-hidden="true"` on an element that has the `hidden` attribute is at best an unnecessary redundancy. At worst its usage can 
-                  prevent access to the content if the `hidden` attribute's default UA style of `display: none` has been purposeuflly overwritten by an author or user style sheet.
-                  Finally, if the `hidden` attribute has the value of `until-found`, the use of `aria-hidden=true` will prevent this content from being discoverable to users of assistive
-                  technology when it is found via a browser's in-page find feature and visually rendered to users.
+                  Using `aria-hidden="true"` on an element that has the
+                  `hidden` attribute is at best an unnecessary redundancy. At
+                  worst its usage can prevent access to the content if the
+                  `hidden` attribute's default UA style of `display: none` has
+                  been purposeuflly overwritten by an author or user style
+                  sheet. Finally, if the `hidden` attribute has the value of
+                  `until-found`, the use of `aria-hidden=true` will prevent
+                  this content from being discoverable to users of assistive
+                  technology when it is found via a browser's in-page find
+                  feature and visually rendered to users.
                 </div>
               </td>
             </tr>
             <tr id="att-placeholder" tabindex="-1">
               <th>
-                Any element where the [^input/placeholder^] attribute is allowed
+                Any element where the [^input/placeholder^] attribute is
+                allowed
               </th>
               <td>
                 `aria-placeholder="..."`
               </td>
               <td>
                 <p>
-                  Use the `placeholder` attribute on any element that is allowed the
-                  `placeholder` attribute in HTML.
+                  Use the `placeholder` attribute on any element that is
+                  allowed the `placeholder` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-placeholder">`aria-placeholder`</a> attribute on any element that is allowed the `placeholder` attribute in HTML, 
-                  or any element with a WAI-ARIA role which allows the `aria-placeholder` attribute.
+                  Authors MAY use the <a data-cite=
+                  "wai-aria-1.2#aria-placeholder">`aria-placeholder`</a>
+                  attribute on any element that is allowed the `placeholder`
+                  attribute in HTML, or any element with a WAI-ARIA role which
+                  allows the `aria-placeholder` attribute.
                 </p>
                 <p>
-                  Authors MUST NOT use the `aria-placeholder` attribute on any element which also has a `placeholder` attribute.
+                  Authors MUST NOT use the `aria-placeholder` attribute on any
+                  element which also has a `placeholder` attribute.
                 </p>
               </td>
             </tr>
             <tr id="att-max" tabindex="-1">
               <th>
-                Any element where the `max` attribute is allowed: `meter` [^meter/max^], `progress` [^progress/max^], and `input` [^input/max^]
+                Any element where the `max` attribute is allowed: `meter`
+                [^meter/max^], `progress` [^progress/max^], and `input`
+                [^input/max^]
               </th>
               <td>
                 `aria-valuemax="..."`
               </td>
               <td>
                 <p>
-                  Use the `max` attribute on any element that is
-                  allowed the `max` attribute in HTML.
+                  Use the `max` attribute on any element that is allowed the
+                  `max` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemax`</a> attribute on any other element with a WAI-ARIA role which allows the `aria-valuemax` attribute.
+                  Authors MAY use the <a data-cite=
+                  "wai-aria-1.2#aria-valuemax">`aria-valuemax`</a> attribute on
+                  any other element with a WAI-ARIA role which allows the
+                  `aria-valuemax` attribute.
                 </p>
                 <p>
-                  Authors SHOULD NOT use `aria-valuemax` on any element which allows the `max` attribute. Use the `max` attribute instead.
+                  Authors SHOULD NOT use `aria-valuemax` on any element which
+                  allows the `max` attribute. Use the `max` attribute instead.
                 </p>
                 <p>
-                  Authors MUST NOT use `aria-valuemax` on any element which also has a `max` attribute.
+                  Authors MUST NOT use `aria-valuemax` on any element which
+                  also has a `max` attribute.
                 </p>
               </td>
             </tr>
             <tr id="att-min" tabindex="-1">
               <th>
-                Any element where the `min` attribute is allowed: `meter` [^meter/min^] and `input` [^input/min^]
+                Any element where the `min` attribute is allowed: `meter`
+                [^meter/min^] and `input` [^input/min^]
               </th>
               <td>
                 `aria-valuemin="..."`
               </td>
               <td>
                 <p>
-                  Use the `min` attribute on any element that is
-                  allowed the `min` attribute in HTML.
+                  Use the `min` attribute on any element that is allowed the
+                  `min` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-valuemax">`aria-valuemin`</a> attribute on any other element with a WAI-ARIA role which allows the `aria-valuemin` attribute.
+                  Authors MAY use the <a data-cite=
+                  "wai-aria-1.2#aria-valuemax">`aria-valuemin`</a> attribute on
+                  any other element with a WAI-ARIA role which allows the
+                  `aria-valuemin` attribute.
                 </p>
                 <p>
-                  Authors SHOULD NOT use `aria-valuemin` on any element which allows the `min` attribute. Use the `min` attribute instead.
+                  Authors SHOULD NOT use `aria-valuemin` on any element which
+                  allows the `min` attribute. Use the `min` attribute instead.
                 </p>
                 <p>
-                  Authors MUST NOT use `aria-valuemin` on any element which also has a `min` attribute.
+                  Authors MUST NOT use `aria-valuemin` on any element which
+                  also has a `min` attribute.
                 </p>
               </td>
             </tr>
             <tr id="att-readonly" tabindex="-1">
               <th>
-                Any element which allows the `readonly` attribute:
-                `input` [^input/readonly^], `textarea` [^textarea/readonly^] and <a>form-associated custom element</a> which allows [^form-associated custom elements/readonly^]
+                Any element which allows the `readonly` attribute: `input`
+                [^input/readonly^], `textarea` [^textarea/readonly^] and
+                <a>form-associated custom element</a> which allows
+                [^form-associated custom elements/readonly^]
               </th>
               <td>
                 `aria-readonly="true"`
               </td>
               <td>
                 <p>
-                  Use the `readonly` attribute on any element that is
-                  allowed the `readonly` attribute in HTML.
+                  Use the `readonly` attribute on any element that is allowed
+                  the `readonly` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a> attribute on any element with a WAI-ARIA role which allows the attribute</a>.
+                  Authors MAY use the <a data-cite=
+                  "wai-aria-1.2#aria-readonly">`aria-readonly`</a> attribute on
+                  any element with a WAI-ARIA role which allows the attribute.
                 </p>
                 <p>
-                  Authors SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.
+                  Authors SHOULD NOT use the `aria-readonly="true"` on any
+                  element which also has a `readonly` attribute.
                 </p>
                 <p>
-                  Authors MUST NOT use `aria-readonly="false"` on any element which also has a `readonly` attribute.
+                  Authors MUST NOT use `aria-readonly="false"` on any element
+                  which also has a `readonly` attribute.
                 </p>
               </td>
             </tr>
             <tr id="att-contenteditable" tabindex="-1">
               <th>
                 <p>
-                  Element with [^html-global/contenteditable^]`=true`
-                  or
+                  Element with [^html-global/contenteditable^]`=true` or
                   element without `contenteditable` attribute whose closest
                   ancestor with a `contenteditable` attribute has
                   `contenteditable="true"`.
@@ -3814,45 +4427,54 @@
                 `aria-readonly="false"`
               </td>
               <td>
-                Authors MUST NOT set `aria-readonly="true"` on an element that has `isContentEditable="true"`.
+                Authors MUST NOT set `aria-readonly="true"` on an element that
+                has `isContentEditable="true"`.
               </td>
             </tr>
             <tr id="att-required" tabindex="-1">
               <th>
-                Any element where the `required` attribute is allowed: `input` [^input/required^], `textarea` [^textarea/required^], and `select` [^select/required^]
+                Any element where the `required` attribute is allowed: `input`
+                [^input/required^], `textarea` [^textarea/required^], and
+                `select` [^select/required^]
               </th>
               <td>
                 `aria-required="true"`
               </td>
               <td>
                 <p>
-                  Use the `required` attribute on any element
-                  that is allowed the `required` attribute in HTML.
+                  Use the `required` attribute on any element that is allowed
+                  the `required` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-required">`aria-required`</a> attribute on any element that is allowed the `required` attribute in HTML, or any element with a WAI-ARIA role which allows the `aria-required` attribute.
+                  Authors MAY use the <a data-cite=
+                  "wai-aria-1.2#aria-required">`aria-required`</a> attribute on
+                  any element that is allowed the `required` attribute in HTML,
+                  or any element with a WAI-ARIA role which allows the
+                  `aria-required` attribute.
                 </p>
                 <p>
-                  Authors SHOULD NOT use the `aria-required="true"` on any element which also has a `required` attribute.
+                  Authors SHOULD NOT use the `aria-required="true"` on any
+                  element which also has a `required` attribute.
                 </p>
                 <p>
-                  Authors MUST NOT use `aria-required="false"` on any element which also has a `required` attribute.
+                  Authors MUST NOT use `aria-required="false"` on any element
+                  which also has a `required` attribute.
                 </p>
               </td>
             </tr>
             <tr id="att-colspan" tabindex="-1">
               <th>
-                Any element where the [^th/colspan^] attribute is allowed: `td` and `th`
+                Any element where the [^th/colspan^] attribute is allowed: `td`
+                and `th`
               </th>
               <td>
                 `aria-colspan="..."`
               </td>
               <td>
                 <p>
-                  Use the `colspan` attribute on any element that is
-                  allowed the `colspan` attribute in HTML.
-                </p>
-                <!--
+                  Use the `colspan` attribute on any element that is allowed
+                  the `colspan` attribute in HTML.
+                </p><!--
                   Removing per issue #338
                   Revised rules to be re-added
                 <p>
@@ -3860,27 +4482,29 @@
                 </p>
                 -->
                 <p>
-                  Authors SHOULD NOT use the `aria-colspan` attribute on any element which also has a `colspan` attribute.
+                  Authors SHOULD NOT use the `aria-colspan` attribute on any
+                  element which also has a `colspan` attribute.
                 </p>
                 <p>
-                  Authors MUST NOT use `aria-colspan` on any element which also has a `colspan` attribute, and the values of each attribute do not match.
+                  Authors MUST NOT use `aria-colspan` on any element which also
+                  has a `colspan` attribute, and the values of each attribute
+                  do not match.
                 </p>
               </td>
             </tr>
             <tr id="att-rowspan" tabindex="-1">
               <th>
-                Any element where the [^th/rowspan^] attribute is allowed:
-                `td` and `th`
+                Any element where the [^th/rowspan^] attribute is allowed: `td`
+                and `th`
               </th>
               <td>
                 `aria-rowspan="..."`
               </td>
               <td>
                 <p>
-                  Use the `rowspan` attribute on any element that is
-                  allowed the `rowspan` attribute in HTML.
-                </p>
-                <!--
+                  Use the `rowspan` attribute on any element that is allowed
+                  the `rowspan` attribute in HTML.
+                </p><!--
                   Removing per issue #338
                   Revised rules to be re-added
                 <p>
@@ -3888,10 +4512,13 @@
                 </p>
                 -->
                 <p>
-                  Authors SHOULD NOT use the `aria-rowspan` attribute on any element which also has a `rowspan` attribute.
+                  Authors SHOULD NOT use the `aria-rowspan` attribute on any
+                  element which also has a `rowspan` attribute.
                 </p>
                 <p>
-                  Authors MUST NOT use `aria-rowspan` on any element which also has a `rowspan` attribute, and the values of each attribute do not match.
+                  Authors MUST NOT use `aria-rowspan` on any element which also
+                  has a `rowspan` attribute, and the values of each attribute
+                  do not match.
                 </p>
               </td>
             </tr>
@@ -3900,105 +4527,151 @@
       </section>
       <section class="addition">
         <h2 id="docconformance-deprecated">
-          Requirements for deprecated ARIA role, state and property and attributes
+          Requirements for deprecated ARIA role, state and property and
+          attributes
         </h2>
         <p>
-          The ARIA Specification's <a data-cite="wai-aria-1.2#deprecated">Deprecated Requirements</a> section indicates that if an ARIA feature is marked as deprecated then authors are advised not to use said feature for new content.
+          The ARIA Specification's <a data-cite=
+          "wai-aria-1.2#deprecated">Deprecated Requirements</a> section
+          indicates that if an ARIA feature is marked as deprecated then
+          authors are advised not to use said feature for new content.
         </p>
         <p>
-          The following roles and attributes are deprecated features of ARIA and DPub ARIA. Conformance checkers MUST warn authors about the deprecated status of these features. Whenever possible, authors are advised to use alternatives to deprecated features.
+          The following roles and attributes are deprecated features of ARIA
+          and DPub ARIA. Conformance checkers MUST warn authors about the
+          deprecated status of these features. Whenever possible, authors are
+          advised to use alternatives to deprecated features.
         </p>
-
-        <h3>Deprecated ARIA roles</h3>
-        <ul>  
-          <li><a data-cite="wai-aria-1.2#directory">`directory`</a></li>
-        </ul>
-        <div class="note">
-          <p>The `directory` role is marked for deprecation in [[wai-aria-1.2|WAI-ARIA 1.2]]. In reality, the `directory` role had no functional difference to an element with an implicit or explicit `list` role. Authors are advised to use one of HTML's native list elements, or an ARIA `list` instead.</p>
-        </div>
-
-        <h3>Deprecated DPub ARIA roles</h3>
+        <h3>
+          Deprecated ARIA roles
+        </h3>
         <ul>
-          <li><a data-cite="dpub-aria-1.1#doc-biblioentry">`doc-biblioentry`</a></li>
-          <li><a data-cite="dpub-aria-1.1#doc-endnote">`doc-endnote`</a></li>
+          <li>
+            <a data-cite="wai-aria-1.2#directory">`directory`</a>
+          </li>
         </ul>
         <div class="note">
-          <p>The `doc-biblioentry` and `doc-endnote` roles are marked for deprecation in [[[dpub-aria-1.1]]], as they are not valid children for an element with an implicit or explicit role of `list`. Authors can use standard list and child `li` elements without the need for these roles.</p>
+          <p>
+            The `directory` role is marked for deprecation in
+            [[wai-aria-1.2|WAI-ARIA 1.2]]. In reality, the `directory` role had
+            no functional difference to an element with an implicit or explicit
+            `list` role. Authors are advised to use one of HTML's native list
+            elements, or an ARIA `list` instead.
+          </p>
         </div>
-
-        <h3>Deprecated ARIA attributes</h3>
+        <h3>
+          Deprecated DPub ARIA roles
+        </h3>
         <ul>
-          <li><a data-cite="wai-aria-1.1#aria-dropeffect">`aria-dropeffect`</a></li>
-          <li><a data-cite="wai-aria-1.1#aria-grabbed">`aria-grabbed`</a></li>
+          <li>
+            <a data-cite="dpub-aria-1.1#doc-biblioentry">`doc-biblioentry`</a>
+          </li>
+          <li>
+            <a data-cite="dpub-aria-1.1#doc-endnote">`doc-endnote`</a>
+          </li>
         </ul>
         <div class="note">
-          <p>The `aria-dropeffect` and `aria-grabbed` attributes were deprecated in [[wai-aria-1.1|WAI-ARIA 1.1]]. There is presently no feature in ARIA to replace their proposed functionality.</p>
+          <p>
+            The `doc-biblioentry` and `doc-endnote` roles are marked for
+            deprecation in [[[dpub-aria-1.1]]], as they are not valid children
+            for an element with an implicit or explicit role of `list`. Authors
+            can use standard list and child `li` elements without the need for
+            these roles.
+          </p>
+        </div>
+        <h3>
+          Deprecated ARIA attributes
+        </h3>
+        <ul>
+          <li>
+            <a data-cite="wai-aria-1.1#aria-dropeffect">`aria-dropeffect`</a>
+          </li>
+          <li>
+            <a data-cite="wai-aria-1.1#aria-grabbed">`aria-grabbed`</a>
+          </li>
+        </ul>
+        <div class="note">
+          <p>
+            The `aria-dropeffect` and `aria-grabbed` attributes were deprecated
+            in [[wai-aria-1.1|WAI-ARIA 1.1]]. There is presently no feature in
+            ARIA to replace their proposed functionality.
+          </p>
         </div>
       </section>
       <section>
-      <h2 id="case-sensitivity">
-        Case requirements for ARIA role, state and property attributes
-      </h2>
-      <p>
-        Authors SHOULD use [=ASCII lowercase=] for all `role` token values
-        and any state or property attributes (`aria-*`) whose values are
-        <a data-cite="wai-aria-1.2#propcharacteristic_value">defined as tokens</a>.
-      </p>
-
-      <div class="note">
+        <h2 id="case-sensitivity">
+          Case requirements for ARIA role, state and property attributes
+        </h2>
         <p>
-          While modern browsers treat the `role` or `aria-*` attribute values as [=ASCII case-insensitive=], not all assistive technologies will correctly parse these values.
+          Authors SHOULD use [=ASCII lowercase=] for all `role` token values
+          and any state or property attributes (`aria-*`) whose values are
+          <a data-cite="wai-aria-1.2#propcharacteristic_value">defined as
+          tokens</a>.
         </p>
-        <p>
-          To reduce interoperability issues, authors are strongly encouraged to use [=ASCII lowercase=] for `aria-*` and `role` attribute values. Further, authors are encouraged to rigorously test with different browser and assistive technology combinations to ensure that their content will be correctly exposed to their users.
-        </p>
-      </div>
-      <aside class="example">
-        <p>
-          <strong>Correct (conforming) examples:</strong>
-        </p>
-        <pre>
+        <div class="note">
+          <p>
+            While modern browsers treat the `role` or `aria-*` attribute values
+            as [=ASCII case-insensitive=], not all assistive technologies will
+            correctly parse these values.
+          </p>
+          <p>
+            To reduce interoperability issues, authors are strongly encouraged
+            to use [=ASCII lowercase=] for `aria-*` and `role` attribute
+            values. Further, authors are encouraged to rigorously test with
+            different browser and assistive technology combinations to ensure
+            that their content will be correctly exposed to their users.
+          </p>
+        </div>
+        <aside class="example">
+          <p>
+            <strong>Correct (conforming) examples:</strong>
+          </p>
+          <pre>
   &lt;div <mark>role="main"</mark>&gt;...&lt;/div&gt;
 
   &lt;a href="home/" <mark>aria-current="page"</mark>&gt;home&lt;/a&gt;
         </pre>
-        <p>
-          <strong>Incorrect (non-conforming) examples:</strong>
-        </p>
-        <pre>&lt;!-- DO NOT DO THE FOLLOWING --&gt;
+          <p>
+            <strong>Incorrect (non-conforming) examples:</strong>
+          </p>
+          <pre>&lt;!-- DO NOT DO THE FOLLOWING --&gt;
 &lt;div <mark>role="MAIN"</mark>&gt;...&lt;/div&gt;
 
 &lt;div <mark>role="Main"</mark>&gt;...&lt;/div&gt;
 
 &lt;a href="home/" <mark>aria-current="Page"</mark>&gt;home&lt;/a&gt;
         </pre>
-      </aside>
+        </aside>
+      </section>
     </section>
-    </section>
-
     <section class="informative">
       <h2>
         Allowed descendants of ARIA roles
       </h2>
-      <p>The following table maps (and extends) the <a data-cite=
-        "html/dom.html#kinds-of-content">Kinds of content</a> and allowed descendant
-        information (defined in the
-        [[HTML]] specification) to elements that have an equivalent `role`.</p>
       <p>
-        Column 1 links to the normative [[[wai-aria-1.2]]] definitions for each ARIA `role`.
-        Column 2 identifies the <a data-cite="html/dom.html#kinds-of-content">Kinds of content</a>
-        categories each `role` has when it is used on an HTML element.
-        Column 3 indicates what kinds of HTML elements can be descendants of
-        an element with an explicit `role` specified, often matching the HTML element with
-        the same <a href="#implicit">implicit</a> role.
+        The following table maps (and extends) the <a data-cite=
+        "html/dom.html#kinds-of-content">Kinds of content</a> and allowed
+        descendant information (defined in the [[HTML]] specification) to
+        elements that have an equivalent `role`.
       </p>
       <p>
-        For example, a [^button^] element has an implicit `role=button`.
-        In HTML a `button` element allows [=phrasing content=] as descendants, and does not allow [=interactive content=]
-        or descendants with a `tabindex` attribute.  Therefore, any elements specified with a `role=button` would follow
-        the same descendant restrictions, and not allow any interactive content descendants,
-        elements with a `tabindex` specified, or any elements with role values
-        that are in the interactive content category (identified in column 3).
+        Column 1 links to the normative [[[wai-aria-1.2]]] definitions for each
+        ARIA `role`. Column 2 identifies the <a data-cite=
+        "html/dom.html#kinds-of-content">Kinds of content</a> categories each
+        `role` has when it is used on an HTML element. Column 3 indicates what
+        kinds of HTML elements can be descendants of an element with an
+        explicit `role` specified, often matching the HTML element with the
+        same <a href="#implicit">implicit</a> role.
+      </p>
+      <p>
+        For example, a [^button^] element has an implicit `role=button`. In
+        HTML a `button` element allows [=phrasing content=] as descendants, and
+        does not allow [=interactive content=] or descendants with a `tabindex`
+        attribute. Therefore, any elements specified with a `role=button` would
+        follow the same descendant restrictions, and not allow any interactive
+        content descendants, elements with a `tabindex` specified, or any
+        elements with role values that are in the interactive content category
+        (identified in column 3).
       </p>
       <div class="example" id="bad-descendants">
         <strong>Examples of non-conforming descendants</strong>
@@ -4016,1118 +4689,1274 @@
 &lt;/div&gt;
         </pre>
       </div>
-
-    <p>
-      Additionally, there are certain roles which [[[wai-aria-1.2]]] has specified specific requirements for their allowed descendants. These have been identified in column 3 (Descendant allowances) by indicating to "Refer to the 'Required Owned Elements'" for those particular roles.
-    </p>
-
-    <table id="aria-table" class="data">
-      <caption>
-        Allowed descendants of ARIA roles
-      </caption>
-      <thead>
-        <tr>
-          <th>
-            Role
-          </th>
-          <th>
-            Kind of content
-          </th>
-          <th>
-            Descendant allowances
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th tabindex="-1" id="index-aria-alert">
-            <a data-cite="wai-aria-1.2#alert">`alert`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-alertdialog">
-            <a data-cite="wai-aria-1.2#alertdialog">`alertdialog`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-application">
-            <a data-cite="wai-aria-1.2#application">`application`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-article">
-            <a data-cite="wai-aria-1.2#article">`article`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Sectioning content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-banner">
-            <a data-cite="wai-aria-1.2#banner">`banner`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a>, <a>header</a>, or <a>footer</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-blockquote">
-            <a data-cite="wai-aria-1.2#blockquote">`blockquote`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-button">
-            <a data-cite="wai-aria-1.2#button">`button`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-caption">
-            <a data-cite="wai-aria-1.2#caption">`caption`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> or <a>table</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-cell">
-            <a data-cite="wai-aria-1.2#cell">`cell`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-checkbox">
-            <a data-cite="wai-aria-1.2#checkbox">`checkbox`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-code">
-            <a data-cite="wai-aria-1.2#code">`code`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-columnheader">
-            <a data-cite="wai-aria-1.2#columnheader">`columnheader`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a>, <a>header</a>, or <a>footer</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-combobox">
-            <a data-cite="wai-aria-1.2#combobox">`combobox`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-complementary">
-            <a data-cite="wai-aria-1.2#complementary">`complementary`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Sectioning content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-contentinfo">
-            <a data-cite="wai-aria-1.2#contentinfo">`contentinfo`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a>, <a>header</a>, or <a>footer</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-definition">
-            <a data-cite="wai-aria-1.2#definition">`definition`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-deletion">
-            <a data-cite="wai-aria-1.2#deletion">`deletion`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-dialog">
-            <a data-cite="wai-aria-1.2#dialog">`dialog`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-directory">
-            <a data-cite="wai-aria-1.2#directory">`directory`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            <!-- fix me -->
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-document">
-            <a data-cite="wai-aria-1.2#document">`document`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-emphasis">
-            <a data-cite="wai-aria-1.2#emphasis">`emphasis`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-feed">
-            <a data-cite="wai-aria-1.2#feed">`feed`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-figure">
-            <a data-cite="wai-aria-1.2#figure">`figure`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-form">
-            <a data-cite="wai-aria-1.2#form">`form`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=], but with no [^form^] element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-generic">
-            <a data-cite="wai-aria-1.2#generic">`generic`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-grid">
-            <a data-cite="wai-aria-1.2#grid">`grid`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Interactive content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#grid">`grid`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-gridcell">
-            <a data-cite="wai-aria-1.2#gridcell">`gridcell`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-group">
-            <a data-cite="wai-aria-1.2#group">`group`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-heading">
-            <a data-cite="wai-aria-1.2#heading">`heading`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Heading content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-img">
-            <a data-cite="wai-aria-1.2#img">`img` or `image`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Embedded content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=], but with no [=interactive content=] descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-insertion">
-            <a data-cite="wai-aria-1.2#insertion">`insertion`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-link">
-            <a data-cite="wai-aria-1.2#link">`link`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=], but with no [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-list">
-            <a data-cite="wai-aria-1.2#list">`list`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#list">`list`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-listbox">
-            <a data-cite="wai-aria-1.2#listbox">`listbox`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Interactive content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#listbox">`listbox`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-listitem">
-            <a data-cite="wai-aria-1.2#listitem">`listitem`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-log">
-            <a data-cite="wai-aria-1.2#log">`log`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=], but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-main">
-            <a data-cite="wai-aria-1.2#main">`main`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=], but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-marquee">
-            <a data-cite="wai-aria-1.2#marquee">`marquee`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=], but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-math">
-            <a data-cite="wai-aria-1.2#math">`math`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-menu">
-            <a data-cite="wai-aria-1.2#menu">`menu`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Interactive content=]</li>
-            </ul>
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#menu">`menu`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-menubar">
-            <a data-cite="wai-aria-1.2#menubar">`menubar`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Interactive content=]</li>
-            </ul>
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#menubar">`menubar`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-menuitem">
-            <a data-cite="wai-aria-1.2#menuitem">`menuitem`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-menuitemcheckbox">
-            <a data-cite="wai-aria-1.2#menuitemcheckbox">`menuitemcheckbox`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-menuitemradio">
-            <a data-cite="wai-aria-1.2#menuitemradio">`menuitemradio`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-meter">
-            <a data-cite="wai-aria-1.2#meter">`meter`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=], but with no <a>meter</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-navigation">
-            <a data-cite="wai-aria-1.2#navigation">`navigation`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Sectioning content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=], but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-none">
-            <a data-cite="wai-aria-1.2#none">`none`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            <a data-cite="html/dom.html#transparent-content-models">Transparent</a>
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-note">
-            <a data-cite="wai-aria-1.2#note">`note`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=], but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-option">
-            <a data-cite="wai-aria-1.2#option">`option`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-paragraph">
-            <a data-cite="wai-aria-1.2#paragraph">`paragraph`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-presentation">
-            <a data-cite="wai-aria-1.2#presentation">`presentation`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            <a data-cite="html/dom.html#transparent-content-models">Transparent</a>
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-progressbar">
-            <a data-cite="wai-aria-1.2#progressbar">`progressbar`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=], but with no <a>progress</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-radio">
-            <a data-cite="wai-aria-1.2#radio">`radio`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-radiogroup">
-            <a data-cite="wai-aria-1.2#radiogroup">`radiogroup`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-region">
-            <a data-cite="wai-aria-1.2#region">`region`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Sectioning content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=], but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-row">
-            <a data-cite="wai-aria-1.2#row">`row`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#row">`row`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-rowgroup">
-            <a data-cite="wai-aria-1.2#rowgroup">`rowgroup`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#rowgroup">`rowgroup`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-rowheader">
-            <a data-cite="wai-aria-1.2#rowheader">`rowheader`</a>
-          </th>
-          <td>
-            N/A
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-scrollbar">
-            <a data-cite="wai-aria-1.2#scrollbar">`scrollbar`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-search">
-            <a data-cite="wai-aria-1.2#search">`search`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-searchbox">
-            <a data-cite="wai-aria-1.2#searchbox">`searchbox`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-separator">
-            <a data-cite="wai-aria-1.2#separator">`separator`</a>
-          </th>
-          <td>
-            [=Interactive content=] (if focusable)
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-slider">
-            <a data-cite="wai-aria-1.2#slider">`slider`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-spinbutton">
-            <a data-cite="wai-aria-1.2#spinbutton">`spinbutton`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-status">
-            <a data-cite="wai-aria-1.2#status">`status`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-strong">
-            <a data-cite="wai-aria-1.2#strong">`strong`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-subscript">
-            <a data-cite="wai-aria-1.2#subscript">`subscript`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-superscript">
-            <a data-cite="wai-aria-1.2#superscript">`superscript`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-switch">
-            <a data-cite="wai-aria-1.2#switch">`switch`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Interactive content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-tab">
-            <a data-cite="wai-aria-1.2#tab">`tab`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Phrasing content=], but with no
-            [=interactive content=] descendants, and no descendants with a `tabindex` attribute specified.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-table">
-            <a data-cite="wai-aria-1.2#table">`table`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#table">`table`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-tablist">
-            <a data-cite="wai-aria-1.2#tablist">`tablist`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <a data-cite="wai-aria-1.2#tablist">`tablist`</a> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-tabpanel">
-            <a data-cite="wai-aria-1.2#tabpanel">`tabpanel`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=]
-          </td>
-        </tr>
-        <tr>
-          <th id="index-aria-term" tabindex="-1">
-            <a data-cite="wai-aria-1.2#term">`term`</a>
-          </th>
-          <td>
-            [=Phrasing content=]
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-textbox">
-            <a data-cite="wai-aria-1.2#textbox">`textbox`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-time">
-            <a data-cite="wai-aria-1.2#time">`time`</a>
-          </th>
-          <td>
-            <ul>
-              <li>[=Flow content=]</li>
-              <li>[=Phrasing content=]</li>
-              <li>[=Palpable content=]</li>
-            </ul>
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-timer">
-            <a data-cite="wai-aria-1.2#timer">`timer`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-toolbar">
-            <a data-cite="wai-aria-1.2#toolbar">`toolbar`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Flow content=] but with no <a>main</a> element descendants.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-tooltip">
-            <a data-cite="wai-aria-1.2#tooltip">`tooltip`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-tree">
-           <a data-cite="wai-aria-1.2#tree">`tree`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <code><a data-cite="wai-aria-1.2#tree">tree</a></code> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-treegrid">
-            <a data-cite="wai-aria-1.2#treegrid">`treegrid`</a>
-          </th>
-          <td>
-            [=Flow content=]
-          </td>
-          <td>
-            Refer to the "Required Owned Elements" as defined for the ARIA <code><a data-cite="wai-aria-1.2#treegrid">treegrid</a></code> role.
-          </td>
-        </tr>
-        <tr>
-          <th tabindex="-1" id="index-aria-treeitem">
-            <a data-cite="wai-aria-1.2#treeitem">`treeitem`</a>
-          </th>
-          <td>
-            [=Interactive content=]
-          </td>
-          <td>
-            [=Phrasing content=]
-          </td>
-        </tr>
-      </tbody>
-    </table>
+      <p>
+        Additionally, there are certain roles which [[[wai-aria-1.2]]] has
+        specified specific requirements for their allowed descendants. These
+        have been identified in column 3 (Descendant allowances) by indicating
+        to "Refer to the 'Required Owned Elements'" for those particular roles.
+      </p>
+      <table id="aria-table" class="data">
+        <caption>
+          Allowed descendants of ARIA roles
+        </caption>
+        <thead>
+          <tr>
+            <th>
+              Role
+            </th>
+            <th>
+              Kind of content
+            </th>
+            <th>
+              Descendant allowances
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th tabindex="-1" id="index-aria-alert">
+              <a data-cite="wai-aria-1.2#alert">`alert`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-alertdialog">
+              <a data-cite="wai-aria-1.2#alertdialog">`alertdialog`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-application">
+              <a data-cite="wai-aria-1.2#application">`application`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-article">
+              <a data-cite="wai-aria-1.2#article">`article`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Sectioning content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-banner">
+              <a data-cite="wai-aria-1.2#banner">`banner`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a>, <a>header</a>, or
+              <a>footer</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-blockquote">
+              <a data-cite="wai-aria-1.2#blockquote">`blockquote`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-button">
+              <a data-cite="wai-aria-1.2#button">`button`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-caption">
+              <a data-cite="wai-aria-1.2#caption">`caption`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> or <a>table</a> element
+              descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-cell">
+              <a data-cite="wai-aria-1.2#cell">`cell`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-checkbox">
+              <a data-cite="wai-aria-1.2#checkbox">`checkbox`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-code">
+              <a data-cite="wai-aria-1.2#code">`code`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-columnheader">
+              <a data-cite="wai-aria-1.2#columnheader">`columnheader`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a>, <a>header</a>, or
+              <a>footer</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-combobox">
+              <a data-cite="wai-aria-1.2#combobox">`combobox`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-complementary">
+              <a data-cite="wai-aria-1.2#complementary">`complementary`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Sectioning content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-contentinfo">
+              <a data-cite="wai-aria-1.2#contentinfo">`contentinfo`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a>, <a>header</a>, or
+              <a>footer</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-definition">
+              <a data-cite="wai-aria-1.2#definition">`definition`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-deletion">
+              <a data-cite="wai-aria-1.2#deletion">`deletion`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-dialog">
+              <a data-cite="wai-aria-1.2#dialog">`dialog`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-directory">
+              <a data-cite="wai-aria-1.2#directory">`directory`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              <!-- fix me -->
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-document">
+              <a data-cite="wai-aria-1.2#document">`document`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-emphasis">
+              <a data-cite="wai-aria-1.2#emphasis">`emphasis`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-feed">
+              <a data-cite="wai-aria-1.2#feed">`feed`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-figure">
+              <a data-cite="wai-aria-1.2#figure">`figure`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-form">
+              <a data-cite="wai-aria-1.2#form">`form`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=], but with no [^form^] element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-generic">
+              <a data-cite="wai-aria-1.2#generic">`generic`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-grid">
+              <a data-cite="wai-aria-1.2#grid">`grid`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#grid">`grid`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-gridcell">
+              <a data-cite="wai-aria-1.2#gridcell">`gridcell`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-group">
+              <a data-cite="wai-aria-1.2#group">`group`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-heading">
+              <a data-cite="wai-aria-1.2#heading">`heading`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Heading content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-img">
+              <a data-cite="wai-aria-1.2#img">`img` or `image`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Embedded content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-insertion">
+              <a data-cite="wai-aria-1.2#insertion">`insertion`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-link">
+              <a data-cite="wai-aria-1.2#link">`link`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-list">
+              <a data-cite="wai-aria-1.2#list">`list`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#list">`list`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-listbox">
+              <a data-cite="wai-aria-1.2#listbox">`listbox`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#listbox">`listbox`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-listitem">
+              <a data-cite="wai-aria-1.2#listitem">`listitem`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-log">
+              <a data-cite="wai-aria-1.2#log">`log`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=], but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-main">
+              <a data-cite="wai-aria-1.2#main">`main`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=], but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-marquee">
+              <a data-cite="wai-aria-1.2#marquee">`marquee`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=], but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-math">
+              <a data-cite="wai-aria-1.2#math">`math`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-menu">
+              <a data-cite="wai-aria-1.2#menu">`menu`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#menu">`menu`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-menubar">
+              <a data-cite="wai-aria-1.2#menubar">`menubar`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#menubar">`menubar`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-menuitem">
+              <a data-cite="wai-aria-1.2#menuitem">`menuitem`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-menuitemcheckbox">
+              <a data-cite=
+              "wai-aria-1.2#menuitemcheckbox">`menuitemcheckbox`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-menuitemradio">
+              <a data-cite="wai-aria-1.2#menuitemradio">`menuitemradio`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-meter">
+              <a data-cite="wai-aria-1.2#meter">`meter`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=], but with no <a>meter</a> element
+              descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-navigation">
+              <a data-cite="wai-aria-1.2#navigation">`navigation`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Sectioning content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=], but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-none">
+              <a data-cite="wai-aria-1.2#none">`none`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              <a data-cite=
+              "html/dom.html#transparent-content-models">Transparent</a>
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-note">
+              <a data-cite="wai-aria-1.2#note">`note`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=], but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-option">
+              <a data-cite="wai-aria-1.2#option">`option`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-paragraph">
+              <a data-cite="wai-aria-1.2#paragraph">`paragraph`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-presentation">
+              <a data-cite="wai-aria-1.2#presentation">`presentation`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              <a data-cite=
+              "html/dom.html#transparent-content-models">Transparent</a>
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-progressbar">
+              <a data-cite="wai-aria-1.2#progressbar">`progressbar`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=], but with no <a>progress</a> element
+              descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-radio">
+              <a data-cite="wai-aria-1.2#radio">`radio`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-radiogroup">
+              <a data-cite="wai-aria-1.2#radiogroup">`radiogroup`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-region">
+              <a data-cite="wai-aria-1.2#region">`region`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Sectioning content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=], but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-row">
+              <a data-cite="wai-aria-1.2#row">`row`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#row">`row`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-rowgroup">
+              <a data-cite="wai-aria-1.2#rowgroup">`rowgroup`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#rowgroup">`rowgroup`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-rowheader">
+              <a data-cite="wai-aria-1.2#rowheader">`rowheader`</a>
+            </th>
+            <td>
+              N/A
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-scrollbar">
+              <a data-cite="wai-aria-1.2#scrollbar">`scrollbar`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-search">
+              <a data-cite="wai-aria-1.2#search">`search`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-searchbox">
+              <a data-cite="wai-aria-1.2#searchbox">`searchbox`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-separator">
+              <a data-cite="wai-aria-1.2#separator">`separator`</a>
+            </th>
+            <td>
+              [=Interactive content=] (if focusable)
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-slider">
+              <a data-cite="wai-aria-1.2#slider">`slider`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-spinbutton">
+              <a data-cite="wai-aria-1.2#spinbutton">`spinbutton`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-status">
+              <a data-cite="wai-aria-1.2#status">`status`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-strong">
+              <a data-cite="wai-aria-1.2#strong">`strong`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-subscript">
+              <a data-cite="wai-aria-1.2#subscript">`subscript`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-superscript">
+              <a data-cite="wai-aria-1.2#superscript">`superscript`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-switch">
+              <a data-cite="wai-aria-1.2#switch">`switch`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Interactive content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-tab">
+              <a data-cite="wai-aria-1.2#tab">`tab`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Phrasing content=], but with no [=interactive content=]
+              descendants, and no descendants with a `tabindex` attribute
+              specified.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-table">
+              <a data-cite="wai-aria-1.2#table">`table`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#table">`table`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-tablist">
+              <a data-cite="wai-aria-1.2#tablist">`tablist`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <a data-cite="wai-aria-1.2#tablist">`tablist`</a> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-tabpanel">
+              <a data-cite="wai-aria-1.2#tabpanel">`tabpanel`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=]
+            </td>
+          </tr>
+          <tr>
+            <th id="index-aria-term" tabindex="-1">
+              <a data-cite="wai-aria-1.2#term">`term`</a>
+            </th>
+            <td>
+              [=Phrasing content=]
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-textbox">
+              <a data-cite="wai-aria-1.2#textbox">`textbox`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-time">
+              <a data-cite="wai-aria-1.2#time">`time`</a>
+            </th>
+            <td>
+              <ul>
+                <li>[=Flow content=]
+                </li>
+                <li>[=Phrasing content=]
+                </li>
+                <li>[=Palpable content=]
+                </li>
+              </ul>
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-timer">
+              <a data-cite="wai-aria-1.2#timer">`timer`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-toolbar">
+              <a data-cite="wai-aria-1.2#toolbar">`toolbar`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Flow content=] but with no <a>main</a> element descendants.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-tooltip">
+              <a data-cite="wai-aria-1.2#tooltip">`tooltip`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-tree">
+              <a data-cite="wai-aria-1.2#tree">`tree`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <code><a data-cite="wai-aria-1.2#tree">tree</a></code> role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-treegrid">
+              <a data-cite="wai-aria-1.2#treegrid">`treegrid`</a>
+            </th>
+            <td>
+              [=Flow content=]
+            </td>
+            <td>
+              Refer to the "Required Owned Elements" as defined for the ARIA
+              <code><a data-cite="wai-aria-1.2#treegrid">treegrid</a></code>
+              role.
+            </td>
+          </tr>
+          <tr>
+            <th tabindex="-1" id="index-aria-treeitem">
+              <a data-cite="wai-aria-1.2#treeitem">`treeitem`</a>
+            </th>
+            <td>
+              [=Interactive content=]
+            </td>
+            <td>
+              [=Phrasing content=]
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </section>
     <section id="conformance">
-      <h2>Conformance checking requirements</h2>
-      <p>Conformance checkers that claim support for checking ARIA in HTML documents
-        MUST implement checks for the conformance requirements for use of the ARIA `role`
-        and `aria-*` attributes on [=HTML elements=] as defined in this specification. </p>
+      <h2>
+        Conformance checking requirements
+      </h2>
       <p>
-        A conforming document MUST NOT contain any elements with author defined `role`
-        or `aria-*` attributes with values other than those which, per this specification,
-        authors MAY use on each [=HTML element=] in [[[#docconformance]]].
-        Conformance checkers SHOULD flag instances where authors are explicitly providing
-        an element with a `role` which matches its
-        <a data-cite="wai-aria-1.2#implicit_semantics">implicit ARIA semantics</a> as failures,
-        as it is NOT RECOMMENDED for authors to explicitly set these roles.
+        Conformance checkers that claim support for checking ARIA in HTML
+        documents MUST implement checks for the conformance requirements for
+        use of the ARIA `role` and `aria-*` attributes on [=HTML elements=] as
+        defined in this specification.
       </p>
       <p>
-        A conformance checker MAY define their own terminology, and level or levels of
-        severity, when surfacing document failures to conform to this specification.
+        A conforming document MUST NOT contain any elements with author defined
+        `role` or `aria-*` attributes with values other than those which, per
+        this specification, authors MAY use on each [=HTML element=] in
+        [[[#docconformance]]]. Conformance checkers SHOULD flag instances where
+        authors are explicitly providing an element with a `role` which matches
+        its <a data-cite="wai-aria-1.2#implicit_semantics">implicit ARIA
+        semantics</a> as failures, as it is NOT RECOMMENDED for authors to
+        explicitly set these roles.
+      </p>
+      <p>
+        A conformance checker MAY define their own terminology, and level or
+        levels of severity, when surfacing document failures to conform to this
+        specification.
       </p>
     </section>
     <section id="priv-sec" class="informative">
@@ -5136,12 +5965,14 @@
       </h2>
       <p>
         This specification does not define the features of [[wai-aria-1.2]],
-        [[dpub-aria-1.0]] or [[HTML]]. Rather it provides rules and guidance for conformance
-        checkers that claim support for checking ARIA in HTML, as well as providing guidance to authors.
+        [[dpub-aria-1.0]] or [[HTML]]. Rather it provides rules and guidance
+        for conformance checkers that claim support for checking ARIA in HTML,
+        as well as providing guidance to authors.
       </p>
       <p>
-        Therefore, there are no known privacy or security impacts of this specification,
-        as it defines no new features to introduce potential concern.
+        Therefore, there are no known privacy or security impacts of this
+        specification, as it defines no new features to introduce potential
+        concern.
       </p>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -3067,10 +3067,6 @@
               <p>
                 <a>No corresponding role</a>
               </p>
-              <div class="note">
-                Many, but not all, user agents expose the `summary` element with an implicit ARIA 
-                <code>role=<a href="#index-aria-button">button</a></code>.
-              </div>
             </td>
             <td>
               <div class="proposed correction">


### PR DESCRIPTION
Closes #553 

Removed the comment, and ran tidy (HTML Tidy for Apple macOS version 5.8.0). It shifted a lot of lines, I'm not sure if it is a versioning issue or if it just has not been run in a while. Feel free to revert the second commit if it is bothersome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/leekeh/html-aria/pull/554.html" title="Last updated on Jul 1, 2025, 9:46 PM UTC (7bc532b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/554/2493015...leekeh:7bc532b.html" title="Last updated on Jul 1, 2025, 9:46 PM UTC (7bc532b)">Diff</a>