### PR TITLE
Addition: update allowances for label element

### DIFF
--- a/index.html
+++ b/index.html
@@ -2241,7 +2241,7 @@
                 <a><strong class="nosupport">no `role`</strong></a>
               </p>
               <p>
-                Otherwise, if the `label` is not associted with an element then <a><strong>any `role`</strong></a> 
+                Otherwise, if the `label` is not associted with an element then <a><strong>any `role`</strong></a>, 
                 though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
               </p>
               <p><a>Naming Prohibited</a> if exposed as the `generic` role, or if exposed as another role which prohibits naming.</p>

--- a/index.html
+++ b/index.html
@@ -2236,9 +2236,15 @@
             </td>
             <td>
               <p>
-                <a><strong class="nosupport">No `role`</strong></a>
+                If a `label` element is implicitly or explicitly associated with a 
+                <a href="data-html/https://html.spec.whatwg.org/multipage/forms.html#category-label">labelable element</a> then
+                <a><strong class="nosupport">no `role`</strong></a>
               </p>
-              <p class="addition"><a>Naming Prohibited</a></p>
+              <p>
+                Otherwise, if the `label` is not associted with an element then <a><strong>any `role`</strong></a> 
+                though <code><a href="#index-aria-generic">generic</a></code> SHOULD NOT be used.
+              </p>
+              <p><a>Naming Prohibited</a> if exposed as the `generic` role, or if exposed as another role which prohibits naming.</p>
               <p>
                 Otherwise, <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a>.
               </p>


### PR DESCRIPTION
Closes #492

This update keeps the same allowances for when a `label` element is associated with a labelable element.  But for instances where an author just uses the `label` element without associating it with a labelable element, then the ARIA allowances should replicate the `span` element.

[test case](https://w3c.github.io/html-aria/tests/label-element.html)

- [x] [HTML validator](https://github.com/validator/validator/issues/1856)
- [ ] [IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/2335)
- [ ] [axe-core](https://github.com/dequelabs/axe-core/issues/4838)
- [x] [ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/84)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/556.html" title="Last updated on Jul 23, 2025, 6:55 PM UTC (fdf02e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/556/a497ae5...fdf02e2.html" title="Last updated on Jul 23, 2025, 6:55 PM UTC (fdf02e2)">Diff</a>