### PR TITLE
Fix role attribute case in main element

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,16 +349,14 @@
           &lt;button role="button"&gt;...&lt;/button&gt;
         </pre>
         <p>
-          Similarly, the following uses a `role=group` on a [^fieldset^] element, and a `role=Main` on a [^main^] element.
+          Similarly, the following uses a `role=group` on a [^fieldset^] element, and a `role=main` on a [^main^] element.
           This is unnecessary, because the `fieldset` element is implicitly exposed as a `role=group`, as is the `main` element 
-          implicitly exposed as a `role=main`. Again, in practice this will likely not have any unforeseen side effects to users 
-          of assistive technology, as long as the declaration of the `role` value uses [=ASCII lowercase=]. 
-          Please see [[[#case-sensitivity]]] for more information.
+          implicitly exposed as a `role=main`.
         </p>
         <pre class="HTML example" title="Redundant role on fieldset and main">
           &lt;!-- Avoid doing this! -->
           &lt;fieldset role="group"&gt;...&lt;/fieldset&gt;
-          &lt;!-- or this! -->
+          &lt;!-- And similarly this! -->
           &lt;main role="main">...&lt;/main>
         </pre>
         <p>

--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@
           &lt;!-- Avoid doing this! -->
           &lt;fieldset role="group"&gt;...&lt;/fieldset&gt;
           &lt;!-- or this! -->
-          &lt;main role="Main">...&lt;/main>
+          &lt;main role="main">...&lt;/main>
         </pre>
         <p>
           The following uses a `role=list` on an [^ul^] element. As the `ul` element has an implicit role of `list`, 


### PR DESCRIPTION
closes #583

lowercases the "m" to the role of `main` in the "Redundant role on fieldset and main" example


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/585.html" title="Last updated on May 19, 2026, 6:46 PM UTC (f0ca33e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/585/d7ea2ba...f0ca33e.html" title="Last updated on May 19, 2026, 6:46 PM UTC (f0ca33e)">Diff</a>