### PR TITLE
ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  open-pull-requests-limit: 99


### PR DESCRIPTION
Noticed that the `actions/checkout` was still using a pretty old version, so rather than a one-off bump, add Dependabot to create PRs for future versions. It should open one to move `checkout` to v6, but the `w3c/spec-prod@v2` still appears to be the current major version