### PR TITLE
Restore ruby sub elements rb and rtc

### DIFF
--- a/index.html
+++ b/index.html
@@ -2726,8 +2726,26 @@
             </td>
           </tr>
           <tr>
+            <th id="el-rb" tabindex="-1">
+              <code><a data-link-type=element href="https://www.w3.org/TR/html-ruby-extensions/#the-rb-element">rb</a></code>
+            </th>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any `role`</strong></a>
+              </p>
+              <p class="addition"><a>Naming Prohibited</a></p>
+              <p>
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>
+                and any `aria-*` attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
             <th id="el-rp" tabindex="-1">
-              [^rp^]
+              <code><a data-link-type=element href="https://www.w3.org/TR/html-ruby-extensions/#the-rp-element">rp</a></code>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -2745,7 +2763,7 @@
           </tr>
           <tr>
             <th id="el-rt" tabindex="-1">
-              [^rt^]
+              <code><a data-link-type=element href="https://www.w3.org/TR/html-ruby-extensions/#the-rt-element">rt</a></code>
             </th>
             <td>
               <a>No corresponding role</a>
@@ -2762,8 +2780,26 @@
             </td>
           </tr>
           <tr>
+            <th id="el-rtc" tabindex="-1">
+              <code><a data-link-type=element href="https://www.w3.org/TR/html-ruby-extensions/#the-rtc-element">rtc</a></code>
+            </th>
+            <td>
+              <a>No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a><strong>Any `role`</strong></a>
+              </p>
+              <p class="addition"><a>Naming Prohibited</a></p>
+              <p>
+                <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a>
+                and any `aria-*` attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
             <th id="el-ruby" tabindex="-1">
-              [^ruby^]
+              <code><a data-link-type=element href="https://www.w3.org/TR/html-ruby-extensions/#the-ruby-element">ruby</a></code>
             </th>
             <td>
               <a>No corresponding role</a>


### PR DESCRIPTION
As https://www.w3.org/TR/html-ruby-extensions/ is restoring the `rb` and `rtc` elements to the HTML language, corresponding HTML-ARIA entries should be added as well. See #571. This PR propose what this could look like.

Reference https://www.w3.org/TR/html-ruby-extensions/ for detailed ruby semantics.

---
labels: needs implementation commitment, needs changelog entry
---

Closes #571

<!-- Important:
  for PRs that introduce normative changes the 'needs implementation commitment' 
  and the 'needs changelog entry' labels are needed.  If this is not a PR that
  introduces normative changes, then these labels can be removed.

  For normative changes, log the necessary bugs/rule change requests to the 
  following checkers. If a checker has already implemented the rule, then
  mark it as complete and remove the todo/link.
-->

- [x] [TODO HTML validator](https://github.com/validator/validator/issues/):
  * PR for rb https://github.com/validator/validator/issues/2031
  * PR for rtc: https://github.com/validator/validator/pull/2049
- [ ] [TODO IBM equal access accessibility checker](https://github.com/IBMa/equal-access/issues/)
- [ ] [TODO axe-core](https://github.com/dequelabs/axe-core/issues/)
- [ ] [TODO ARC toolkit](https://github.com/ThePacielloGroup/WAI-ARIA-Usage/issues/)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/frivoal/html-aria/pull/572.html" title="Last updated on Mar 4, 2026, 12:27 PM UTC (cceb7ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/572/cf08b8c...frivoal:cceb7ac.html" title="Last updated on Mar 4, 2026, 12:27 PM UTC (cceb7ac)">Diff</a>