### PR TITLE
Fix broken link to "labelable element"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2252,7 +2252,7 @@
             <td>
               <p>
                 If a `label` element is implicitly or explicitly associated with a 
-                <a href="https://html.spec.whatwg.org/multipage/forms.html#category-label">labelable element</a> then
+                <a data-cite="html/forms.html#category-label">labelable element</a> then
                 <a><strong class="nosupport">no `role`</strong></a>
               </p>
               <p>

--- a/index.html
+++ b/index.html
@@ -2252,7 +2252,7 @@
             <td>
               <p>
                 If a `label` element is implicitly or explicitly associated with a 
-                <a href="data-html/https://html.spec.whatwg.org/multipage/forms.html#category-label">labelable element</a> then
+                <a href="https://html.spec.whatwg.org/multipage/forms.html#category-label">labelable element</a> then
                 <a><strong class="nosupport">no `role`</strong></a>
               </p>
               <p>


### PR DESCRIPTION
Assuming we just need a straightforward `href` here, and not a `data-cite`? (either way, the current format is broken)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/559.html" title="Last updated on Aug 5, 2025, 11:22 AM UTC (02666b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/559/75bd4b7...02666b3.html" title="Last updated on Aug 5, 2025, 11:22 AM UTC (02666b3)">Diff</a>