### PR TITLE
Update the "list of option" link for "option" element to reflect the intent

### DIFF
--- a/index.html
+++ b/index.html
@@ -2581,7 +2581,7 @@
           <tr>
             <th id="el-option" tabindex="-1">
               [^option^] element that is in a <a data-cite=
-              "html/input.html#attr-input-list">list of options</a> or that
+              "html/form-elements.html#concept-select-option-list">list of options</a> or that
               represents a suggestion in a [^datalist^]
             </th>
             <td>


### PR DESCRIPTION
Closes #566

Update the "list of option" link to reference the [select option list concept](https://html.spec.whatwg.org/multipage/form-elements.html#concept-select-option-list) in the HTML specification, instead of the current `list` attribute for the `datalist` element.

- [ ] [TODO HTML validator](https://github.com/validator/validator/issues/)
- [ ] [TODO IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/)
- [ ] [TODO axe-core](https://github.com/dequelabs/axe-core/issues/)
- [ ] [TODO ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/html-aria/pull/567.html" title="Last updated on Feb 20, 2026, 4:16 PM UTC (c406216)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/567/bf16983...giacomo-petri:c406216.html" title="Last updated on Feb 20, 2026, 4:16 PM UTC (c406216)">Diff</a>