### PR TITLE
Clarify img element accessibility descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1616,7 +1616,7 @@
             <td>
               If the `img` has non-empty [^img/alt^] (`alt="some text"`) or an accessible name is provided by another 
               <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming method</a>, 
-              or the `img` has no `alt` and has not been provided a name:<br>
+              or the `img` has no `alt` and no accessible name:<br>
               <code>role=<a href="#index-aria-img">img or image</a></code>
             </td>
             <td>
@@ -1659,7 +1659,7 @@
           </tr>
           <tr>
             <th id="el-img-no-name" tabindex="-1">
-              [^img^] with no accessible name
+              [^img^] with empty `alt` and no accessible name
             </th>
             <td>
               <div class="proposed correction">
@@ -1668,11 +1668,6 @@
                   <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>:<br>
                   <code>role=<a href="#index-aria-none">none</a></code>, 
                   <code>role=<a href="#index-aria-presentation">presentation</a></code>
-                </p>
-                <p id="el-img-no-alt" tabindex="-1">
-                  If the `img` <a data-cite="html/images.html#unknown-images">lacks an `alt` attribute</a> and lacks any other 
-                  <a data-cite="html-aam-1.0#img-element-accessible-name-computation">`img` naming methods</a>:<br>
-                  <code>role=<a href="#index-aria-img">img or image</a></code>
                 </p>
               </div>
             </td>
@@ -1692,10 +1687,6 @@
               <p>
                 <strong>No `aria-*` attributes</strong>
                 except <a data-cite="wai-aria-1.2#aria-hidden">`aria-hidden="true"`</a>.
-              </p>
-              <p>
-                Otherwise, if the `img` has an author defined accessible name, 
-                see <a href="#el-img">`img` with an accessible name</a>.
               </p>
               </div>
             </td>

--- a/index.html
+++ b/index.html
@@ -1655,6 +1655,13 @@
                 <a data-cite="wai-aria-1.2#global_states">Global `aria-*` attributes</a> 
                 and any `aria-*` attributes applicable to the allowed roles.
               </p>
+
+              <p>
+                If the `img` has no `alt` attribute or no accessible name:
+                <a><strong class="nosupport">No `role`</strong></a> other than the  
+                <code>role=<a href="#index-aria-none">none</a></code> or <code><a href="#index-aria-presentation">presentation</a></code> roles.
+                (<code>role=<a href="#index-aria-img">img or image</a></code> is also allowed, but NOT RECOMMENDED.)
+              </p>
             </td>
           </tr>
           <tr>
@@ -1673,12 +1680,6 @@
             </td>
             <td>
               <div class="correction proposed">
-              <p>
-                If the `img` has no `alt` attribute or accessible name:
-                <a><strong class="nosupport">No `role`</strong></a> other than the  
-                <code>role=<a href="#index-aria-none">none</a></code> or <code><a href="#index-aria-presentation">presentation</a></code> roles.
-                (<code>role=<a href="#index-aria-img">img or image</a></code> is also allowed, but NOT RECOMMENDED.)
-              </p>
               <p>
                 If the `img` has an empty `alt=""` attribute and no `aria-label` or `aria-labelledby` attributes to provide it an accessible name:
                 <a><strong class="nosupport">No `role`</strong></a> other than the <code>role=<a href="#index-aria-none">none</a></code> or

--- a/index.html
+++ b/index.html
@@ -1681,7 +1681,6 @@
             <td>
               <div class="correction proposed">
               <p>
-                If the `img` has an empty `alt=""` attribute and no `aria-label` or `aria-labelledby` attributes to provide it an accessible name:
                 <a><strong class="nosupport">No `role`</strong></a> other than the <code>role=<a href="#index-aria-none">none</a></code> or
                 <code><a href="#index-aria-presentation">presentation</a></code> roles, which are NOT RECOMMENDED.
               </p>


### PR DESCRIPTION
closes #586

clarifies language for the two image rows.   no bugs filed to a11y checkers, as while the issue noted these as confusing, tools have implemented these checks per the intent


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/pull/592.html" title="Last updated on Jun 23, 2026, 2:19 PM UTC (8ea47b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/592/7998c77...8ea47b1.html" title="Last updated on Jun 23, 2026, 2:19 PM UTC (8ea47b1)">Diff</a>