### PR TITLE
chore: drop stray closing anchor tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
           The HTML parser will modify the above markup to be output as the following:
         </p>
         <pre class="HTML example" title="Unwanted rendered markup with valid alternative solution">
-          &lt!-- The previous example's markup will render as follows -->
+          &lt;!-- The previous example's markup will render as follows -->
           &lt;p>...&lt;/p>
           &lt;div role=link tabindex=0>...&lt;/div> 
           ... 

--- a/index.html
+++ b/index.html
@@ -3723,7 +3723,7 @@
                 </p>
                 <p>
                   Authors MAY use the <a data-cite="wai-aria-1.2#aria-disabled">`aria-disabled`</a> attribute on any element that is allowed the `disabled` attribute in HTML, 
-                  or any element with a WAI-ARIA role which allows the `aria-disabled` attribute</a>.
+                  or any element with a WAI-ARIA role which allows the `aria-disabled` attribute.
                 </p>
                 <p>
                   Authors SHOULD NOT use `aria-disabled="true"` on any element which also has a `disabled` attribute.
@@ -3841,7 +3841,7 @@
                   allowed the `readonly` attribute in HTML.
                 </p>
                 <p>
-                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a> attribute on any element with a WAI-ARIA role which allows the attribute</a>.
+                  Authors MAY use the <a data-cite="wai-aria-1.2#aria-readonly">`aria-readonly`</a> attribute on any element with a WAI-ARIA role which allows the attribute.
                 </p>
                 <p>
                   Authors SHOULD NOT use the `aria-readonly="true"` on any element which also has a `readonly` attribute.


### PR DESCRIPTION
Was doing another PR, but when I when to try the `tidy` run in the config, I noticed a few warnings/errors from the tool while running. I noticed the reflow diff was pretty large, so didn't end up including it, but the minor issues it noted still made sense to include.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/html-aria/pull/593.html" title="Last updated on May 19, 2026, 8:13 PM UTC (93d468d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/html-aria/593/9706711...nschonni:93d468d.html" title="Last updated on May 19, 2026, 8:13 PM UTC (93d468d)">Diff</a>