### PR TITLE
Clarify role and attributes for summary element

### DIFF
--- a/index.html
+++ b/index.html
@@ -3117,22 +3117,23 @@
                 <a>No corresponding role</a>
               </p>
               <div class="note">
-                Many, but not all, user agents expose the `summary` element with an implicit ARIA 
-                <code>role=<a href="#index-aria-button">button</a></code>.
+                The exposed role of a `summary` element can vary depending on the user agent and assistive technology.
               </div>
             </td>
             <td>
               <div class="proposed correction">
                 <p>
                   <a><strong class="nosupport">No `role`</strong></a> if the `summary` element is a 
-                  <a data-cite="html/interactive-elements.html#summary-for-its-parent-details">summary for its parent details</a>.
+                  <a data-cite="html/interactive-elements.html#summary-for-its-parent-details">summary for its parent details</a> element.
                 </p>
                 <p>
                   <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>, 
                   `aria-disabled`, and `aria-haspopup` attributes.
                 </p>
                 <p>
-                  Otherwise, authors MAY specifiy <a><strong>Any `role`</strong></a>, and any 
+                  Otherwise, if the `summary` element is <strong>not</strong> a 
+                  <a data-cite="html/interactive-elements.html#summary-for-its-parent-details">summary for its parent details</a> 
+                  element, authors MAY specifiy <a><strong>any `role`</strong></a>, and any 
                   <a data-cite="wai-aria-1.2#global_states">global `aria-*` attributes</a> 
                   and any `aria-*` attributes applicable to the allowed roles.
                 </p>


### PR DESCRIPTION
closes #553

updates the note in the implicit role column for the summary element to be more accurate to the current reality of how a summary is exposed by UAs and AT.

additionally, this PR updates the wording to clarify the condition for when a summary can have any role (e.g., when used incorrectly).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/560.html" title="Last updated on Sep 22, 2025, 1:57 PM UTC (5686fff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/560/181421a...5686fff.html" title="Last updated on Sep 22, 2025, 1:57 PM UTC (5686fff)">Diff</a>