### PR TITLE
Editorial wording fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3958,7 +3958,7 @@
       </section>
       <section class="addition">
         <h2 id="docconformance-deprecated">
-          Requirements for deprecated ARIA role, state and property and attributes
+          Requirements for deprecated ARIA role, state and property attributes
         </h2>
         <p>
           The ARIA Specification's <a data-cite="wai-aria-1.2#deprecated">Deprecated Requirements</a> section indicates that if an ARIA feature is marked as deprecated then authors are advised not to use said feature for new content.
@@ -3972,7 +3972,7 @@
           <li><a data-cite="wai-aria-1.2#directory">`directory`</a></li>
         </ul>
         <div class="note">
-          <p>The `directory` role is marked for deprecation in [[wai-aria-1.2|WAI-ARIA 1.2]]. In reality, the `directory` role had no functional difference to an element with an implicit or explicit `list` role. Authors are advised to use one of HTML's native list elements, or an ARIA `list` instead.</p>
+          <p>The `directory` role is marked for deprecation in [[wai-aria-1.2|WAI-ARIA 1.2]]. In reality, the `directory` role had no functional difference compared to an element with an implicit or explicitly declared `list` role. Authors are advised to use one of HTML's native list elements, or an ARIA `list` role instead.</p>
         </div>
 
         <h3>Deprecated DPub ARIA roles</h3>


### PR DESCRIPTION
closes #581

- removes extra "and" in the heading for section 4.3
- revises the wording of the sentence to mitigate the minor grammatical issue


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/584.html" title="Last updated on May 5, 2026, 3:21 PM UTC (a349cb6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/584/ee49004...a349cb6.html" title="Last updated on May 5, 2026, 3:21 PM UTC (a349cb6)">Diff</a>