### PR TITLE
Update: Clarify and update role allowances for td and th elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3338,7 +3338,7 @@
               </p>
               <div class="note">
                 <p>
-                  If a `th` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `th` is marked as 
+                  If a `th` element is a descendant of a `table` element exposed with a role of `table`, `grid` or `treegrid`, and the `th` is marked as 
                   `role=none` or `presentation`, then it is advised that the `th` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
                   element with with a role of `cell`, `gridcell`, `columnheader` or `rowheader`. Otherwise, that the presentational `th` be empty,  
                   own only whitespace characters or content hidden from the accessibility tree.

--- a/index.html
+++ b/index.html
@@ -3241,10 +3241,10 @@
               </p>
               <div class="note">
                 <p>
-                  If a `td` element's nearest descendant `table` element is exposed with a role of `table`, `grid` or `treegrid`, 
-                  and the `td` element is marked as `role=none` or `presentation`, then it is advised that the `td` element be empty, 
-                  contain only whitespace characters or contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> element with 
-                  a role of `cell`, `gridcell`, `columnheader` or `rowheader` - whichever would be most appropriate for what the content represents.
+                  If a `td` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `td` is marked as 
+                  `role=none` or `presentation`, then it is advised that the `td` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
+                  element with with a role of `cell`, `gridcell`, `columnheader` or `rowheader`. Otherwise, it is advised that the presentational `td` be empty,  
+                  contain only whitespace characters or content hidden from the accessibility tree.
                 </p>
               </div>
               <p>

--- a/index.html
+++ b/index.html
@@ -3216,35 +3216,40 @@
             </th>
             <td>
               <p>
-                <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
+                <code>role=<a href="#index-aria-cell">cell</a></code> if the nearest ancestor
                 `table` element is exposed as a `role=table`
               </p>
               <p>
-                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
+                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the nearest ancestor
                 `table` element is exposed as a `role=grid` or `treegrid`
               </p>
               <p>
-                <a>No corresponding role</a> if the ancestor `table` element is not exposed
+                <a>No corresponding role</a> if the nearest ancestor `table` element is not exposed
                 as a `role=table`, `grid` or `treegrid`
               </p>
             </td>
             <td>
               <p>
-                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
-                <a><strong class="nosupport">no `role`</strong></a>
-                other than the following:
+                If the nearest ancestor `table` element has `role=table`, `grid`, or `treegrid`
+                then the following roles are allowed: 
+                <code><a href="#index-aria-columnheader">columnheader</a></code>, 
+                <code><a href="#index-aria-none">none</a></code>,
+                <code><a href="#index-aria-none">none</a></code>, 
+                <code><a href="#index-aria-presentation">presentation</a></code> 
+                or <code><a href="#index-aria-rowheader">rowheader</a></code>.
+                (<code><a href="#index-aria-cell">cell</a></code> and <code><a href="#index-aria-gridcell">gridcell</a></code> are allowed, but NOT RECOMMENDED.)
               </p>
-              <ul>
-                <li>If the ancestor `table` element is exposed as a `role=table`, then
-                <code><a href="#index-aria-cell">cell</a></code>
-                is allowed, but NOT RECOMMENDED.</li>
-                <li>If the ancestor `table` element is exposed as a `role=grid` or `treegrid`, then
-                <code><a href="#index-aria-gridcell">gridcell</a></code>
-                is allowed, but NOT RECOMMENDED.</li>
-              </ul>
+              <div class="note">
+                <p>
+                  If a `td` element's nearest descendent `table` element is exposed with a role of `table`, `grid` or `treegrid`, 
+                  and the `td` element is marked as `role=none` or `presentation`, then it is advised that the `td` element be empty, 
+                  contain only whitespace characters or contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> element with 
+                  a role of `cell`, `gridcell`, `columnheader` or `rowheader` - whichever would be most appropriate for what the content represents.
+                </p>
+              </div>
               <p>
-                Otherwise, if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`,
+                If the nearest ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid`, 
+                or if the `td` element is not a descendent of a `table` element, 
                 <a><strong>any `role`</strong></a>.
               </p>
               <p>
@@ -3308,45 +3313,42 @@
               <p>
                 <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
                 <a href="#index-aria-rowheader">`rowheader`</a> or 
-                <a href="#index-aria-rowheader">`cell`</a> if the ancestor
-                `table` element is exposed as a `role=table`
+                <a href="#index-aria-rowheader">`cell`</a> if the nearest ancestor
+                `table` element is exposed as a `role=table`, `grid` or `treegrid`.
               </p>
               <p>
                 <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
                 <a href="#index-aria-rowheader">`rowheader`</a> or 
-                <a href="#index-aria-rowheader">`gridcell`</a> if the ancestor
+                <a href="#index-aria-rowheader">`gridcell`</a> if the nearest ancestor
                 `table` element is exposed as a `role=grid` or `treegrid`
              </p>
               <p>
-                <a>No corresponding role</a> if the ancestor `table` element is not exposed
+                <a>No corresponding role</a> if the nearest ancestor `table` element is not exposed
                 as a `role=table`, `grid` or `treegrid`
               </p>
             </td>
             <td>
               <p>
-                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
-                <a><strong class="nosupport">no `role`</strong></a>
-                other than the following:
+                If the nearest ancestor `table` element has `role=table`, `grid`, or `treegrid`
+                then the following roles are allowed:
+                <a href="#index-aria-cell">`cell`</a>,
+                <a href="#index-aria-gridcell">`cell`</a>,
+                <a href="#index-aria-none">`none`</a>
+                or <a href="#index-aria-presentation">`cell`</a>.
+                (<code><a href="#index-aria-columnheader">columnheader</a></code> and <a href="#index-aria-rowheader">`rowheader`</a>
+                are allowed, but NOT RECOMMENDED).
               </p>
-              <ul>
-                <li>
-                If the ancestor `table` element is exposed as a `role=table`, then
-                <code><a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> and
-                <a href="#index-aria-rowheader">`cell`</a>
-                are allowed, but NOT RECOMMENDED.
-                </li>
-                <li>
-                If the ancestor `table` element is exposed as a `role=grid` or `treegrid`, then
-                <code><a href="#index-aria-columnheader">columnheader</a></code>,
-                <a href="#index-aria-rowheader">`rowheader`</a> or
-                <a href="#index-aria-rowheader">`gridcell`</a>
-                are allowed, but NOT RECOMMENDED.
-                </li>
-              </ul>
+              <div class="note">
+                <p>
+                  If a `tr` element's nearest descendent `table` element is exposed with a role of `table`, `grid` or `treegrid`, 
+                  and the `tr` element is marked as `role=none` or `presentation`, then it is advised that the `tr` element be empty, 
+                  contain only whitespace characters or contain <a data="aria/#dfn-accessibility-child">accessibility children</a> with 
+                  roles of `cell`, `gridcell`, `columnheader` or `rowheader`, as appropriate.
+                </p>
+              </div>
               <p>
-                Otherwise, if the ancestor `table` element is not exposed
-                as a `role=table`, `grid` or `treegrid`,
+                If the nearest ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid`, 
+                or if the `tr` element is not a descendent of a `table` element, 
                 <a><strong>any `role`</strong></a>.
               </p>
               <p>

--- a/index.html
+++ b/index.html
@@ -3420,7 +3420,7 @@
               </p>
               <div class="note">
                 <p>
-                  If a `tr` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `tr` is marked as 
+                  If a `tr` element is a descendant of a `table` element exposed with a role of `table`, `grid` or `treegrid`, and the `tr` is marked as 
                   as `role=none` or `presentation`, then it is advised that the `tr` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
                   element with with a role of `row` or `rowgroup`. Otherwise, that the presentational `tr` be empty, own only whitespace characters or 
                   content hidden from the accessibility tree.

--- a/index.html
+++ b/index.html
@@ -3244,7 +3244,7 @@
                   If a `td` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `td` is marked as 
                   `role=none` or `presentation`, then it is advised that the `td` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
                   element with with a role of `cell`, `gridcell`, `columnheader` or `rowheader`. Otherwise, it is advised that the presentational `td` be empty,  
-                  contain only whitespace characters or content hidden from the accessibility tree.
+                  own only whitespace characters or content hidden from the accessibility tree.
                 </p>
               </div>
               <p>
@@ -3340,10 +3340,10 @@
               </p>
               <div class="note">
                 <p>
-                  If a `tr` element's nearest descendant `table` element is exposed with a role of `table`, `grid` or `treegrid`, 
-                  and the `tr` element is marked as `role=none` or `presentation`, then it is advised that the `tr` element be empty, 
-                  contain only whitespace characters or contain <a data="aria/#dfn-accessibility-child">accessibility children</a> with 
-                  roles of `cell`, `gridcell`, `columnheader` or `rowheader`, as appropriate.
+                  If a `tr` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `tr` is marked as 
+                  as `role=none` or `presentation`, then it is advised that the `tr` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
+                  element with with a role of `row` or `rowgroup`. Otherwise, it is advised that the presentational `tr` be empty, own only whitespace 
+                  characters, or content hidden from the accessibility tree.
                 </p>
               </div>
               <p>

--- a/index.html
+++ b/index.html
@@ -3340,7 +3340,7 @@
               </p>
               <div class="note">
                 <p>
-                  If a `tr` element's nearest descendent `table` element is exposed with a role of `table`, `grid` or `treegrid`, 
+                  If a `tr` element's nearest descendant `table` element is exposed with a role of `table`, `grid` or `treegrid`, 
                   and the `tr` element is marked as `role=none` or `presentation`, then it is advised that the `tr` element be empty, 
                   contain only whitespace characters or contain <a data="aria/#dfn-accessibility-child">accessibility children</a> with 
                   roles of `cell`, `gridcell`, `columnheader` or `rowheader`, as appropriate.

--- a/index.html
+++ b/index.html
@@ -3240,7 +3240,7 @@
               </p>
               <div class="note">
                 <p>
-                  If a `td` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `td` is marked as 
+                  If a `td` element is a descendant of a `table` element exposed with a role of `table`, `grid` or `treegrid`, and the `td` is marked as 
                   `role=none` or `presentation`, then it is advised that the `td` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
                   element with with a role of `cell`, `gridcell`, `columnheader` or `rowheader`. Otherwise, that the presentational `td` be empty,  
                   own only whitespace characters or content hidden from the accessibility tree.

--- a/index.html
+++ b/index.html
@@ -3233,7 +3233,6 @@
                 If the nearest ancestor `table` element has `role=table`, `grid`, or `treegrid`
                 then the following roles are allowed: 
                 <code><a href="#index-aria-columnheader">columnheader</a></code>, 
-                <code><a href="#index-aria-none">none</a></code>,
                 <code><a href="#index-aria-none">none</a></code>, 
                 <code><a href="#index-aria-presentation">presentation</a></code> 
                 or <code><a href="#index-aria-rowheader">rowheader</a></code>.
@@ -3243,14 +3242,13 @@
                 <p>
                   If a `td` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `td` is marked as 
                   `role=none` or `presentation`, then it is advised that the `td` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
-                  element with with a role of `cell`, `gridcell`, `columnheader` or `rowheader`. Otherwise, it is advised that the presentational `td` be empty,  
+                  element with with a role of `cell`, `gridcell`, `columnheader` or `rowheader`. Otherwise, that the presentational `td` be empty,  
                   own only whitespace characters or content hidden from the accessibility tree.
                 </p>
               </div>
               <p>
-                If the nearest ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid`, 
-                or if the `td` element is not a descendent of a `table` element, 
-                <a><strong>any `role`</strong></a>.
+                Otherwise, <a><strong>any `role`</strong></a> if the nearest ancestor `table` element is not exposed as a `role=table`, 
+                `grid` or `treegrid`, or if the `td` element is not a descendent of a `table` element.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -3332,7 +3330,7 @@
                 If the nearest ancestor `table` element has `role=table`, `grid`, or `treegrid`
                 then the following roles are allowed:
                 <a href="#index-aria-cell">`cell`</a>,
-                <a href="#index-aria-gridcell">`cell`</a>,
+                <a href="#index-aria-gridcell">`gridcell`</a>,
                 <a href="#index-aria-none">`none`</a>
                 or <a href="#index-aria-presentation">`cell`</a>.
                 (<code><a href="#index-aria-columnheader">columnheader</a></code> and <a href="#index-aria-rowheader">`rowheader`</a>
@@ -3340,16 +3338,15 @@
               </p>
               <div class="note">
                 <p>
-                  If a `tr` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `tr` is marked as 
-                  as `role=none` or `presentation`, then it is advised that the `tr` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
-                  element with with a role of `row` or `rowgroup`. Otherwise, it is advised that the presentational `tr` be empty, own only whitespace 
-                  characters, or content hidden from the accessibility tree.
+                  If a `th` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `th` is marked as 
+                  `role=none` or `presentation`, then it is advised that the `th` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
+                  element with with a role of `cell`, `gridcell`, `columnheader` or `rowheader`. Otherwise, that the presentational `th` be empty,  
+                  own only whitespace characters or content hidden from the accessibility tree.
                 </p>
               </div>
               <p>
-                If the nearest ancestor `table` element is not exposed as a `role=table`, `grid` or `treegrid`, 
-                or if the `tr` element is not a descendent of a `table` element, 
-                <a><strong>any `role`</strong></a>.
+                Otherwise, <a><strong>any `role`</strong></a> if the nearest ancestor `table` element is not exposed as a `role=table`, 
+                `grid` or `treegrid`, or if the `th` element is not a descendent of a `table` element.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
@@ -3414,10 +3411,24 @@
             </td>
             <td>
               <p>
-                If the ancestor `table` element has `role=table`, `grid`, or `treegrid`,
-                <a><strong class="nosupport">no `role`</strong></a> other than <code><a href="#index-aria-row">row</a></code>, which is NOT RECOMMENDED;
-                otherwise
-                <a><strong>any `role`</strong></a>, though <code><a href="#index-aria-row">row</a></code> is NOT RECOMMENDED.
+                If the neartest ancestor `table` element has `role=table`, `grid`, or `treegrid`,
+                then the following roles are allowed:
+                <code><a href="#index-aria-none">none</a></code>,
+                <code><a href="#index-aria-presentation">presentation</a></code>
+                or <code><a href="#index-aria-rowgroup">rowgroup</a></code>.
+                (<code><a href="#index-aria-row">row</a></code> is allowed, but NOT RECOMMENDED).
+              </p>
+              <div class="note">
+                <p>
+                  If a `tr` element is a descendant of a `table` element with exposed with a role of `table`, `grid` or `treegrid`, and the `tr` is marked as 
+                  as `role=none` or `presentation`, then it is advised that the `tr` contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> 
+                  element with with a role of `row` or `rowgroup`. Otherwise, that the presentational `tr` be empty, own only whitespace characters or 
+                  content hidden from the accessibility tree.
+                </p>
+              </div>
+              <p>
+                Otherwise, <a><strong>any `role`</strong></a> if the nearest ancestor `table` element is not exposed as a `role=table`, 
+                `grid` or `treegrid`, or if the `tr` element is not a descendent of a `table` element.
               </p>
               <p>
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 

--- a/index.html
+++ b/index.html
@@ -3241,7 +3241,7 @@
               </p>
               <div class="note">
                 <p>
-                  If a `td` element's nearest descendent `table` element is exposed with a role of `table`, `grid` or `treegrid`, 
+                  If a `td` element's nearest descendant `table` element is exposed with a role of `table`, `grid` or `treegrid`, 
                   and the `td` element is marked as `role=none` or `presentation`, then it is advised that the `td` element be empty, 
                   contain only whitespace characters or contain an <a data="aria/#dfn-accessibility-child">accessibility child</a> element with 
                   a role of `cell`, `gridcell`, `columnheader` or `rowheader` - whichever would be most appropriate for what the content represents.


### PR DESCRIPTION
This PR covers a few things:

1. clarifies that the mention of "ancestor table" was meant to mean "nearest ancestor table" - re: https://github.com/validator/validator/issues/1304
2. Per feedback / use cases for correcting errant tables, the allowances for td and th elements have been expanded to allow other reasonable roles that developers may need to use.
3. It is meant to supersede parts of the dormant PR #265 
4. this will close https://github.com/w3c/html-aria/issues/562

TODO: need test cases / updated test cases for the updated role allowances.

- [ ] [TODO HTML validator](https://github.com/validator/validator/issues/)
- [ ] [TODO IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/)
- [ ] [TODO axe-core](https://github.com/dequelabs/axe-core/issues/)
- [ ] [TODO ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/563.html" title="Last updated on Mar 9, 2026, 7:35 PM UTC (dc4ede5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/563/cf08b8c...dc4ede5.html" title="Last updated on Mar 9, 2026, 7:35 PM UTC (dc4ede5)">Diff</a>